### PR TITLE
Add credentials group to CI

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -16,6 +16,7 @@ schedules:
         - main
 
 variables:
+  - group: credentials
   - group: JARSigningPublish
   - name: GATEWAY_VERSION
     value: 0.1.0


### PR DESCRIPTION
Required for GITHUB-PAT used in api docs publish

Signed-off-by: James Taylor <jamest@uk.ibm.com>