### PR TITLE
FABGW-5 Change error msgs to start with lower case

### DIFF
--- a/cmd/gateway/config.go
+++ b/cmd/gateway/config.go
@@ -56,13 +56,13 @@ func loadConfig() (*config, error) {
 		}
 		err = yaml.Unmarshal(cfg, &conf)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse gateway config: %w", err)
+			return nil, fmt.Errorf("failed to parse gateway config: %w", err)
 		}
 	}
 	// apply any env-var overrides
 	err := envconfig.Process("GATEWAY", &conf.Gateway)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to apply env-var overrides: %w", err)
+		return nil, fmt.Errorf("failed to apply env-var overrides: %w", err)
 	}
 
 	return conf, nil

--- a/pkg/client/contract.go
+++ b/pkg/client/contract.go
@@ -129,7 +129,7 @@ func (contract *Contract) NewProposal(transactionName string, options ...Proposa
 func (contract *Contract) NewSignedProposal(bytes []byte, signature []byte) (*Proposal, error) {
 	proposedTransactionProto := &gateway.ProposedTransaction{}
 	if err := proto.Unmarshal(bytes, proposedTransactionProto); err != nil {
-		return nil, fmt.Errorf("Failed to deserialize proposal: %w", err)
+		return nil, fmt.Errorf("failed to deserialize proposal: %w", err)
 	}
 
 	proposal := &Proposal{
@@ -147,7 +147,7 @@ func (contract *Contract) NewSignedProposal(bytes []byte, signature []byte) (*Pr
 func (contract *Contract) NewSignedTransaction(bytes []byte, signature []byte) (*Transaction, error) {
 	preparedTransaction := &gateway.PreparedTransaction{}
 	if err := proto.Unmarshal(bytes, preparedTransaction); err != nil {
-		return nil, fmt.Errorf("Failed to deserialize transaction: %w", err)
+		return nil, fmt.Errorf("failed to deserialize transaction: %w", err)
 	}
 
 	transaction := &Transaction{

--- a/pkg/client/gateway.go
+++ b/pkg/client/gateway.go
@@ -82,7 +82,7 @@ func WithEndpoint(endpoint *connection.Endpoint) ConnectOption {
 	return func(gateway *Gateway) error {
 		clientConnection, err := endpoint.Dial()
 		if err != nil {
-			return fmt.Errorf("Failed to establish Gateway connection: %w", err)
+			return fmt.Errorf("failed to establish Gateway connection: %w", err)
 		}
 
 		gateway.closer = clientConnection

--- a/pkg/client/proposal.go
+++ b/pkg/client/proposal.go
@@ -48,7 +48,7 @@ func (proposal *Proposal) Endorse() (*Transaction, error) {
 
 	preparedTransaction, err := proposal.client.Endorse(ctx, proposal.proposedTransaction)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to endorse proposal: %w", err)
+		return nil, fmt.Errorf("failed to endorse proposal: %w", err)
 	}
 
 	result := &Transaction{
@@ -70,7 +70,7 @@ func (proposal *Proposal) Evaluate() ([]byte, error) {
 
 	result, err := proposal.client.Evaluate(ctx, proposal.proposedTransaction)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to evaluate transaction: %w", err)
+		return nil, fmt.Errorf("failed to evaluate transaction: %w", err)
 	}
 
 	return result.Value, nil

--- a/pkg/client/proposalbuilder.go
+++ b/pkg/client/proposalbuilder.go
@@ -29,12 +29,12 @@ type proposalBuilder struct {
 func (builder *proposalBuilder) build() (*Proposal, error) {
 	proposalProto, transactionID, err := builder.newProposalProto()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create Proposal protobuf: %w", err)
+		return nil, fmt.Errorf("failed to create Proposal protobuf: %w", err)
 	}
 
 	proposalBytes, err := proto.Marshal(proposalProto)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshall Proposal protobuf: %w", err)
+		return nil, fmt.Errorf("failed to marshall Proposal protobuf: %w", err)
 	}
 
 	signedProposalProto := &peer.SignedProposal{
@@ -66,7 +66,7 @@ func (builder *proposalBuilder) newProposalProto() (*peer.Proposal, string, erro
 
 	creator, err := builder.signingID.Creator()
 	if err != nil {
-		return nil, "", fmt.Errorf("Failed to serialize identity: %w", err)
+		return nil, "", fmt.Errorf("failed to serialize identity: %w", err)
 	}
 
 	result, transactionID, err := protoutil.CreateChaincodeProposalWithTransient(
@@ -77,7 +77,7 @@ func (builder *proposalBuilder) newProposalProto() (*peer.Proposal, string, erro
 		builder.transient,
 	)
 	if err != nil {
-		return nil, "", fmt.Errorf("Failed to create chaincode proposal: %w", err)
+		return nil, "", fmt.Errorf("failed to create chaincode proposal: %w", err)
 	}
 
 	return result, transactionID, nil

--- a/pkg/client/transaction.go
+++ b/pkg/client/transaction.go
@@ -32,7 +32,7 @@ func (transaction *Transaction) Result() []byte {
 func (transaction *Transaction) Bytes() ([]byte, error) {
 	transactionBytes, err := proto.Marshal(transaction.preparedTransaction)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshall Proposal protobuf: %w", err)
+		return nil, fmt.Errorf("failed to marshall Proposal protobuf: %w", err)
 	}
 
 	return transactionBytes, nil
@@ -54,7 +54,7 @@ func (transaction *Transaction) Submit() (chan error, error) {
 	stream, err := transaction.client.Submit(ctx, transaction.preparedTransaction)
 	if err != nil {
 		cancel()
-		return nil, fmt.Errorf("Failed to submit transaction to the orderer: %w", err)
+		return nil, fmt.Errorf("failed to submit transaction to the orderer: %w", err)
 	}
 
 	commit := make(chan error)
@@ -67,7 +67,7 @@ func (transaction *Transaction) Submit() (chan error, error) {
 				return
 			}
 			if err != nil {
-				commit <- fmt.Errorf("Failed to receive event: %w", err)
+				commit <- fmt.Errorf("failed to receive event: %w", err)
 				return
 			}
 			fmt.Println(event)

--- a/pkg/identity/sign.go
+++ b/pkg/identity/sign.go
@@ -24,7 +24,7 @@ func NewPrivateKeySign(privateKey crypto.PrivateKey) (Sign, error) {
 	case *ecdsa.PrivateKey:
 		return ecdsaPrivateKeySign(key), nil
 	default:
-		return nil, fmt.Errorf("Unsupported key type: %T", privateKey)
+		return nil, fmt.Errorf("unsupported key type: %T", privateKey)
 	}
 }
 

--- a/pkg/internal/test/credentials.go
+++ b/pkg/internal/test/credentials.go
@@ -41,7 +41,7 @@ func NewCertificate(privateKey crypto.PrivateKey) (*x509.Certificate, error) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to generate serial number: %w", err)
+		return nil, fmt.Errorf("failed to generate serial number: %w", err)
 	}
 
 	notBefore := time.Now()
@@ -64,7 +64,7 @@ func NewCertificate(privateKey crypto.PrivateKey) (*x509.Certificate, error) {
 
 	certificateBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(privateKey), privateKey)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to generate certificate: %w", err)
+		return nil, fmt.Errorf("failed to generate certificate: %w", err)
 	}
 
 	return x509.ParseCertificate(certificateBytes)

--- a/pkg/network/discovery.go
+++ b/pkg/network/discovery.go
@@ -42,7 +42,7 @@ func newChannelDiscovery(client discovery.DiscoveryClient, sign identity.Sign, h
 func (cd *channelDiscovery) invokeDiscovery(request *discovery.Request) (*discovery.Response, error) {
 	payload, err := proto.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal discovery request: %w", err)
+		return nil, fmt.Errorf("failed to marshal discovery request: %w", err)
 	}
 
 	digest, err := cd.hash(payload)
@@ -52,7 +52,7 @@ func (cd *channelDiscovery) invokeDiscovery(request *discovery.Request) (*discov
 
 	signature, err := cd.sign(digest)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to sign discovery request: %w", err)
+		return nil, fmt.Errorf("failed to sign discovery request: %w", err)
 	}
 
 	response, err := cd.client.Discover(
@@ -63,7 +63,7 @@ func (cd *channelDiscovery) invokeDiscovery(request *discovery.Request) (*discov
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Discovery failed: %w", err)
+		return nil, fmt.Errorf("discovery failed: %w", err)
 	}
 
 	return response, nil

--- a/pkg/network/events.go
+++ b/pkg/network/events.go
@@ -21,7 +21,7 @@ import (
 func (reg *registry) ListenForTxEvents(channel string, txid string, done chan<- bool) error {
 	envelope, err := createDeliverEnvelope(channel, reg.signer)
 	if err != nil {
-		return fmt.Errorf("Failed to create deliver env: %w", err)
+		return fmt.Errorf("failed to create deliver env: %w", err)
 	}
 	eventCh := make(chan *peer.FilteredTransaction)
 
@@ -81,7 +81,7 @@ func createDeliverEnvelope(
 		// tlsCertHash,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Error signing envelope: %w", err)
+		return nil, fmt.Errorf("error signing envelope: %w", err)
 	}
 
 	return env, nil
@@ -94,12 +94,12 @@ func listenForTxEvent(deliverClient peer.DeliverClient, txid string, envelope *c
 
 	df, err := deliverClient.DeliverFiltered(ctx)
 	if err != nil {
-		return fmt.Errorf("Failed to register for events: %w", err)
+		return fmt.Errorf("failed to register for events: %w", err)
 	}
 	defer df.CloseSend()
 	err = df.Send(envelope)
 	if err != nil {
-		return fmt.Errorf("Error sending deliver seek info envelope: %w", err)
+		return fmt.Errorf("error sending deliver seek info envelope: %w", err)
 	}
 
 	for {

--- a/pkg/network/registry.go
+++ b/pkg/network/registry.go
@@ -122,11 +122,11 @@ func NewRegistry(config Config) (*registry, error) {
 
 	clientTLSCert, err := tls.X509KeyPair(config.Certificate(), config.Key())
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create tls cert: %w", err)
+		return nil, fmt.Errorf("failed to create tls cert: %w", err)
 	}
 	clientID, err := signingIdentity.Serialize()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to serialize gateway id: %w", err)
+		return nil, fmt.Errorf("failed to serialize gateway id: %w", err)
 	}
 	authInfo := &discovery.AuthInfo{
 		ClientIdentity:    clientID,
@@ -154,7 +154,7 @@ func (reg *registry) addPeer(channel string, mspid string, host string, port uin
 		creds := credentials.NewClientTLSFromCert(certPool, host)
 		conn, err := grpc.Dial(translateURL(url), grpc.WithTransportCredentials(creds))
 		if err != nil {
-			return fmt.Errorf("Failed to connect to peer: %w", err)
+			return fmt.Errorf("failed to connect to peer: %w", err)
 		}
 		ec := peer.NewEndorserClient(conn)
 		// query channels for this peer
@@ -210,7 +210,7 @@ func (reg *registry) addOrderer(channel string, mspid string, host string, port 
 			if ok {
 				fmt.Println(rpcStatus.Message())
 			}
-			return fmt.Errorf("Failed to connect to orderer: %w", err)
+			return fmt.Errorf("failed to connect to orderer: %w", err)
 		}
 		reg.orderers[url] = ordererClient{
 			endpoint:        ep,
@@ -315,7 +315,7 @@ func (reg *registry) getChannels(target peer.EndorserClient) ([]string, error) {
 
 	creator, err := reg.signer.Serialize()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to serialize Signer: %w", err)
+		return nil, fmt.Errorf("failed to serialize Signer: %w", err)
 	}
 
 	proposal, _, err := protoutil.CreateChaincodeProposal(
@@ -325,12 +325,12 @@ func (reg *registry) getChannels(target peer.EndorserClient) ([]string, error) {
 		creator,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to create chaincode proposal: %w", err)
+		return nil, fmt.Errorf("failed to create chaincode proposal: %w", err)
 	}
 
 	proposalBytes, err := proto.Marshal(proposal)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal chaincode proposal: %w", err)
+		return nil, fmt.Errorf("failed to marshal chaincode proposal: %w", err)
 	}
 
 	signature, err := reg.signer.Sign(proposalBytes)

--- a/pkg/server/api.go
+++ b/pkg/server/api.go
@@ -29,11 +29,11 @@ func (gs *Server) Evaluate(ctx context.Context, proposedTransaction *pb.Proposed
 	endorsers := gs.registry.GetEndorsers(channel, chaincodeID)
 	fmt.Printf("Evaluate: #endorsers=%d\n", len(endorsers))
 	if len(endorsers) == 0 {
-		return nil, fmt.Errorf("No endorsing peers found for channel: %s", proposedTransaction.ChannelId)
+		return nil, fmt.Errorf("no endorsing peers found for channel: %s", proposedTransaction.ChannelId)
 	}
 	response, err := endorsers[0].ProcessProposal(ctx, signedProposal) // choose suitable peer
 	if err != nil {
-		return nil, fmt.Errorf("Failed to evaluate transaction: %w", err)
+		return nil, fmt.Errorf("failed to evaluate transaction: %w", err)
 	}
 
 	return getValueFromResponse(response)
@@ -45,7 +45,7 @@ func (gs *Server) Endorse(ctx context.Context, proposedTransaction *pb.ProposedT
 	signedProposal := proposedTransaction.Proposal
 	var proposal peer.Proposal
 	if err := proto.Unmarshal(signedProposal.ProposalBytes, &proposal); err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal signed proposal: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal signed proposal: %w", err)
 	}
 	channel, chaincodeID, err := getChannelAndChaincodeFromSignedProposal(proposedTransaction.Proposal)
 	if err != nil {
@@ -58,19 +58,19 @@ func (gs *Server) Endorse(ctx context.Context, proposedTransaction *pb.ProposedT
 	for i := 0; i < len(endorsers); i++ {
 		response, err := endorsers[i].ProcessProposal(ctx, signedProposal)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to process proposal: %w", err)
+			return nil, fmt.Errorf("failed to process proposal: %w", err)
 		}
 		responses = append(responses, response)
 	}
 
 	env, err := createUnsignedTx(&proposal, responses...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to assemble transaction: %w", err)
+		return nil, fmt.Errorf("failed to assemble transaction: %w", err)
 	}
 
 	retVal, err := getValueFromResponse(responses[0])
 	if err != nil {
-		return nil, fmt.Errorf("Failed to extract value from reponse payload: %w", err)
+		return nil, fmt.Errorf("failed to extract value from reponse payload: %w", err)
 	}
 
 	preparedTxn := &pb.PreparedTransaction{
@@ -95,15 +95,15 @@ func (gs *Server) Submit(txn *pb.PreparedTransaction, cs pb.Gateway_SubmitServer
 	go gs.registry.ListenForTxEvents("mychannel", txn.TxId, done)
 
 	if err := orderers[0].Send(txn.Envelope); err != nil {
-		return fmt.Errorf("Failed to send envelope to orderer: %w", err)
+		return fmt.Errorf("failed to send envelope to orderer: %w", err)
 	}
 
 	oresp, err := orderers[0].Recv()
 	if err == io.EOF {
-		return fmt.Errorf("Failed to to get response from orderer: %w", err)
+		return fmt.Errorf("failed to to get response from orderer: %w", err)
 	}
 	if err != nil {
-		return fmt.Errorf("Failed to to get response from orderer: %w", err)
+		return fmt.Errorf("failed to to get response from orderer: %w", err)
 	}
 	if oresp == nil {
 		return fmt.Errorf("received nil response from orderer")

--- a/pkg/server/protoutils.go
+++ b/pkg/server/protoutils.go
@@ -20,7 +20,7 @@ import (
 func (gs *Server) signProposal(proposal *peer.Proposal, sign identity.Sign) (*peer.SignedProposal, error) {
 	proposalBytes, err := proto.Marshal(proposal)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to marshal chaincode proposal: %w", err)
+		return nil, fmt.Errorf("failed to marshal chaincode proposal: %w", err)
 	}
 
 	signature, err := sign(proposalBytes)
@@ -116,7 +116,7 @@ func createUnsignedTx(
 	cap := &peer.ChaincodeActionPayload{ChaincodeProposalPayload: propPayloadBytes, Action: cea}
 	capBytes, err := proto.Marshal(cap)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshaling ChaincodeActionPayload: %w", err)
+		return nil, fmt.Errorf("error marshaling ChaincodeActionPayload: %w", err)
 	}
 
 	// create a transaction
@@ -128,14 +128,14 @@ func createUnsignedTx(
 	// serialize the tx
 	txBytes, err := proto.Marshal(tx)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshaling Transaction: %w", err)
+		return nil, fmt.Errorf("error marshaling Transaction: %w", err)
 	}
 
 	// create the payload
 	payl := &common.Payload{Header: hdr, Data: txBytes}
 	paylBytes, err := proto.Marshal(payl)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshaling Payload: %w", err)
+		return nil, fmt.Errorf("error marshaling Payload: %w", err)
 	}
 
 	// here's the envelope
@@ -173,7 +173,7 @@ func getChannelAndChaincodeFromSignedProposal(signedProposal *peer.SignedProposa
 func unmarshalChannelHeader(bytes []byte) (*common.ChannelHeader, error) {
 	var channelHeader common.ChannelHeader
 	if err := proto.Unmarshal(bytes, &channelHeader); err != nil {
-		return nil, fmt.Errorf("Failed to unmarshal channel header: %w", err)
+		return nil, fmt.Errorf("failed to unmarshal channel header: %w", err)
 	}
 	return &channelHeader, nil
 }
@@ -181,7 +181,7 @@ func unmarshalChannelHeader(bytes []byte) (*common.ChannelHeader, error) {
 func unmarshalProposalResponsePayload(prpBytes []byte) (*peer.ProposalResponsePayload, error) {
 	prp := &peer.ProposalResponsePayload{}
 	if err := proto.Unmarshal(prpBytes, prp); err != nil {
-		return nil, fmt.Errorf("Error unmarshaling ProposalResponsePayload: %w", err)
+		return nil, fmt.Errorf("error unmarshaling ProposalResponsePayload: %w", err)
 	}
 	return prp, nil
 }
@@ -189,7 +189,7 @@ func unmarshalProposalResponsePayload(prpBytes []byte) (*peer.ProposalResponsePa
 func unmarshalChaincodeAction(caBytes []byte) (*peer.ChaincodeAction, error) {
 	chaincodeAction := &peer.ChaincodeAction{}
 	if err := proto.Unmarshal(caBytes, chaincodeAction); err != nil {
-		return nil, fmt.Errorf("Error unmarshaling ChaincodeAction: %w", err)
+		return nil, fmt.Errorf("error unmarshaling ChaincodeAction: %w", err)
 	}
 	return chaincodeAction, nil
 }
@@ -197,7 +197,7 @@ func unmarshalChaincodeAction(caBytes []byte) (*peer.ChaincodeAction, error) {
 func unmarshalHeader(bytes []byte) (*common.Header, error) {
 	hdr := &common.Header{}
 	if err := proto.Unmarshal(bytes, hdr); err != nil {
-		return nil, fmt.Errorf("Error unmarshaling Header: %w", err)
+		return nil, fmt.Errorf("error unmarshaling Header: %w", err)
 	}
 	return hdr, nil
 }
@@ -205,7 +205,7 @@ func unmarshalHeader(bytes []byte) (*common.Header, error) {
 func unmarshalChaincodeProposalPayload(bytes []byte) (*peer.ChaincodeProposalPayload, error) {
 	cpp := &peer.ChaincodeProposalPayload{}
 	if err := proto.Unmarshal(bytes, cpp); err != nil {
-		return nil, fmt.Errorf("Error unmarshaling ChaincodeProposalPayload: %w", err)
+		return nil, fmt.Errorf("error unmarshaling ChaincodeProposalPayload: %w", err)
 	}
 	return cpp, nil
 }
@@ -222,7 +222,7 @@ func getBytesProposalPayloadForTx(
 	cppNoTransient := &peer.ChaincodeProposalPayload{Input: payload.Input, TransientMap: nil}
 	cppBytes, err := proto.Marshal(cppNoTransient)
 	if err != nil {
-		return nil, fmt.Errorf("Error marshaling ChaincodeProposalPayload: %w", err)
+		return nil, fmt.Errorf("error marshaling ChaincodeProposalPayload: %w", err)
 	}
 	return cppBytes, nil
 }

--- a/scenario/fixtures/chaincode/golang/basic/main.go
+++ b/scenario/fixtures/chaincode/golang/basic/main.go
@@ -39,7 +39,7 @@ func (s *SmartContract) Echo(ctx contractapi.TransactionContextInterface, arg st
 func (s *SmartContract) EchoTransient(ctx contractapi.TransactionContextInterface) (map[string]string, error) {
 	transient, err := ctx.GetStub().GetTransient()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get transient data: %w", err)
+		return nil, fmt.Errorf("failed to get transient data: %w", err)
 	}
 
 	return toStringValues(transient), nil
@@ -48,7 +48,7 @@ func (s *SmartContract) EchoTransient(ctx contractapi.TransactionContextInterfac
 // Put a value for a given ledger key and return the value
 func (s *SmartContract) Put(ctx contractapi.TransactionContextInterface, key string, value string) (string, error) {
 	if err := ctx.GetStub().PutState(key, []byte(value)); err != nil {
-		return "", fmt.Errorf("Failed to put state to ledger: %w", err)
+		return "", fmt.Errorf("failed to put state to ledger: %w", err)
 	}
 
 	return value, nil
@@ -58,7 +58,7 @@ func (s *SmartContract) Put(ctx contractapi.TransactionContextInterface, key str
 func (s *SmartContract) Get(ctx contractapi.TransactionContextInterface, key string) (string, error) {
 	value, err := ctx.GetStub().GetState(key)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get state from ledger: %w", err)
+		return "", fmt.Errorf("failed to get state from ledger: %w", err)
 	}
 
 	return string(value), nil

--- a/scenario/fixtures/chaincode/golang/echo/echo.go
+++ b/scenario/fixtures/chaincode/golang/echo/echo.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"fmt"
-	"github.com/pkg/errors"
 
 	"github.com/hyperledger/fabric-contract-api-go/contractapi"
 )
@@ -19,7 +18,7 @@ type SmartContract struct {
 // AddEntry adds a new entry to the world state with given details
 func (s *SmartContract) AddEntry(ctx contractapi.TransactionContextInterface, name string, value string) (string, error) {
 	if err := ctx.GetStub().PutState(name, []byte(value)); err != nil {
-		return "", errors.Wrap(err,"Failed to write to world state")
+		return "", fmt.Errorf("failed to write to world state: %w", err)
 	}
 
 	return value, nil
@@ -30,7 +29,7 @@ func (s *SmartContract) ReadEntry(ctx contractapi.TransactionContextInterface, n
 	bytes, err := ctx.GetStub().GetState(name)
 
 	if err != nil {
-		return "", errors.Wrap(err, "Failed to read from world state")
+		return "", fmt.Errorf("failed to read from world state: %w", err)
 	}
 
 	if bytes == nil {

--- a/scenario/go/scenario_test.go
+++ b/scenario/go/scenario_test.go
@@ -349,7 +349,7 @@ func createGateway(user string, mspID string) error {
 func connectGateway(address string) error {
 	hostPort := strings.Split(address, ":")
 	if len(hostPort) != 2 {
-		return fmt.Errorf("Invalid endpoint: %s", address)
+		return fmt.Errorf("invalid endpoint: %s", address)
 	}
 
 	host := hostPort[0]
@@ -549,7 +549,7 @@ func theTransactionShouldFail() error {
 	}
 
 	if transactionResult, err = invoke(transaction.name, transaction.options...); nil == err {
-		return fmt.Errorf("Transaction invocation was expected to fail, but it returned: %s", transactionResult)
+		return fmt.Errorf("transaction invocation was expected to fail, but it returned: %s", transactionResult)
 	}
 	return nil
 }
@@ -561,7 +561,7 @@ func transactionInvokeFn(txType TransactionType) (func(string, ...client.Proposa
 	case Evaluate:
 		return contract.Evaluate, nil
 	default:
-		return nil, fmt.Errorf("Unknown transaction type: %v", txType)
+		return nil, fmt.Errorf("unknown transaction type: %v", txType)
 	}
 }
 
@@ -600,7 +600,7 @@ func jsonEqual(a, b []byte) (bool, error) {
 func theResponseShouldBe(expected string) error {
 	actual := string(transactionResult)
 	if actual != expected {
-		return fmt.Errorf("Transaction response \"%s\" does not match expected value \"%s\"", actual, expected)
+		return fmt.Errorf("transaction response \"%s\" does not match expected value \"%s\"", actual, expected)
 	}
 	return nil
 }


### PR DESCRIPTION
Error strings should not start with capital letters according to:
https://github.com/golang/go/wiki/CodeReviewComments#error-strings

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>