### PR TITLE
FABGW-7: Include channel and transaction ID in ProposedTransaction an…

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
@@ -108,6 +108,8 @@ class ProposalImpl implements Proposal {
         ProposalPackage.SignedProposal signedProposal = signProposal(proposal);
         ProposedTransaction proposedTransaction = ProposedTransaction.newBuilder()
                 .setProposal(signedProposal)
+                .setTxId(getTransactionId())
+                .setChannelId(channelName)
                 .build();
         return proposedTransaction;
     }

--- a/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
@@ -157,7 +157,7 @@ public final class EvaluateTransactionTest {
     }
 
     @Test
-    void sends_network_name() throws ContractException, InvalidProtocolBufferException {
+    void sends_network_name_in_proposal() throws ContractException, InvalidProtocolBufferException {
         network = gateway.getNetwork("MY_NETWORK");
 
         Contract contract = network.getContract("CHAINCODE_ID");
@@ -167,5 +167,32 @@ public final class EvaluateTransactionTest {
         String networkName = mocker.getChannelHeader(request).getChannelId();
 
         assertThat(networkName).isEqualTo("MY_NETWORK");
+    }
+
+    @Test
+    void sends_network_name_in_proposed_transaction() throws ContractException, InvalidProtocolBufferException {
+        network = gateway.getNetwork("MY_NETWORK");
+
+        Contract contract = network.getContract("CHAINCODE_ID");
+        contract.evaluateTransaction("TRANSACTION_NAME");
+
+        ProposedTransaction request = mocker.captureEvaluate();
+        String networkName = request.getChannelId();
+
+        assertThat(networkName).isEqualTo("MY_NETWORK");
+    }
+
+    @Test
+    void sends_transaction_ID_in_proposed_transaction() throws ContractException, InvalidProtocolBufferException {
+        network = gateway.getNetwork("MY_NETWORK");
+
+        Contract contract = network.getContract("CHAINCODE_ID");
+        contract.evaluateTransaction("TRANSACTION_NAME");
+
+        ProposedTransaction request = mocker.captureEvaluate();
+        String expected = mocker.getChannelHeader(request).getTxId();
+        String actual = request.getTxId();
+
+        assertThat(actual).isEqualTo(expected);
     }
 }

--- a/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
@@ -147,7 +147,7 @@ public final class SubmitTransactionTest {
     }
 
     @Test
-    void sends_network_name() throws Exception {
+    void sends_network_name_in_proposal() throws Exception {
         network = gateway.getNetwork("MY_NETWORK");
 
         Contract contract = network.getContract("CHAINCODE_ID");
@@ -157,6 +157,33 @@ public final class SubmitTransactionTest {
         String networkName = mocker.getChannelHeader(request).getChannelId();
 
         assertThat(networkName).isEqualTo("MY_NETWORK");
+    }
+
+    @Test
+    void sends_network_name_in_proposed_transaction() throws Exception {
+        network = gateway.getNetwork("MY_NETWORK");
+
+        Contract contract = network.getContract("CHAINCODE_ID");
+        contract.submitTransaction("TRANSACTION_NAME");
+
+        ProposedTransaction request = mocker.captureEndorse();
+        String networkName = request.getChannelId();
+
+        assertThat(networkName).isEqualTo("MY_NETWORK");
+    }
+
+    @Test
+    void sends_transaction_ID_in_proposed_transaction() throws Exception {
+        network = gateway.getNetwork("MY_NETWORK");
+
+        Contract contract = network.getContract("CHAINCODE_ID");
+        contract.submitTransaction("TRANSACTION_NAME");
+
+        ProposedTransaction request = mocker.captureEndorse();
+        String expected = mocker.getChannelHeader(request).getTxId();
+        String actual = request.getTxId();
+
+        assertThat(actual).isEqualTo(expected);
     }
 
     @Test

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Proposal, ProposalImpl } from "./proposal";
-import { common, protos } from "./protos/protos";
 import { GatewayClient } from "./client";
+import { Proposal, ProposalImpl } from "./proposal";
 import { ProposalBuilder, ProposalOptions } from "./proposalbuilder";
+import { protos } from "./protos/protos";
 import { SigningIdentity } from "./signingidentity";
 import { Transaction, TransactionImpl } from "./transaction";
 
@@ -178,16 +178,11 @@ export class ContractImpl implements Contract {
 
     newSignedProposal(bytes: Uint8Array, signature: Uint8Array): Proposal {
         const proposedTransaction = protos.ProposedTransaction.decode(bytes);
-        const proposal = protos.Proposal.decode(proposedTransaction.proposal!.proposal_bytes!);
-        const header = common.Header.decode(proposal.header);
-        const channelHeader = common.ChannelHeader.decode(header.channel_header);
-        const transactionId = channelHeader.tx_id;
 
         const result = new ProposalImpl({
             client: this.#client,
             signingIdentity: this.#signingIdentity,
             proposedTransaction,
-            transactionId,
         });
         result.setSignature(signature);
 

--- a/node/src/offlinesign.test.ts
+++ b/node/src/offlinesign.test.ts
@@ -128,4 +128,26 @@ describe('Offline sign', () => {
             expect(actual).toBe(expected.toString());
         });
     });
+
+    describe('serialization', () => {
+        it('keeps same transaction ID', async () => {
+            const unsignedProposal = contract.newProposal('TRANSACTION_NAME');
+            const expected = unsignedProposal.getTransactionId();
+
+            const signedProposal = contract.newSignedProposal(unsignedProposal.getBytes(), Buffer.from('SIGNATURE'));
+            const actual = signedProposal.getTransactionId();
+    
+            expect(actual).toBe(expected);
+        });
+
+        it('keeps same digest', async () => {
+            const unsignedProposal = contract.newProposal('TRANSACTION_NAME');
+            const expected = unsignedProposal.getDigest();
+
+            const signedProposal = contract.newSignedProposal(unsignedProposal.getBytes(), Buffer.from('SIGNATURE'));
+            const actual = signedProposal.getDigest();
+    
+            expect(actual).toEqual(expected);
+        });
+    });
 });

