### PR TITLE
Fix Java scenario test hang

### DIFF
--- a/scenario/fixtures/docker-compose/.env
+++ b/scenario/fixtures/docker-compose/.env
@@ -2,4 +2,3 @@ DOCKER_IMG_TAG=:2.3
 PEER_IMG_TAG=:2.4
 FABRIC_CA_TAG=:1.4
 COUCHDB_IMG_TAG=:3.1.1
-DOCKER_DEBUG=:info:chaincode.platform,dockercontroller,gateway=debug


### PR DESCRIPTION
Not sure why atm, but the DOCKER_DEBUG env-var seems to hang the Java scenario tests when exec’ing the
peer lifecycle chaincode package
command.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>