### PR TITLE
Simplify creation of MockGatewayClient

### DIFF
--- a/pkg/client/evaluate_test.go
+++ b/pkg/client/evaluate_test.go
@@ -31,10 +31,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Returns gRPC invocation error", func(t *testing.T) {
 		expectedError := "EVALUATE_ERROR"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Return(nil, errors.New(expectedError))
 
@@ -49,10 +46,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Returns result", func(t *testing.T) {
 		expected := []byte("TRANSACTION_RESULT")
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Return(newEvaluateResponse(expected), nil)
 
@@ -70,10 +64,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Includes channel name in proposal", func(t *testing.T) {
 		var actual string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				actual = test.AssertUnmarshallChannelheader(t, in.ProposedTransaction).ChannelId
@@ -96,10 +87,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Includes chaincode ID in proposal", func(t *testing.T) {
 		var actual string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				actual = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.ChaincodeId.Name
@@ -122,10 +110,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Includes transaction name in proposal for default smart contract", func(t *testing.T) {
 		var args [][]byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				args = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.Input.Args
@@ -149,10 +134,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Includes transaction name in proposal for named smart contract", func(t *testing.T) {
 		var args [][]byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				args = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.Input.Args
@@ -176,10 +158,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Includes arguments in proposal", func(t *testing.T) {
 		var args [][]byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				args = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.Input.Args
@@ -203,10 +182,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Includes channel name in proposed transaction", func(t *testing.T) {
 		var actual string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				actual = in.ChannelId
