### PR TITLE
Fix sample-network target in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ staticcheck:
 	staticcheck $(base_dir)/pkg/... $(scenario_dir)/go
 
 sample-network: pull-latest-peer vendor-chaincode
-	cd $(scenario_dir)/go; GATEWAY_NO_SHUTDOWN=TRUE godog $(scenario_dir)/features/basic.feature
+	cd $(scenario_dir)/go; GATEWAY_NO_SHUTDOWN=TRUE godog $(scenario_dir)/features/transactions.feature
 
 generate:
 	go generate ./pkg/...


### PR DESCRIPTION
Removing the basic.feature file broke the makefile target for preparing the sample network.
Changed to use transaction.feature instead.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>