### PR TITLE
FABGW-10 Update samples to show async submit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ go_dir := $(base_dir)/pkg
 node_dir := $(base_dir)/node
 java_dir := $(base_dir)/java
 scenario_dir := $(base_dir)/scenario
+samples_dir := $(base_dir)/samples
 
 # PEER_IMAGE_PULL is where to pull peer image from, it can be set by external env variable
 PEER_IMAGE_PULL ?= hyperledger-fabric.jfrog.io/fabric-peer:amd64-latest
@@ -69,6 +70,12 @@ staticcheck:
 
 sample-network: pull-latest-peer vendor-chaincode
 	cd $(scenario_dir)/go; GATEWAY_NO_SHUTDOWN=TRUE godog $(scenario_dir)/features/transactions.feature
+
+run-samples: sample-network
+	cd $(samples_dir)/go; go run sample.go
+	cd $(samples_dir)/node; npm install; npm run build; npm start
+	cd $(samples_dir)/java; mvn test
+	docker ps -aq | xargs docker rm -f; docker network prune --force
 
 generate:
 	go generate ./pkg/...

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -141,6 +141,17 @@ stages:
           # TODO: update this variable name in the Makefile
           JENKINS_URL: true
 
+  - job: Samples
+    pool:
+      vmImage: ubuntu-20.04
+    dependsOn: []
+    timeoutInMinutes: 60
+    steps:
+      - template: install_deps.yml
+      - checkout: self
+      - script: make run-samples
+        displayName: Run SDK samples
+
 # TODO only run on the scheduled builds (run on merge builds while debugging)
 - stage: Publish
   dependsOn: Test

--- a/samples/java/src/main/java/com/example/Sample.java
+++ b/samples/java/src/main/java/com/example/Sample.java
@@ -11,13 +11,19 @@ import java.nio.file.Paths;
 import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
 import io.grpc.Channel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import org.hyperledger.fabric.client.Contract;
 import org.hyperledger.fabric.client.Gateway;
 import org.hyperledger.fabric.client.Network;
+import org.hyperledger.fabric.client.Transaction;
 import org.hyperledger.fabric.client.identity.*;
+import org.hyperledger.fabric.protos.peer.TransactionPackage;
 
 public class Sample
 {
@@ -51,6 +57,7 @@ public class Sample
 
             String time = LocalDateTime.now().toString();
 
+            // Submit a transaction, blocking until the transaction has been committed on the ledger.
             System.out.println("Submitting transaction to basic chaincode with value " + time + "...");
             byte[] result = contract.submitTransaction("put", "time", time);
             System.out.println("Submit result = " + new String(result));
@@ -58,6 +65,25 @@ public class Sample
             System.out.println("Evaluating query...");
             result = contract.evaluateTransaction("get", "time");
             System.out.println("Query result = " + new String(result));
+
+            // Submit transaction asynchronously, allowing this thread to process the chaincode response (e.g. update a UI)
+            // without waiting for the commit notification
+            System.out.println("Submitting transaction asynchronously to basic chaincode with value " + time + "...");
+            Transaction txn = contract.newProposal("put")
+                    .addArguments("async", time)
+                    .build()
+                    .endorse();
+            Supplier<TransactionPackage.TxValidationCode> commit = txn.submitAsync();
+            System.out.println("Proposal result = " + new String(txn.getResult()));
+
+            // wait for transactions to commit before querying the value
+            TransactionPackage.TxValidationCode status = commit.get();
+            if (status != TransactionPackage.TxValidationCode.VALID) {
+                throw new Exception("Failed to commit transaction");
+            }
+            // Committed.  Check the value:
+            result = contract.evaluateTransaction("get", "async");
+            System.out.println("Transaction committed. Query result = " + new String(result));
         }
     }
 }

--- a/samples/node/package.json
+++ b/samples/node/package.json
@@ -14,7 +14,8 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
-    "fabric-gateway": "^0.1.1-dev.20210325.1.0"
+    "fabric-gateway": "^0.1.0-dev.20210428.4",
+    "fabric-protos": "^2.2.5"
   },
   "devDependencies": {
     "@tsconfig/node12": "^1.0.7",


### PR DESCRIPTION
Add extra example code to the 3 SDK samples to show how to
submit multiple transactions without blocking the main thread, and later awaiting commit before querying the value.

Add running of samples to CI

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>