### PR TITLE
FABGW-8: Wait for commit during transaction submit in Go client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build-node: build-protos
 unit-test: generate unit-test-go unit-test-node unit-test-java
 
 unit-test-go: lint staticcheck
-	go test -coverprofile=$(base_dir)/cover.out $(base_dir)/pkg/...
+	go test -timeout 10s -coverprofile=$(base_dir)/cover.out $(base_dir)/pkg/...
 
 unit-test-node: build-node
 	cd $(node_dir); npm test

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -17,7 +17,7 @@ variables:
 stages:
 - stage: Test
   jobs:
-  - job: UnitTest
+  - job: UnitTestGo
     pool:
       vmImage: ubuntu-20.04
     dependsOn: []
@@ -25,8 +25,28 @@ stages:
     steps:
     - template: install_deps.yml
     - checkout: self
-    - script: make unit-test
-      displayName: Run unit tests
+    - script: make generate unit-test-go
+      displayName: Run Go unit tests
+  - job: UnitTestNode
+    pool:
+      vmImage: ubuntu-20.04
+    dependsOn: []
+    timeoutInMinutes: 60
+    steps:
+    - template: install_deps.yml
+    - checkout: self
+    - script: make unit-test-node
+      displayName: Run Node unit tests
+  - job: UnitTestJava
+    pool:
+      vmImage: ubuntu-20.04
+    dependsOn: []
+    timeoutInMinutes: 60
+    steps:
+    - template: install_deps.yml
+    - checkout: self
+    - script: make unit-test-java
+      displayName: Run Java unit tests
   #   - script: bash <(curl https://codecov.io/bash) -t $CODECOV_UPLOAD_TOKEN
   #     env:
   #       CODECOV_UPLOAD_TOKEN: $(CODECOV_UPLOAD_TOKEN)

--- a/pkg/client/identity_test.go
+++ b/pkg/client/identity_test.go
@@ -88,6 +88,9 @@ func TestIdentity(t *testing.T) {
 				Payload: nil,
 			},
 		}
+		statusResponse := gateway.CommitStatusResponse{
+			Result: peer.TxValidationCode_VALID,
+		}
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest, _ ...grpc.CallOption) {
 				actual = test.AssertUnmarshallSignatureHeader(t, in.ProposedTransaction).Creator
@@ -96,6 +99,8 @@ func TestIdentity(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&statusResponse, nil)
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithIdentity(id))
 

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -43,6 +43,10 @@ func TestOfflineSign(t *testing.T) {
 		}
 	}
 
+	statusResponse := gateway.CommitStatusResponse{
+		Result: peer.TxValidationCode_VALID,
+	}
+
 	t.Run("Evaluate", func(t *testing.T) {
 		t.Run("Returns error with signer and no explicit signing", func(t *testing.T) {
 			mockController := gomock.NewController(t)
@@ -224,6 +228,8 @@ func TestOfflineSign(t *testing.T) {
 				}).
 				Return(nil, nil).
 				Times(1)
+			mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+				Return(&statusResponse, nil)
 
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 

--- a/pkg/client/sign_test.go
+++ b/pkg/client/sign_test.go
@@ -32,6 +32,10 @@ func TestSign(t *testing.T) {
 		},
 	}
 
+	statusResponse := gateway.CommitStatusResponse{
+		Result: peer.TxValidationCode_VALID,
+	}
+
 	t.Run("Evaluate signs proposal using client signing implementation", func(t *testing.T) {
 		expected := []byte("SIGNATURE")
 		sign := func(digest []byte) ([]byte, error) {
@@ -78,6 +82,8 @@ func TestSign(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&statusResponse, nil)
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithSign(sign))
 
@@ -108,6 +114,8 @@ func TestSign(t *testing.T) {
 			}).
 			Return(nil, nil).
 			Times(1)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&statusResponse, nil)
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithSign(sign))
 

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -31,6 +31,10 @@ func TestSubmitTransaction(t *testing.T) {
 		}
 	}
 
+	validStatusResponse := gateway.CommitStatusResponse{
+		Result: peer.TxValidationCode_VALID,
+	}
+
 	t.Run("Returns endorsement error", func(t *testing.T) {
 		expectedError := "ENDORSE_ERROR"
 		mockController := gomock.NewController(t)
@@ -99,6 +103,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
@@ -109,6 +115,53 @@ func TestSubmitTransaction(t *testing.T) {
 
 		if !bytes.Equal(actual, expected) {
 			t.Fatalf("Expected %s, got %s", expected, actual)
+		}
+	})
+
+	t.Run("Returns error with status code for commit failure", func(t *testing.T) {
+		expectedError := peer.TxValidationCode_name[int32(peer.TxValidationCode_MVCC_READ_CONFLICT)]
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+
+		mockClient := NewMockGatewayClient(mockController)
+		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
+			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
+		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
+			Return(nil, nil)
+		readConflictResponse := &gateway.CommitStatusResponse{
+			Result: peer.TxValidationCode_MVCC_READ_CONFLICT,
+		}
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(readConflictResponse, nil)
+
+		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
+
+		_, err := contract.SubmitTransaction("transaction")
+
+		if nil == err || !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error containing %s, got %v", expectedError, err)
+		}
+	})
+
+	t.Run("Returns error with details on communication failure getting transaction commit status", func(t *testing.T) {
+		expectedError := "COMMIT_STATUS_ERROR"
+		mockController := gomock.NewController(t)
+		defer mockController.Finish()
+
+		mockClient := NewMockGatewayClient(mockController)
+		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
+			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
+		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
+			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, errors.New(expectedError))
+
+		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
+
+		_, err := contract.SubmitTransaction("transaction")
+
+		if nil == err || !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error containing %s, got %v", expectedError, err)
 		}
 	})
 
@@ -126,6 +179,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
@@ -154,6 +209,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
@@ -182,6 +239,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
@@ -211,6 +270,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContractWithName(t, "chaincode", "CONTRACT_NAME", WithClient(mockClient))
 
@@ -240,6 +301,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
@@ -269,6 +332,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
@@ -299,6 +364,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
@@ -330,6 +397,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient), WithSign(sign))
 
@@ -361,6 +430,8 @@ func TestSubmitTransaction(t *testing.T) {
 			}).
 			Return(nil, nil).
 			Times(1)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient), WithSign(sign))
 
@@ -392,6 +463,8 @@ func TestSubmitTransaction(t *testing.T) {
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
+			Return(&validStatusResponse, nil)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient), WithSign(sign), WithHash(hash))
 


### PR DESCRIPTION
Also add a timeout to Go unit tests for safety, and split unit test runs by language to provide more targeted feedback in build results.

Basic implementation not including retries on connection error obtaining commit status.