--- a/node/src/proposal.test.ts
+++ b/node/src/proposal.test.ts
@@ -116,14 +116,11 @@ describe('Proposal', () => {
         it('includes channel name in proposal', async () => {
             await contract.evaluateTransaction('TRANSACTION_NAME');
     
-            expect(client.evaluate).toHaveBeenCalled();
-    
             const proposedTransaction = client.evaluate.mock.calls[0][0];
             const channelHeader = assertDecodeChannelHeader(proposedTransaction);
-    
             expect(channelHeader.channel_id).toBe(network.getName());
         });
-    
+
         it('includes chaincode ID in proposal', async () => {
             await contract.evaluateTransaction('TRANSACTION_NAME');
     
@@ -193,6 +190,21 @@ describe('Proposal', () => {
             }).finish();
             expect(signatureHeader.creator).toEqual(expected);
         });
+
+        it('includes channel name in proposed transaction', async () => {
+            await contract.evaluateTransaction('TRANSACTION_NAME');
+    
+            const proposedTransaction = client.evaluate.mock.calls[0][0];
+            expect(proposedTransaction.channelId).toBe(network.getName());
+        });
+
+        it('includes transaction ID in proposed transaction', async () => {
+            await contract.evaluateTransaction('TRANSACTION_NAME');
+    
+            const proposedTransaction = client.evaluate.mock.calls[0][0];
+            const expected = assertDecodeChannelHeader(proposedTransaction).tx_id;
+            expect(proposedTransaction.txId).toBe(expected);
+        });
     });
 
     describe('submit', () => {
@@ -219,10 +231,9 @@ describe('Proposal', () => {
     
             const proposedTransaction = client.endorse.mock.calls[0][0];
             const channelHeader = assertDecodeChannelHeader(proposedTransaction);
-    
             expect(channelHeader.channel_id).toBe(network.getName());
         });
-    
+
         it('includes chaincode ID in proposal', async () => {
             await contract.submitTransaction('TRANSACTION_NAME');
     
@@ -291,6 +302,21 @@ describe('Proposal', () => {
                 id_bytes: identity.credentials
             }).finish();
             expect(signatureHeader.creator).toEqual(expected);
+        });
+    
+        it('includes channel name in proposed transaction', async () => {
+            await contract.submitTransaction('TRANSACTION_NAME');
+    
+            const proposedTransaction = client.endorse.mock.calls[0][0];
+            expect(proposedTransaction.channelId).toBe(network.getName());
+        });
+
+        it('includes transaction ID in proposed transaction', async () => {
+            await contract.submitTransaction('TRANSACTION_NAME');
+    
+            const proposedTransaction = client.endorse.mock.calls[0][0];
+            const expected = assertDecodeChannelHeader(proposedTransaction).tx_id;
+            expect(proposedTransaction.txId).toBe(expected);
         });
     });
 });

