### PR TITLE
Close gRPC channels in Java NetworkTest unit test

### DIFF
--- a/java/src/test/java/org/hyperledger/fabric/client/GatewayTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/GatewayTest.java
@@ -46,9 +46,7 @@ public final class GatewayTest {
         if (gateway != null) {
             gateway.close();
         }
-        if (channel != null) {
-            GatewayUtils.shutdownChannel(channel, 5, TimeUnit.SECONDS);
-        }
+        GatewayUtils.shutdownChannel(channel, 5, TimeUnit.SECONDS);
     }
 
     @Test

--- a/java/src/test/java/org/hyperledger/fabric/client/NetworkTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/NetworkTest.java
@@ -6,6 +6,8 @@
 
 package org.hyperledger.fabric.client;
 
+import java.util.concurrent.TimeUnit;
+
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
 import org.junit.jupiter.api.AfterEach;
@@ -31,6 +33,7 @@ public final class NetworkTest {
     @AfterEach
     void afterEach() {
         gateway.close();
+        GatewayUtils.shutdownChannel(channel, 5, TimeUnit.SECONDS);
     }
 
     @Test


### PR DESCRIPTION
This did not affect unit test success but produced spurious console errors.