### PR TITLE
Update images used in Gateway sample scenario

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,14 @@ node_dir := $(base_dir)/node
 java_dir := $(base_dir)/java
 scenario_dir := $(base_dir)/scenario
 
-PEER_VERSION = 2.4
-ALPINE_VER ?= 3.12
-BASE_VERSION = 2.3.0
-# TWO_DIGIT_VERSION is derived, e.g. "2.0", especially useful as a local tag
-# for two digit references to most recent baseos and ccenv patch releases
-TWO_DIGIT_VERSION = $(shell echo $(BASE_VERSION) | cut -d '.' -f 1,2)
+# PEER_IMAGE_PULL is where to pull peer image from, it can be set by external env variable
+PEER_IMAGE_PULL ?= hyperledger-fabric.jfrog.io/fabric-peer:amd64-latest
+
+# PEER_IMAGE_TAG is what to tag the pulled peer image as, it will also be used in docker-compose to reference the image
+PEER_IMAGE_TAG ?= 2.4
+
+# TWO_DIGIT_VERSION specifies which chaincode images to pull, they will be tagged to be consistent with PEER_IMAGE_TAG
+TWO_DIGIT_VERSION ?= 2.3
 
 PKGNAME = github.com/hyperledger/fabric-gateway
 ARCH=$(shell go env GOARCH)
@@ -91,12 +93,12 @@ test: unit-test scenario-test
 all: test
 
 pull-latest-peer:
-	docker pull hyperledger-fabric.jfrog.io/fabric-peer:amd64-latest
-	docker tag hyperledger-fabric.jfrog.io/fabric-peer:amd64-latest hyperledger/fabric-peer:$(PEER_VERSION)
+	docker pull $(PEER_IMAGE_PULL)
+	docker tag $(PEER_IMAGE_PULL) hyperledger/fabric-peer:$(PEER_IMAGE_TAG)
 	# also need to retag the following images for the chaincode builder
 	for IMAGE in baseos ccenv javaenv nodeenv; do \
 		docker pull hyperledger/fabric-$$IMAGE:$(TWO_DIGIT_VERSION); \
-		docker tag hyperledger/fabric-$$IMAGE:$(TWO_DIGIT_VERSION) hyperledger/fabric-$$IMAGE:$(PEER_VERSION); \
+		docker tag hyperledger/fabric-$$IMAGE:$(TWO_DIGIT_VERSION) hyperledger/fabric-$$IMAGE:$(PEER_IMAGE_TAG); \
 	done
 
 .PHONEY: clean

--- a/samples/README.md
+++ b/samples/README.md
@@ -3,16 +3,19 @@
 The samples in this repo show how to create client applications that invoke transactions using the new embedded Gateway
 in Fabric.
 
-The samples will only run against the latest Tech Preview version of Fabric.  The easiest way of setting up a gateway
+The samples will only run against the latest version of Fabric - v2.4.0-alpha.  The easiest way of setting up a gateway
 enabled Fabric network is to use the scenario test framework that is part of this `fabric-gateway` repository using the
 following command:
 
-`make sample-network`
+```
+export PEER_IMAGE_PULL=hyperledger/fabric-peer:2.4.0-alpha
+make sample-network
+```
 
 This will create a local docker network comprising five peers across three organisations and a single ordering node.
 One of the peers (`peer0.org1.example.com`) has been configured with the gateway enabled.
 