--- a/node/src/proposal.ts
+++ b/node/src/proposal.ts
@@ -41,20 +41,17 @@ export interface Proposal {
 export interface ProposalImplOptions {
     readonly client: GatewayClient;
     readonly signingIdentity: SigningIdentity;
-    readonly transactionId: string;
     readonly proposedTransaction: protos.IProposedTransaction;
 }
 
 export class ProposalImpl implements Proposal {
     readonly #client: GatewayClient;
     readonly #signingIdentity: SigningIdentity;
-    readonly #transactionId: string;
     readonly #proposedTransaction: protos.IProposedTransaction;
 
     constructor(options: ProposalImplOptions) {
         this.#client = options.client;
         this.#signingIdentity = options.signingIdentity;
-        this.#transactionId = options.transactionId;
         this.#proposedTransaction = options.proposedTransaction;
     }
 
@@ -67,7 +64,7 @@ export class ProposalImpl implements Proposal {
     }
 
     getTransactionId(): string {
-        return this.#transactionId;
+        return this.#proposedTransaction.txId!;
     }
 
     async evaluate(): Promise<Uint8Array> {

--- a/node/src/proposalbuilder.ts
+++ b/node/src/proposalbuilder.ts
@@ -37,11 +37,12 @@ export class ProposalBuilder {
         return new ProposalImpl({
             client: this.#options.client,
             signingIdentity: this.#options.signingIdentity,
-            transactionId: this.#transactionContext.getTransactionId(),
             proposedTransaction: {
                 proposal: {
                     proposal_bytes: protos.Proposal.encode(this.newProposal()).finish(),
                 },
+                txId: this.#transactionContext.getTransactionId(),
+                channelId: this.#options.channelName,
             },
         });
     }

--- a/pkg/client/contract.go
+++ b/pkg/client/contract.go
@@ -110,11 +110,16 @@ func (contract *Contract) NewProposal(transactionName string, options ...Proposa
 
 // NewSignedProposal creates a transaction proposal with signature, which can be sent to peers for endorsement.
 func (contract *Contract) NewSignedProposal(bytes []byte, signature []byte) (*Proposal, error) {
+	var proposedTransactionProto *gateway.ProposedTransaction
+	proto.Unmarshal(bytes, proposedTransactionProto)
+
 	proposal := &Proposal{
-		client:    contract.client,
-		bytes:     bytes,
-		signature: signature,
+		client:              contract.client,
+		signingID:           contract.signingID,
+		proposedTransaction: proposedTransactionProto,
 	}
+	proposal.setSignature(signature)
+
 	return proposal, nil
 }
 

--- a/pkg/client/proposalbuilder.go
+++ b/pkg/client/proposalbuilder.go
@@ -36,11 +36,20 @@ func (builder *proposalBuilder) build() (*Proposal, error) {
 		return nil, errors.Wrap(err, "Failed to marshall Proposal protobuf")
 	}
 
+	signedProposalProto := &peer.SignedProposal{
+		ProposalBytes: proposalBytes,
+	}
+
+	proposedTransactionProto := &gateway.ProposedTransaction{
+		Proposal:  signedProposalProto,
+		TxId:      transactionID,
+		ChannelId: builder.channelName,
+	}
+
 	proposal := &Proposal{
-		client:        builder.client,
-		signingID:     builder.signingID,
-		transactionID: transactionID,
-		bytes:         proposalBytes,
+		client:              builder.client,
+		signingID:           builder.signingID,
+		proposedTransaction: proposedTransactionProto,
 	}
 	return proposal, nil
 }

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -23,13 +23,9 @@ import (
 // Evaluate will invoke the transaction function as specified in the SignedProposal
 func (gs *Server) Evaluate(ctx context.Context, proposedTransaction *pb.ProposedTransaction) (*pb.Result, error) {
 	signedProposal := proposedTransaction.Proposal
-	channelHeader, err := getChannelHeaderFromSignedProposal(signedProposal)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to unpack channel header: ")
-	}
-	endorsers := gs.registry.GetEndorsers(channelHeader.ChannelId)
+	endorsers := gs.registry.GetEndorsers(proposedTransaction.ChannelId)
 	if len(endorsers) == 0 {
-		return nil, errors.New("No endorsing peers found for channel: " + channelHeader.ChannelId)
+		return nil, errors.New("No endorsing peers found for channel: " + proposedTransaction.ChannelId)
 	}
 	response, err := endorsers[0].ProcessProposal(ctx, signedProposal) // choose suitable peer
 	if err != nil {
@@ -44,15 +40,10 @@ func (gs *Server) Evaluate(ctx context.Context, proposedTransaction *pb.Proposed
 func (gs *Server) Endorse(ctx context.Context, proposedTransaction *pb.ProposedTransaction) (*pb.PreparedTransaction, error) {
 	signedProposal := proposedTransaction.Proposal
 	var proposal peer.Proposal
-	err := proto.Unmarshal(signedProposal.ProposalBytes, &proposal)
-	if err != nil {
+	if err := proto.Unmarshal(signedProposal.ProposalBytes, &proposal); err != nil {
 		return nil, errors.Wrap(err, "failed to unmarshal signed proposal")
 	}
-	channelHeader, err := getChannelHeaderFromSignedProposal(signedProposal)
-	if err != nil {
-		return nil, errors.Wrap(err, "Failed to unpack channel header: ")
-	}
-	endorsers := gs.registry.GetEndorsers(channelHeader.ChannelId)
+	endorsers := gs.registry.GetEndorsers(proposedTransaction.ChannelId)
 
 	var responses []*peer.ProposalResponse
 	// send to all the endorsers
@@ -75,9 +66,10 @@ func (gs *Server) Endorse(ctx context.Context, proposedTransaction *pb.ProposedT
 	}
 
 	preparedTxn := &pb.PreparedTransaction{
-		TxId:     channelHeader.TxId,
-		Response: retVal,
-		Envelope: env,
+		TxId:      proposedTransaction.TxId,
+		ChannelId: proposedTransaction.ChannelId,
+		Response:  retVal,
+		Envelope:  env,
 	}
 	return preparedTxn, nil
 }
@@ -85,11 +77,7 @@ func (gs *Server) Endorse(ctx context.Context, proposedTransaction *pb.ProposedT
 // Submit will send the signed transaction to the ordering service.  The output stream will close
 // once the transaction is committed on a sufficient number of peers according to a defined policy.
 func (gs *Server) Submit(txn *pb.PreparedTransaction, cs pb.Gateway_SubmitServer) error {
-	channelHeader, err := getChannelHeaderFromEnvelope(txn.Envelope)
-	if err != nil {
-		return errors.Wrap(err, "Failed to unpack channel header: ")
-	}
-	orderers := gs.registry.GetOrderers(channelHeader.ChannelId)
+	orderers := gs.registry.GetOrderers(txn.ChannelId)
 
 	if len(orderers) == 0 {
 		return errors.New("no orderers discovered")
@@ -98,8 +86,7 @@ func (gs *Server) Submit(txn *pb.PreparedTransaction, cs pb.Gateway_SubmitServer
 	done := make(chan bool)
 	go gs.registry.ListenForTxEvents("mychannel", txn.TxId, done)
 
-	err = orderers[0].Send(txn.Envelope)
-	if err != nil {
+	if err := orderers[0].Send(txn.Envelope); err != nil {
 		return errors.Wrap(err, "failed to send envelope to orderer")
 	}
 

--- a/protos/gateway.proto
+++ b/protos/gateway.proto
@@ -33,14 +33,17 @@ message Result {
 // The signed proposal ready for endorsement plus any processing options
 message ProposedTransaction {
     SignedProposal proposal = 1;
+    string txId = 2;
+    string channelId = 3;
 }
 
 // The set of transaction responses from the endorsing peers for signing by the client
 // before submitting to ordering service (via gateway)
 message PreparedTransaction {
-    string txId = 1;
+    common.Envelope envelope = 1;
     Result response = 2;
-    common.Envelope envelope = 3;
+    string txId = 3;
+    string channelId = 4;
 }
 
 message Event {


### PR DESCRIPTION
…d PreparedTransaction

Provides access to these values without deserialization of multiple nested protobufs both at the client side during off-line signing flow and at the server side during transaction evaluate and endorse.