### PR TITLE
Update npm prerelease version

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -126,7 +126,7 @@ stages:
           workingFile: '$(Agent.TempDirectory)/.npmrc'
           customEndpoint: 'npm'
       - script: |
-          npm version prepatch --preid=dev.${BUILD_DATE}.${BUILD_NUMBER}
+          npm version prepatch --preid=dev-${BUILD_DATE}-${BUILD_NUMBER}
         displayName: 'set prerelease version'
         workingDirectory: $(Pipeline.Workspace)/NodeBuild
         env:


### PR DESCRIPTION
npm publish is failing with

“403 a package version that is forbidden by your security policy”

which may be due to the prerelease version string

Signed-off-by: James Taylor <jamest@uk.ibm.com>