-A simple smart contract (named `basic`) will have been instantiated on all the peers.  The source code for the smart 
+A simple smart contract (named `basic`) will have been instantiated on all the peers.  The source code for the smart
 contract can examined [here](https://github.com/hyperledger/fabric-gateway/blob/main/scenario/fixtures/chaincode/golang/basic/main.go).
 
 A sample client application is provided for each of the supported SDKs.
@@ -20,7 +23,7 @@ Note that the SDKs implement the Fabric 'Gateway' programming model which has be
 Fabric v1.4, but these are new implementations that target the embedded peer gateway and they share no common code with
 existing Fabric SDKs.
 
-In each of the language samples, the client application submits a transaction (`put`) to update the ledger followed by 
+In each of the language samples, the client application submits a transaction (`put`) to update the ledger followed by
 evaluating a transaction (`get`) to retrieve the value from the ledger (query).
 The value that is being updated and retrieved is the current timestamp to demonstrate that the update is working.
 
@@ -46,3 +49,7 @@ npm start
 cd <base-path>/fabric-gateway/samples/java
 mvn test
 ```
+
+When you are finished running the samples, the local docker network can be brought down with the following command:
+
+`docker rm -f $(docker ps -aq) && docker network prune --force`

--- a/scenario/fixtures/crypto-material/core.yaml
+++ b/scenario/fixtures/crypto-material/core.yaml
@@ -230,7 +230,13 @@ peer:
             # indicates whenever state transfer is enabled or not
             # default value is true, i.e. state transfer is active
             # and takes care to sync up missing blocks allowing
-            # lagging peer to catch up to speed with rest network
+            # lagging peer to catch up to speed with rest network.
+            # Keep in mind that when peer.gossip.useLeaderElection is true
+            # and there are several peers in the organization,
+            # or peer.gossip.useLeaderElection is false alongside with
+            # peer.gossip.orgleader being false, the peer's ledger may lag behind
+            # the rest of the peers and will never catch up due to state transfer
+            # being disabled.
             enabled: false
             # checkInterval interval to check whether peer is lagging behind enough to
             # request blocks via state transfer from another peer.

--- a/scenario/fixtures/docker-compose/.env
+++ b/scenario/fixtures/docker-compose/.env
@@ -1,4 +1,7 @@
-DOCKER_IMG_TAG=:2.3
-PEER_IMG_TAG=:2.4
-FABRIC_CA_TAG=:1.4
-COUCHDB_IMG_TAG=:3.1.1
+# Environment variables will be overridden if set in user environment or Makefile.
+ORDER_IMAGE_TAG=2.3
+TOOLS_IMAGE_TAG=2.3
+PEER_IMAGE_TAG=2.4
+FABRIC_CA_IMAGE_TAG=1.5
+COUCHDB_IMAGE_TAG=3.1.1
+DOCKER_DEBUG=info:dockercontroller,gateway=debug

--- a/scenario/fixtures/docker-compose/docker-compose-base.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-base.yaml
@@ -15,7 +15,7 @@ version: '2'
 
 services:
   ca0:
-    image: hyperledger/fabric-ca${FABRIC_CA_TAG}
+    image: hyperledger/fabric-ca:${FABRIC_CA_IMAGE_TAG}
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org1
@@ -29,7 +29,7 @@ services:
     container_name: ca_peerOrg1
 
   ca1:
-    image: hyperledger/fabric-ca${FABRIC_CA_TAG}
+    image: hyperledger/fabric-ca:${FABRIC_CA_IMAGE_TAG}
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org2
@@ -44,7 +44,7 @@ services:
 
   orderer:
     container_name: orderer
-    image: hyperledger/fabric-orderer${DOCKER_IMG_TAG}
+    image: hyperledger/fabric-orderer:${ORDER_IMAGE_TAG}
     environment:
       - ORDERER_GENERAL_LOGLEVEL=${DOCKER_DEBUG}
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -65,7 +65,7 @@ services:
 
   peer:
     container_name: peer
-    image: hyperledger/fabric-peer${PEER_IMG_TAG}
+    image: hyperledger/fabric-peer:${PEER_IMAGE_TAG}
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ADDRESSAUTODETECT=true
@@ -91,7 +91,7 @@ services:
 
 #  gateway:
 #    container_name: gateway
-#    image: hyperledger/fabric-gateway${DOCKER_IMG_TAG}
+#    image: hyperledger/fabric-gateway$:{DOCKER_IMAGE_TAG}
 #    environment:
 #      - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
 #
@@ -130,7 +130,7 @@ services:
 
   couchdb:
     container_name: couchdb
-    image: couchdb${COUCHDB_IMG_TAG}
+    image: couchdb:${COUCHDB_IMAGE_TAG}
     environment:
       - COUCHDB_USER=admin
       - COUCHDB_PASSWORD=adminpw

--- a/scenario/fixtures/docker-compose/docker-compose-cli.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-cli.yaml
@@ -17,7 +17,7 @@ version: '2'
 services:
   clinopeer:
     container_name: cli
-    image: hyperledger/fabric-tools${DOCKER_IMG_TAG}
+    image: hyperledger/fabric-tools:${TOOLS_IMAGE_TAG}
     tty: true
     environment:
       - GOPATH=/opt/gopath


### PR DESCRIPTION
Make the peer image configurable to pull from jfrog latest (default)
or a named docker image/version, e.g.:
export PEER_IMAGE_PULL=hyperledger/fabric-peer:2.4.0-alpha

Make PEER_IMAGE_TAG consistent across Makefile and .env file.
The tagged value will be used in docker-compose.

Finally, clean up the other env variables with clearer names.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>