### PR TITLE
Better curve support in Node client signing implementation

### DIFF
--- a/node/src/identity/decoder.ts
+++ b/node/src/identity/decoder.ts
@@ -10,7 +10,7 @@
 import * as asn1 from 'asn1.js';
 import * as crypto from 'crypto';
 
-export function ecPrivateKeyAsRaw(privateKey: crypto.KeyObject): Buffer {
+export function ecPrivateKeyAsRaw(privateKey: crypto.KeyObject): { privateKey: Buffer, curveObjectId: number[] } {
     const ECPrivateKey = asn1.define('ECPrivateKey', function() {
         this.seq().obj(
             this.key('version').int().def(1),
@@ -21,5 +21,8 @@ export function ecPrivateKeyAsRaw(privateKey: crypto.KeyObject): Buffer {
     });
     const privateKeyPem = privateKey.export({ format: 'der', type: 'sec1' });
     const decodedDer = ECPrivateKey.decode(privateKeyPem, 'der');
-    return decodedDer.privateKey
+    return {
+        privateKey: decodedDer.privateKey,
+        curveObjectId: decodedDer.parameters,
+    };
 }

--- a/node/src/identity/signers.test.ts
+++ b/node/src/identity/signers.test.ts
@@ -8,28 +8,48 @@ import * as crypto from 'crypto';
 import { newPrivateKeySigner } from './signers';
 
 describe('signers', () => {
-    const { publicKey, privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
-
     it('throws for public key', () => {
+        const { publicKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
         expect(() => newPrivateKeySigner(publicKey))
             .toThrowError(publicKey.type);
     });
 
     it('throws for unsupported private key type', () => {
-        const { privateKey: dsaKey } = crypto.generateKeyPairSync('dsa', { modulusLength: 2048, divisorLength: 256 });
+        const { privateKey } = crypto.generateKeyPairSync('dsa', { modulusLength: 2048, divisorLength: 256 });
 
-        expect(() => newPrivateKeySigner(dsaKey))
-            .toThrowError(dsaKey.asymmetricKeyType);
+        expect(() => newPrivateKeySigner(privateKey))
+            .toThrowError(privateKey.asymmetricKeyType);
     });
 
-    it('creates valid signer for EC private key', async () => {
-        const message = Buffer.from('conga');
+    describe('EC', () => {
+        it('creates valid signer for P-256 private key', async () => {
+            const { publicKey, privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-256' });
+            const message = Buffer.from('conga');
 
-        const signer = newPrivateKeySigner(privateKey);
-        const digest = crypto.createHash('sha256').update(message).digest();
-        const signature = await signer(digest);
-        const valid = crypto.verify('sha256', message, publicKey, signature);
+            const signer = newPrivateKeySigner(privateKey);
+            const digest = crypto.createHash('sha256').update(message).digest();
+            const signature = await signer(digest);
+            const valid = crypto.verify('sha256', message, publicKey, signature);
 
-        expect(valid).toBeTruthy();
+            expect(valid).toBeTruthy();
+        });
+
+        it('creates valid signer for P-384 private key', async () => {
+            const { publicKey, privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'P-384' });
+            const message = Buffer.from('conga');
+
+            const signer = newPrivateKeySigner(privateKey);
+            const digest = crypto.createHash('sha256').update(message).digest();
+            const signature = await signer(digest);
+            const valid = crypto.verify('sha256', message, publicKey, signature);
+
+            expect(valid).toBeTruthy();
+        });
+
+        it('throws for unsupported curve', () => {
+            const { privateKey } = crypto.generateKeyPairSync('ec', { namedCurve: 'secp256k1' });
+            expect(() => newPrivateKeySigner(privateKey))
+                .toThrowError('1.3.132.0.10');
+        });
     });
 });


### PR DESCRIPTION
Use the parameters (namedCurve) Object Identifier from the elliptic curve private key to pick the correct curve from a set of supported key types, instead of always using the P-256 curve.