### PR TITLE
Fix JavaDoc warnings

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -35,8 +35,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <javaVersion>8</javaVersion>
     </properties>
 
     <repositories>
@@ -159,6 +158,8 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
                     <configuration>
+                        <source>${javaVersion}</source>
+                        <target>${javaVersion}</target>
                         <showDeprecation>true</showDeprecation>
                         <showWarnings>true</showWarnings>
                         <compilerArgs>
@@ -235,16 +236,17 @@
                 <version>3.2.0</version>
                 <configuration>
                     <excludePackageNames>
-                        org.hyperledger.fabric.client.impl:org.hyperledger.fabric.protos.*
+                        org.hyperledger.fabric.protos.*
                     </excludePackageNames>
                     <show>public</show>
                     <doctitle>Hyperledger Fabric Gateway SDK for Java</doctitle>
                     <nohelp>true</nohelp>
-                    <failOnError>false</failOnError>
+                    <failOnError>true</failOnError>
                     <links>
                         <link>https://docs.oracle.com/javase/8/docs/api/</link>
                     </links>
-                    <source>8</source>
+                    <source>${javaVersion}</source>
+                    <detectJavaApiLink>false</detectJavaApiLink>
                 </configuration>
                 <executions>
                     <execution>
@@ -258,7 +260,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>3.1.2</version>
                 <configuration>
                     <configLocation>checkstyle.xml</configLocation>
                     <encoding>UTF-8</encoding>
@@ -275,6 +277,13 @@
                         </goals>
                     </execution>
                 </executions>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.puppycrawl.tools</groupId>
+                        <artifactId>checkstyle</artifactId>
+                        <version>8.41.1</version>
+                    </dependency>
+                </dependencies>
             </plugin>
             <plugin>
                 <groupId>org.xolstice.maven.plugins</groupId>

--- a/java/src/main/java/org/hyperledger/fabric/client/Contract.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Contract.java
@@ -19,9 +19,9 @@ import com.google.protobuf.InvalidProtocolBufferException;
  * <p>The Contract allows applications to:</p>
  * <ul>
  *     <li>Evaluate transactions that query state from the ledger using {@link #evaluateTransaction(String, String...)}
- *     or {@link #evaluateTransaction(String, byte[]...)}.</li>
+ *     or {@link #evaluateTransaction(String, byte[][]) evaluateTransaction(String, byte[]...)}.</li>
  *     <li>Submit transactions that store state to the ledger using {@link #submitTransaction(String, String...)} or
- *     {@link #submitTransaction(String, byte[]...)}.</li>
+ *     {@link #submitTransaction(String, byte[][]) submitTransaction(String, byte[]...)}.</li>
  * </ul>
  *
  * For more complex transaction invocations, such as including transient data, the transaction proposal can be built

--- a/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
@@ -113,6 +113,6 @@ public interface Gateway extends AutoCloseable {
          * Connects to the gateway using the specified options.
          * @return The connected {@link Gateway} object.
          */
-        Gateway connect() throws Exception;
+        Gateway connect();
     }
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayImpl.java
@@ -49,7 +49,7 @@ final class GatewayImpl implements Gateway {
         }
 
         @Override
-        public GatewayImpl connect() throws Exception {
+        public GatewayImpl connect() {
             if (this.client == null) {
                 throw new IllegalStateException("No gRPC channel has been provided");
             }

--- a/java/src/main/java/org/hyperledger/fabric/client/identity/Signer.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/identity/Signer.java
@@ -18,6 +18,7 @@ public interface Signer {
      * Signs the supplied message digest. The digest is typically a hash of the message.
      * @param digest A message digest.
      * @return A digital signature.
+     * @throws GeneralSecurityException if a signing error occurs.
      */
     byte[] sign(byte[] digest) throws GeneralSecurityException;
 }


### PR DESCRIPTION
- Added some missing elements
- Workaround to bug in Java 8 JavaDoc linking to varargs methods
- Avoid Java 11 Javadoc warning of unnamed modules in Java 8 code
- Update checkstyle version