### PR TITLE
FABGW-14: Use traditional Cucumber API for Java tests

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -91,21 +91,22 @@
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
-            <artifactId>cucumber-java8</artifactId>
-            <version>6.9.0</version>
+            <artifactId>cucumber-java</artifactId>
+            <version>6.9.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>6.9.0</version>
+            <version>6.9.1</version>
             <scope>test</scope>
-        </dependency>        <dependency>
-        <groupId>javax.json</groupId>
-        <artifactId>javax.json-api</artifactId>
-        <version>1.1</version>
-        <scope>test</scope>
-    </dependency>
+        </dependency>
+        <dependency>
+            <groupId>javax.json</groupId>
+            <artifactId>javax.json-api</artifactId>
+            <version>1.1.4</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.glassfish</groupId>
             <artifactId>javax.json</artifactId>

--- a/java/src/test/java/scenario/CleanupScenarioTest.java
+++ b/java/src/test/java/scenario/CleanupScenarioTest.java
@@ -6,7 +6,7 @@ public class CleanupScenarioTest {
 
 	@Test
 	public void stopFabric() throws Exception {
-		ScenarioSteps.stopFabric(true);
+		ScenarioSteps.stopFabric();
 	}
 
 }

--- a/java/src/test/java/scenario/ScenarioSteps.java
+++ b/java/src/test/java/scenario/ScenarioSteps.java
@@ -26,9 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -40,7 +37,10 @@ import javax.json.JsonString;
 
 import io.cucumber.datatable.DataTable;
 import io.cucumber.docstring.DocString;
-import io.cucumber.java8.En;
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import org.hyperledger.fabric.client.Contract;
 import org.hyperledger.fabric.client.Gateway;
 import org.hyperledger.fabric.client.Network;
