### PR TITLE
FABGW-5: Refine Jest coverage collection

### DIFF
--- a/node/jest.config.js
+++ b/node/jest.config.js
@@ -1,22 +1,17 @@
 module.exports = {
-  "roots": [
-    "<rootDir>/src"
-  ],
-  "preset": "ts-jest",
-  "testEnvironment": "node",
-  "collectCoverage": true,
-  "collectCoverageFrom": [
-//    '**/*.ts',
-    "src/**/*.{js,jsx,ts,tsx}",
-    "!src/protos/*.{ts,js}",
-    "!**/node_modules/"
-  ],
-  "coverageProvider": "v8",
-  "testMatch": [
-    "**/?(*.)+(spec|test).+(ts|tsx|js)"
-  ],
-  "transform": {
-//    "^.+\\.(ts|tsx)$": "ts-jest"
-    "\\.ts": "ts-jest"
-  },
+    "roots": [
+        "<rootDir>/src"
+    ],
+    "preset": "ts-jest",
+    "testEnvironment": "node",
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+        "**/*.[jt]s?(x)",
+        "!**/*.d.ts",
+        "!src/protos/**",
+    ],
+    "coverageProvider": "v8",
+    "testMatch": [
+        "**/?(*.)+(spec|test).[jt]s?(x)"
+    ],
 }


### PR DESCRIPTION
- Remove redundant elements
- Exclude .d.ts files since they cannot contain executable code and generate spurious coverage misses

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>