@@ -230,10 +206,7 @@ func TestEvaluateTransaction(t *testing.T) {
 	t.Run("Includes transaction ID in proposed transaction", func(t *testing.T) {
 		var actual string
 		var expected string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				actual = in.TransactionId
@@ -260,10 +233,7 @@ func TestEvaluateTransaction(t *testing.T) {
 		sign := func(digest []byte) ([]byte, error) {
 			return expected, nil
 		}
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest) {
 				actual = in.ProposedTransaction.Signature
@@ -293,10 +263,7 @@ func TestEvaluateTransaction(t *testing.T) {
 		hash := func(message []byte) []byte {
 			return expected
 		}
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Return(newEvaluateResponse(nil), nil)
 

--- a/pkg/client/gateway_test.go
+++ b/pkg/client/gateway_test.go
@@ -93,10 +93,7 @@ func TestGateway(t *testing.T) {
 
 	t.Run("GetNetwork returns correctly named Network", func(t *testing.T) {
 		networkName := "network"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		gateway := AssertNewTestGateway(t, WithClient(mockClient))
 
 		network := gateway.GetNetwork(networkName)
@@ -110,10 +107,7 @@ func TestGateway(t *testing.T) {
 	})
 
 	t.Run("Identity returns connecting identity", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		gateway := AssertNewTestGateway(t, WithIdentity(id), WithClient(mockClient))
 
 		result := gateway.Identity()

--- a/pkg/client/identity_test.go
+++ b/pkg/client/identity_test.go
@@ -49,10 +49,7 @@ func TestIdentity(t *testing.T) {
 
 	t.Run("Evaluate uses client identity for proposals", func(t *testing.T) {
 		var actual []byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		evaluateResponse := gateway.EvaluateResponse{
 			Result: &peer.Response{
 				Payload: nil,
@@ -78,10 +75,7 @@ func TestIdentity(t *testing.T) {
 
 	t.Run("Submit uses client identity for proposals", func(t *testing.T) {
 		var actual []byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		endorseResponse := gateway.EndorseResponse{
 			PreparedTransaction: &common.Envelope{},
 			Result: &peer.Response{

--- a/pkg/client/network_test.go
+++ b/pkg/client/network_test.go
@@ -20,10 +20,7 @@ func AssertNewTestNetwork(t *testing.T, networkName string, options ...ConnectOp
 func TestNetwork(t *testing.T) {
 	t.Run("GetContract returns correctly named Contract", func(t *testing.T) {
 		chaincodeID := "chaincode"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		network := AssertNewTestNetwork(t, "network", WithClient(mockClient))
 
 		contract := network.GetContract(chaincodeID)
@@ -42,10 +39,7 @@ func TestNetwork(t *testing.T) {
 	t.Run("GetContractWithName returns correctly named Contract", func(t *testing.T) {
 		chaincodeID := "chaincode"
 		contractName := "contract"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		network := AssertNewTestNetwork(t, "network", WithClient(mockClient))
 
 		contract := network.GetContractWithName(chaincodeID, contractName)

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -55,10 +55,7 @@ func TestOfflineSign(t *testing.T) {
 
 	t.Run("Evaluate", func(t *testing.T) {
 		t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 				Return(&evaluateResponse, nil).
 				AnyTimes()
@@ -78,10 +75,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Uses off-line signature", func(t *testing.T) {
 			expected := []byte("SIGNATURE")
 			var actual []byte
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 				Do(func(_ context.Context, in *gateway.EvaluateRequest, _ ...grpc.CallOption) {
 					actual = in.ProposedTransaction.Signature
@@ -118,10 +112,7 @@ func TestOfflineSign(t *testing.T) {
 
 	t.Run("Endorse", func(t *testing.T) {
 		t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Return(newEndorseResponse("result"), nil).
 				AnyTimes()
@@ -141,10 +132,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Uses off-line signature", func(t *testing.T) {
 			expected := []byte("SIGNATURE")
 			var actual []byte
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Do(func(_ context.Context, in *gateway.EndorseRequest, _ ...grpc.CallOption) {
 					actual = in.ProposedTransaction.Signature
@@ -182,10 +170,7 @@ func TestOfflineSign(t *testing.T) {
 			var actual []string
 			expected := []string{"MY_ORG"}
 
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Do(func(_ context.Context, in *gateway.EndorseRequest, _ ...grpc.CallOption) {
 					actual = in.EndorsingOrganizations
@@ -222,10 +207,7 @@ func TestOfflineSign(t *testing.T) {
 
 	t.Run("Submit", func(t *testing.T) {
 		t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Return(newEndorseResponse("result"), nil).
 				AnyTimes()
@@ -263,10 +245,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Uses off-line signature", func(t *testing.T) {
 			expected := []byte("SIGNATURE")
 			var actual []byte
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Return(newEndorseResponse("result"), nil)
 			mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -320,10 +299,7 @@ func TestOfflineSign(t *testing.T) {
 
 	t.Run("Commit", func(t *testing.T) {
 		t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Return(newEndorseResponse("result"), nil).
 				AnyTimes()
@@ -379,10 +355,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Uses off-line signature", func(t *testing.T) {
 			expected := []byte("SIGNATURE")
 			var actual []byte
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Return(newEndorseResponse("result"), nil)
 			mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -455,10 +428,7 @@ func TestOfflineSign(t *testing.T) {
 
 	t.Run("Serialization", func(t *testing.T) {
 		t.Run("Proposal keeps same digest", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
@@ -485,10 +455,7 @@ func TestOfflineSign(t *testing.T) {
 		})
 
 		t.Run("Proposal keeps same transaction ID", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
@@ -515,10 +482,7 @@ func TestOfflineSign(t *testing.T) {
 		})
 
 		t.Run("Transaction keeps same digest", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Return(newEndorseResponse("result"), nil).
 				Times(1)
@@ -564,10 +528,7 @@ func TestOfflineSign(t *testing.T) {
 		})
 
 		t.Run("Commit keeps same digest", func(t *testing.T) {
-			mockController := gomock.NewController(t)
-			defer mockController.Finish()
-
-			mockClient := NewMockGatewayClient(mockController)
+			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 				Return(newEndorseResponse("result"), nil).
 				Times(1)

--- a/pkg/client/sign_test.go
+++ b/pkg/client/sign_test.go
@@ -42,10 +42,7 @@ func TestSign(t *testing.T) {
 			return expected, nil
 		}
 		var actual []byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EvaluateRequest, _ ...grpc.CallOption) {
 				actual = in.ProposedTransaction.Signature
@@ -70,10 +67,7 @@ func TestSign(t *testing.T) {
 			return expected, nil
 		}
 		var actual []byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest, _ ...grpc.CallOption) {
 				actual = in.ProposedTransaction.Signature
@@ -102,10 +96,7 @@ func TestSign(t *testing.T) {
 			return expected, nil
 		}
 		var actual []byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(&endorseResponse, nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -129,10 +120,7 @@ func TestSign(t *testing.T) {
 	})
 
 	t.Run("Default error implementation is used if no signing implementation supplied", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
 			Return(&evaluateResponse, nil).
 			AnyTimes()

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -39,10 +39,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Returns endorsement error", func(t *testing.T) {
 		expectedError := "ENDORSE_ERROR"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(nil, errors.New(expectedError))
 
@@ -57,10 +54,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Returns error sending to orderer", func(t *testing.T) {
 		expectedError := "SUBMIT_ERROR"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -77,10 +71,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Returns commit error", func(t *testing.T) {
 		expectedError := "COMMIT_ERROR"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -97,10 +88,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Returns result for committed transaction", func(t *testing.T) {
 		expected := []byte("TRANSACTION_RESULT")
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -122,10 +110,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Returns error with status code for commit failure", func(t *testing.T) {
 		expectedError := peer.TxValidationCode_name[int32(peer.TxValidationCode_MVCC_READ_CONFLICT)]
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -144,10 +129,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Returns error with details on communication failure getting transaction commit status", func(t *testing.T) {
 		expectedError := "COMMIT_STATUS_ERROR"
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -166,10 +148,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Includes channel name in proposal", func(t *testing.T) {
 		var actual string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				actual = test.AssertUnmarshallChannelheader(t, in.ProposedTransaction).ChannelId
@@ -196,10 +175,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Includes chaincode ID in proposal", func(t *testing.T) {
 		var actual string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				actual = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.ChaincodeId.Name
@@ -226,10 +202,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Includes transaction name in proposal for default contract", func(t *testing.T) {
 		var args [][]byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				args = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.Input.Args
@@ -257,10 +230,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Includes transaction name in proposal for named contract", func(t *testing.T) {
 		var args [][]byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				args = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.Input.Args
@@ -288,10 +258,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Includes arguments in proposal", func(t *testing.T) {
 		var args [][]byte
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				args = test.AssertUnmarshallInvocationSpec(t, in.ProposedTransaction).ChaincodeSpec.Input.Args
@@ -319,10 +286,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Includes channel name in proposed transaction", func(t *testing.T) {
 		var actual string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				actual = in.ChannelId
@@ -350,10 +314,7 @@ func TestSubmitTransaction(t *testing.T) {
 	t.Run("Includes transaction ID in proposed transaction", func(t *testing.T) {
 		var actual string
 		var expected string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				actual = in.TransactionId
@@ -380,10 +341,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 	t.Run("Includes channel name in commit status request", func(t *testing.T) {
 		var actual string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -413,10 +371,7 @@ func TestSubmitTransaction(t *testing.T) {
 	t.Run("Includes transaction ID in commit status request", func(t *testing.T) {
 		var actual string
 		var expected string
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				expected = test.AssertUnmarshallChannelheader(t, in.ProposedTransaction).TxId
@@ -451,10 +406,7 @@ func TestSubmitTransaction(t *testing.T) {
 		sign := func(digest []byte) ([]byte, error) {
 			return expected, nil
 		}
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				actual = in.ProposedTransaction.Signature
@@ -484,10 +436,7 @@ func TestSubmitTransaction(t *testing.T) {
 		sign := func(digest []byte) ([]byte, error) {
 			return expected, nil
 		}
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -516,10 +465,7 @@ func TestSubmitTransaction(t *testing.T) {
 		expectedOrgs := []string{"MY_ORG"}
 		var actualPrice []byte
 		expectedPrice := []byte("3000")
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest) {
 				actualOrgs = in.EndorsingOrganizations
@@ -559,10 +505,7 @@ func TestSubmitTransaction(t *testing.T) {
 		sign := func(digest []byte) ([]byte, error) {
 			return expected, nil
 		}
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -596,10 +539,7 @@ func TestSubmitTransaction(t *testing.T) {
 		hash := func(message []byte) []byte {
 			return expected
 		}
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -625,10 +565,7 @@ func TestSubmitTransaction(t *testing.T) {
 	})
 
 	t.Run("Commit returns transaction status", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -654,10 +591,7 @@ func TestSubmitTransaction(t *testing.T) {
 	})
 
 	t.Run("Commit returns successful for successful transaction", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
@@ -683,10 +617,7 @@ func TestSubmitTransaction(t *testing.T) {
 	})
 
 	t.Run("Commit returns unsuccessful for failed transaction", func(t *testing.T) {
-		mockController := gomock.NewController(t)
-		defer mockController.Finish()
-
-		mockClient := NewMockGatewayClient(mockController)
+		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
Go v1.14+ with Mockgen v1.5.0+ no longer requires test code to explicitly call Finish() on the mock controller to assert expectations on the mock.