@@ -52,8 +52,7 @@ import org.hyperledger.fabric.client.identity.X509Identity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class ScenarioSteps implements En {
-    private static final long EVENT_TIMEOUT_SECONDS = 30;
+public class ScenarioSteps {
     private static final Set<String> runningChaincodes = new HashSet<>();
     private static boolean channelsJoined = false;
     private static final String DOCKER_COMPOSE_TLS_FILE = "docker-compose-tls.yaml";
@@ -97,6 +96,7 @@ public class ScenarioSteps implements En {
         final String cli;
         final String anchortx;
         final Set<String> peers;
+
         OrgConfig(String cli, String anchortx, String... peers) {
             this.cli = cli;
             this.anchortx = anchortx;
@@ -105,226 +105,236 @@ public class ScenarioSteps implements En {
         }
     }
 
-    public ScenarioSteps() throws IOException {
-        After(() -> {
-            if (gateway != null) {
-                gateway.close();
-            }
-        });
+    @After
+    public void afterEach() {
+        if (gateway != null) {
+            gateway.close();
+        }
+    }
 
-        Given("I have deployed a {word} Fabric network", (String tlsType) -> {
-            // tlsType is either "tls" or "non-tls"
-            fabricNetworkType = tlsType;
-        });
+    @Given("I have deployed a {word} Fabric network")
+    public void deployFabricNetwork(String tlsType) {
+        // tlsType is either "tls" or "non-tls"
+        fabricNetworkType = tlsType;
+    }
 
-        Given("I have created and joined all channels from the {word} connection profile", (String tlsType) -> {
-            // TODO this only does mychannel
-            startAllPeers();
-            if (!channelsJoined) {
-                final List<String> tlsOptions;
-                if (tlsType.equals("tls")) {
-                    tlsOptions = Arrays.asList("--tls", "true", "--cafile",
-                            "/etc/hyperledger/configtx/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem");
-                } else {
-                    tlsOptions = Collections.emptyList();
-                }
-
-                List<String> createChannelCommand = new ArrayList<>();
-                Collections.addAll(createChannelCommand, "docker", "exec", "org1_cli", "peer", "channel", "create",
-                        "-o", "orderer.example.com:7050", "-c", "mychannel", "-f",
-                        "/etc/hyperledger/configtx/channel.tx", "--outputBlock",
-                        "/etc/hyperledger/configtx/mychannel.block");
-                createChannelCommand.addAll(tlsOptions);
-                exec(createChannelCommand);
-
-                for (OrgConfig org : ORG_CONFIGS) {
-                    for (String peer : org.peers) {
-                        String env = "CORE_PEER_ADDRESS=" + peer;
-                        List<String> joinChannelCommand = new ArrayList<>();
-                        Collections.addAll(joinChannelCommand, "docker", "exec", "-e", env, org.cli, "peer", "channel", "join",
-                                "-b", "/etc/hyperledger/configtx/mychannel.block");
-                        joinChannelCommand.addAll(tlsOptions);
-                        exec(joinChannelCommand);
-                    }
-
-                    List<String> anchorPeersCommand = new ArrayList<>();
-                    Collections.addAll(anchorPeersCommand, "docker", "exec", org.cli, "peer", "channel", "update",
-                            "-o", "orderer.example.com:7050", "-c", "mychannel", "-f", org.anchortx);
-                    anchorPeersCommand.addAll(tlsOptions);
-                    exec(anchorPeersCommand);
-                }
-
-                channelsJoined = true;
-            }
-        });
-
-        Given("I deploy {word} chaincode named {word} at version {word} for all organizations on channel {word} with endorsement policy {}",
-                (String ccType, String ccName, String version, String channelName, String signaturePolicy) -> {
-                    String mangledName = ccName + version + channelName;
-                    if (runningChaincodes.contains(mangledName)) {
-                        return;
-                    }
-
-                    final List<String> tlsOptions;
-                    if (fabricNetworkType.equals("tls")) {
-                        tlsOptions = Arrays.asList("--tls", "true", "--cafile",
-                                "/etc/hyperledger/configtx/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem");
-                    } else {
-                        tlsOptions = Collections.emptyList();
-                    }
-
-                    String ccPath;
-                    if (ccType == "golang") {
-                        ccPath = Paths.get(FileSystems.getDefault().getSeparator(),
-                                "github.com", "chaincode", ccType, ccName).toString();
-                    } else {
-                        ccPath = Paths.get(FileSystems.getDefault().getSeparator(), "opt", "gopath", "src",
-                                "github.com", "chaincode", ccType, ccName).toString();
-                    }
-
-                    String ccLabel = ccName + "v" + version;
-                    String ccPackage = ccName + ".tar.gz";
-
-                    for (OrgConfig org : ORG_CONFIGS) {
-                        exec("docker", "exec", org.cli, "peer", "lifecycle", "chaincode", "package", ccPackage, "--lang",
-                                ccType, "--label", ccLabel, "--path", ccPath);
-
-                        for (String peer : org.peers) {
-                            String env = "CORE_PEER_ADDRESS=" + peer;
-                            exec("docker", "exec", "-e", env, org.cli, "peer", "lifecycle", "chaincode", "install", ccPackage);
-                        }
-
-                        String installed = exec("docker", "exec", org.cli, "peer", "lifecycle", "chaincode",
-                                "queryinstalled");
-                        Pattern regex = Pattern.compile(".*Package ID: (.*), Label: " + ccLabel + ".*");
-                        Matcher matcher = regex.matcher(installed);
-                        if (!matcher.matches()) {
-                            System.out.println(installed);
-                            throw new IllegalStateException("Cannot find installed chaincode for Org1: " + ccLabel);
-                        }
-                        String packageId = matcher.group(1);
-
-                        List<String> approveCommand = new ArrayList<>();
-                        Collections.addAll(approveCommand, "docker", "exec", org.cli, "peer", "lifecycle", "chaincode",
-                                "approveformyorg", "--package-id", packageId, "--channelID", channelName, "--name", ccName,
-                                "--version", version, "--signature-policy", signaturePolicy,
-                                "--sequence", "1", "--waitForEvent");
-                        approveCommand.addAll(tlsOptions);
-                        exec(approveCommand);
-                    }
-
-                    // commit
-                    List<String> commitCommand = new ArrayList<>();
-                    Collections.addAll(commitCommand, "docker", "exec", "org1_cli", "peer", "lifecycle", "chaincode", "commit",
-                            "--channelID", channelName,
-                            "--name", ccName,
-                            "--version", version,
-                            "--signature-policy", signaturePolicy,
-                            "--sequence", "1",
-                            "--waitForEvent",
-                            "--peerAddresses", "peer0.org1.example.com:7051",
-                            "--peerAddresses",
-                            "peer0.org2.example.com:8051",
-                            "--tlsRootCertFiles",
-                            "/etc/hyperledger/configtx/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
-                            "--tlsRootCertFiles",
-                            "/etc/hyperledger/configtx/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt");
-                    commitCommand.addAll(tlsOptions);
-                    exec(commitCommand);
-
-                    runningChaincodes.add(mangledName);
-                    Thread.sleep(60000);
-                });
-
-        Given("I create a gateway for user {word} in MSP {word}", (String user, String mspId) -> {
-            gatewayBuilder = Gateway.newInstance()
-                    .identity(newIdentity(user, mspId))
-                    .signer(newSigner(user, mspId));
-        });
-
-        Given("I create a gateway without signer for user {word} in MSP {word}", (String user, String mspId) -> {
-            gatewayBuilder = Gateway.newInstance()
-                    .identity(newIdentity(user, mspId));
-        });
-
-        Given("I connect the gateway to {word}", (String address) -> {
-            gateway = gatewayBuilder.endpoint(address).connect();
-        });
-
-        Given("I use the {word} network", (String networkName) -> {
-            network = gateway.getNetwork(networkName);
-        });
-
-        Given("I use the {word} contract", (String contractName) -> {
-            contract = network.getContract(contractName);
-        });
-
-        When("^I prepare to (evaluate|submit) an? ([^ ]+) transaction$", (String action, String transactionName) -> {
-            if (action.equals("submit")) {
-                transactionInvocation = TransactionInvocation.prepareToSubmit(contract, transactionName);
+    @Given("I have created and joined all channels from the {word} connection profile")
+    public void createAndJoinAllChannels(String tlsType) throws IOException, InterruptedException {
+        // TODO this only does mychannel
+        startAllPeers();
+        if (!channelsJoined) {
+            final List<String> tlsOptions;
+            if ("tls".equals(tlsType)) {
+                tlsOptions = Arrays.asList("--tls", "true", "--cafile",
+                        "/etc/hyperledger/configtx/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem");
             } else {
-                transactionInvocation = TransactionInvocation.prepareToEvaluate(contract, transactionName);
+                tlsOptions = Collections.emptyList();
             }
-        });
 
-        When("^I set the transaction arguments? to (.+)$", (String argsJson) -> {
-            String[] args = newStringArray(parseJsonArray(argsJson));
-            transactionInvocation.setArguments(args);
-        });
+            List<String> createChannelCommand = new ArrayList<>();
+            Collections.addAll(createChannelCommand, "docker", "exec", "org1_cli", "peer", "channel", "create",
+                    "-o", "orderer.example.com:7050", "-c", "mychannel", "-f",
+                    "/etc/hyperledger/configtx/channel.tx", "--outputBlock",
+                    "/etc/hyperledger/configtx/mychannel.block");
+            createChannelCommand.addAll(tlsOptions);
+            exec(createChannelCommand);
 
-        Given("I do off-line signing as user {word} in MSP {word}", (String user, String mspId) -> {
-            transactionInvocation.setOfflineSigner(newSigner(user, mspId));
-        });
+            for (OrgConfig org : ORG_CONFIGS) {
+                for (String peer : org.peers) {
+                    String env = "CORE_PEER_ADDRESS=" + peer;
+                    List<String> joinChannelCommand = new ArrayList<>();
+                    Collections.addAll(joinChannelCommand, "docker", "exec", "-e", env, org.cli, "peer", "channel", "join",
+                            "-b", "/etc/hyperledger/configtx/mychannel.block");
+                    joinChannelCommand.addAll(tlsOptions);
+                    exec(joinChannelCommand);
+                }
 
-        When("I invoke the transaction", () -> {
-            transactionInvocation.invoke();
-            transactionInvocation.getResponse();
-        });
-
-        When("I set transient data on the transaction to", (DataTable data) -> {
-            Map<String, String> table = data.asMap(String.class, String.class);
-            Map<String, byte[]> transientMap = table.entrySet().stream()
-                    .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getBytes(StandardCharsets.UTF_8)));
-            transactionInvocation.setTransient(transientMap);
-        });
-
-
-        When("I stop the peer named {}", (String peer) -> {
-            exec("docker", "stop", peer);
-            runningPeers.put(peer, false);
-        });
-
-        When("I start the peer named {}", (String peer) -> {
-            exec("docker", "start", peer);
-            runningPeers.put(peer, true);
-            Thread.sleep(20000);
-        });
-
-        Then("the transaction invocation should fail", () -> {
-            transactionInvocation.invoke();
-            transactionInvocation.getError();
-        });
-
-        Then("the response should be JSON matching", (DocString expected) -> {
-            try (JsonReader expectedReader = createJsonReader(expected.getContent());
-                    JsonReader actualReader = createJsonReader(transactionInvocation.getResponse())) {
-                JsonObject expectedObject = expectedReader.readObject();
-                JsonObject actualObject = actualReader.readObject();
-                assertThat(actualObject).isEqualTo(expectedObject);
+                List<String> anchorPeersCommand = new ArrayList<>();
+                Collections.addAll(anchorPeersCommand, "docker", "exec", org.cli, "peer", "channel", "update",
+                        "-o", "orderer.example.com:7050", "-c", "mychannel", "-f", org.anchortx);
+                anchorPeersCommand.addAll(tlsOptions);
+                exec(anchorPeersCommand);
             }
-        });
 
-        Then("the response should be {string}", (String expected) -> {
-            assertThat(transactionInvocation.getResponse()).isEqualTo(expected);
-        });
+            channelsJoined = true;
+        }
+    }
 
-        Then("the error message should contain {string}",
-                (String expected) -> assertThat(transactionInvocation.getError().getMessage()).contains(expected));
+    @Given("I deploy {word} chaincode named {word} at version {word} for all organizations on channel {word} with endorsement policy {}")
+    public void deployChaincode(String ccType, String ccName, String version, String channelName, String signaturePolicy) throws IOException, InterruptedException {
+        String mangledName = ccName + version + channelName;
+        if (runningChaincodes.contains(mangledName)) {
+            return;
+        }
+
+        final List<String> tlsOptions;
+        if (fabricNetworkType.equals("tls")) {
+            tlsOptions = Arrays.asList("--tls", "true", "--cafile",
+                    "/etc/hyperledger/configtx/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem");
+        } else {
+            tlsOptions = Collections.emptyList();
+        }
+
+        String ccPath = Paths.get(FileSystems.getDefault().getSeparator(), "opt", "gopath", "src",
+                "github.com", "chaincode", ccType, ccName).toString();
+        String ccLabel = ccName + "v" + version;
+        String ccPackage = ccName + ".tar.gz";
+
+        for (OrgConfig org : ORG_CONFIGS) {
+            exec("docker", "exec", org.cli, "peer", "lifecycle", "chaincode", "package", ccPackage, "--lang",
+                    ccType, "--label", ccLabel, "--path", ccPath);
+
+            for (String peer : org.peers) {
+                String env = "CORE_PEER_ADDRESS=" + peer;
+                exec("docker", "exec", "-e", env, org.cli, "peer", "lifecycle", "chaincode", "install", ccPackage);
+            }
+
+            String installed = exec("docker", "exec", org.cli, "peer", "lifecycle", "chaincode",
+                    "queryinstalled");
+            Pattern regex = Pattern.compile(".*Package ID: (.*), Label: " + ccLabel + ".*");
+            Matcher matcher = regex.matcher(installed);
+            if (!matcher.matches()) {
+                System.out.println(installed);
+                throw new IllegalStateException("Cannot find installed chaincode for Org1: " + ccLabel);
+            }
+            String packageId = matcher.group(1);
+
+            List<String> approveCommand = new ArrayList<>();
+            Collections.addAll(approveCommand, "docker", "exec", org.cli, "peer", "lifecycle", "chaincode",
+                    "approveformyorg", "--package-id", packageId, "--channelID", channelName, "--name", ccName,
+                    "--version", version, "--signature-policy", signaturePolicy,
+                    "--sequence", "1", "--waitForEvent");
+            approveCommand.addAll(tlsOptions);
+            exec(approveCommand);
+        }
+
+        // commit
+        List<String> commitCommand = new ArrayList<>();
+        Collections.addAll(commitCommand, "docker", "exec", "org1_cli", "peer", "lifecycle", "chaincode", "commit",
+                "--channelID", channelName,
+                "--name", ccName,
+                "--version", version,
+                "--signature-policy", signaturePolicy,
+                "--sequence", "1",
+                "--waitForEvent",
+                "--peerAddresses", "peer0.org1.example.com:7051",
+                "--peerAddresses",
+                "peer0.org2.example.com:8051",
+                "--tlsRootCertFiles",
+                "/etc/hyperledger/configtx/crypto-config/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls/ca.crt",
+                "--tlsRootCertFiles",
+                "/etc/hyperledger/configtx/crypto-config/peerOrganizations/org2.example.com/peers/peer0.org2.example.com/tls/ca.crt");
+        commitCommand.addAll(tlsOptions);
+        exec(commitCommand);
+
+        runningChaincodes.add(mangledName);
+        Thread.sleep(60000);
+    }
+
+    @Given("I create a gateway for user {word} in MSP {word}")
+    public void createGateway(String user, String mspId) throws CertificateException, InvalidKeyException, IOException {
+        gatewayBuilder = Gateway.newInstance()
+                .identity(newIdentity(user, mspId))
+                .signer(newSigner(user, mspId));
+    }
+
+    @Given("I create a gateway without signer for user {word} in MSP {word}")
+    public void createGatewayWithoutSigner(String user, String mspId) throws CertificateException, IOException {
+        gatewayBuilder = Gateway.newInstance()
+                .identity(newIdentity(user, mspId));
+    }
+
+    @Given("I connect the gateway to {word}")
+    public void connectGateway(String address) {
+        gateway = gatewayBuilder.endpoint(address).connect();
+    }
+
+    @Given("I use the {word} network")
+    public void useNetwork(String networkName) {
+        network = gateway.getNetwork(networkName);
+    }
+
+    @Given("I use the {word} contract")
+    public void useContract(String contractName) {
+        contract = network.getContract(contractName);
+    }
+
+    @When("^I prepare to (evaluate|submit) an? ([^ ]+) transaction$")
+    public void prepareTransaction(String action, String transactionName) {
+        if (action.equals("submit")) {
+            transactionInvocation = TransactionInvocation.prepareToSubmit(contract, transactionName);
+        } else {
+            transactionInvocation = TransactionInvocation.prepareToEvaluate(contract, transactionName);
+        }
+    }
+
+    @When("^I set the transaction arguments? to (.+)$")
+    public void setTransactionArguments(String argsJson) {
+        String[] args = newStringArray(parseJsonArray(argsJson));
+        transactionInvocation.setArguments(args);
+    }
+
+    @When("I do off-line signing as user {word} in MSP {word}")
+    public void offlineSign(String user, String mspId) throws InvalidKeyException, IOException {
+        transactionInvocation.setOfflineSigner(newSigner(user, mspId));
+    }
+
+    @When("I invoke the transaction")
+    public void invokeTransaction() {
+        transactionInvocation.invoke();
+        transactionInvocation.getResponse();
+    }
+
+    @When("I set transient data on the transaction to")
+    public void setTransientData(DataTable data) {
+        Map<String, String> table = data.asMap(String.class, String.class);
+        Map<String, byte[]> transientMap = table.entrySet().stream()
+                .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getBytes(StandardCharsets.UTF_8)));
+        transactionInvocation.setTransient(transientMap);
+    }
+
+    @When("I stop the peer named {}")
+    public void stopPeer(String peer) throws IOException, InterruptedException {
+        exec("docker", "stop", peer);
+        runningPeers.put(peer, false);
+    }
+
+    @When("I start the peer named {}")
+    public void startPeer(String peer) throws IOException, InterruptedException {
+        exec("docker", "start", peer);
+        runningPeers.put(peer, true);
+        Thread.sleep(20000);
+    }
+
+    @Then("the transaction invocation should fail")
+    public void invokeFailingTransaction() {
+        transactionInvocation.invoke();
+        transactionInvocation.getError();
+    }
+
+    @Then("the response should be JSON matching")
+    public void assertJsonResponse(DocString expected) {
+        try (JsonReader expectedReader = createJsonReader(expected.getContent());
+                JsonReader actualReader = createJsonReader(transactionInvocation.getResponse())) {
+            JsonObject expectedObject = expectedReader.readObject();
+            JsonObject actualObject = actualReader.readObject();
+            assertThat(actualObject).isEqualTo(expectedObject);
+        }
+    }
+
+    @Then("the response should be {string}")
+    public void assertResponse(String expected) {
+        assertThat(transactionInvocation.getResponse()).isEqualTo(expected);
+    }
+
+    @Then("the error message should contain {string}")
+    public void assertErrorMessageContains(String expected) {
+        assertThat(transactionInvocation.getError()).hasMessageContaining(expected);
     }
 
     private static void startAllPeers() throws InterruptedException, IOException {
         for (String peer : runningPeers.keySet()) {
-            if (runningPeers.get(peer) == false) {
+            if (!runningPeers.get(peer)) {
                 exec("docker", "start", peer);
                 runningPeers.put(peer, true);
             }
@@ -348,30 +358,6 @@ public class ScenarioSteps implements En {
 
     public static String newString(byte[] bytes) {
         return new String(bytes, StandardCharsets.UTF_8);
-    }
-
-    /**
-     * Remove and return the first element matching the given predicate. All other
-     * elements remain on the queue.
-     *
-     * @param queue A queue.
-     * @param match Filter used to match queue elements.
-     * @return The first matching element or null if no matches are found.
-     * @throws InterruptedException If waiting for queue elements is interrupted.
-     */
-    private <T> T removeFirstMatch(BlockingQueue<T> queue, Predicate<? super T> match) throws InterruptedException {
-        List<T> unmatchedElements = new ArrayList<>();
-        T element;
-
-        while ((element = queue.poll(EVENT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) != null) {
-            if (match.test(element)) {
-                break;
-            }
-            unmatchedElements.add(element);
-        }
-
-        queue.addAll(unmatchedElements); // Re-queue elements that didn't match
-        return element;
     }
 
     private static String exec(List<String> commandArgs) throws IOException, InterruptedException {
@@ -417,13 +403,13 @@ public class ScenarioSteps implements En {
         return sb.toString();
     }
 
-    static void startFabric(boolean tls) throws Exception {
+    static void startFabric() throws Exception {
         createCryptoMaterial();
         exec(DOCKER_COMPOSE_DIR, "docker-compose", "-f", DOCKER_COMPOSE_TLS_FILE, "-p", "node", "up", "-d");
         Thread.sleep(10000);
     }
 
-    static void stopFabric(boolean tls) throws Exception {
+    static void stopFabric() throws Exception {
         exec(DOCKER_COMPOSE_DIR, "docker-compose", "-f", DOCKER_COMPOSE_TLS_FILE, "-p", "node", "down");
     }
 
@@ -432,7 +418,7 @@ public class ScenarioSteps implements En {
         exec(fixtures, "./generate.sh");
     }
 
-    private static Identity newIdentity(String user, String mspId) throws IOException, CertificateException, InvalidKeyException {
+    private static Identity newIdentity(String user, String mspId) throws IOException, CertificateException {
         String org = getOrgForMspId(mspId);
         Path credentialPath = getCredentialPath(user, org);
         Path certificatePath = credentialPath.resolve(Paths.get("signcerts", user + "@" + org + "-cert.pem"));
@@ -441,7 +427,7 @@ public class ScenarioSteps implements En {
         return new X509Identity(mspId, certificate);
     }
 
-    private static Signer newSigner(String user, String mspId) throws IOException, CertificateException, InvalidKeyException {
+    private static Signer newSigner(String user, String mspId) throws IOException, InvalidKeyException {
         String org = getOrgForMspId(mspId);
         Path credentialPath = getCredentialPath(user, org);
         Path privateKeyPath = credentialPath.resolve(Paths.get("keystore", "key.pem"));
@@ -478,5 +464,4 @@ public class ScenarioSteps implements En {
             return Identities.readPrivateKey(privateKeyReader);
         }
     }
-
 }

--- a/java/src/test/java/scenario/SetupScenarioTest.java
+++ b/java/src/test/java/scenario/SetupScenarioTest.java
@@ -7,7 +7,7 @@ public class SetupScenarioTest {
 	@Test
 	public void startFabric() throws Exception {
 		System.err.println("Starting Fabric");
-    	ScenarioSteps.startFabric(true);
+    	ScenarioSteps.startFabric();
 	}
 
 }


### PR DESCRIPTION
Lambda API is apparently being deprecated, and is currently causing failures with Java 11, at least with OpenJDK on MacOS.