### PR TITLE
FABGW-20 EndorsingOrganizations for evaluate()

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
@@ -52,6 +52,7 @@ final class ProposalImpl implements Proposal {
                 .setTransactionId(proposedTransaction.getTransactionId())
                 .setChannelId(channelName)
                 .setProposedTransaction(proposedTransaction.getProposal())
+                .addAllTargetOrganizations(proposedTransaction.getEndorsingOrganizationsList())
                 .build();
         return client.evaluate(evaluateRequest)
                 .getResult()

--- a/node/src/proposal.test.ts
+++ b/node/src/proposal.test.ts
@@ -189,6 +189,12 @@ describe('Proposal', () => {
             expect(argStrings.slice(1)).toStrictEqual(expected);
         });
 
+        it('sets endorsing orgs', async () => {
+            await contract.evaluate('TRANSACTION_NAME', { endorsingOrganizations: ['org1']});
+            const actualOrgs = client.evaluate.mock.calls[0][0].target_organizations;
+            expect(actualOrgs).toStrictEqual(['org1']);
+        });
+
         it('uses signer', async () => {
             signer.mockResolvedValue(Buffer.from('MY_SIGNATURE'));
 

--- a/node/src/proposal.ts
+++ b/node/src/proposal.ts
@@ -134,6 +134,7 @@ export class ProposalImpl implements Proposal {
             transaction_id: this.#proposedTransaction.transaction_id,
             channel_id: this.#channelName,
             proposed_transaction: this.#proposal,
+            target_organizations: this.#proposedTransaction.endorsing_organizations,
         };
     }
 

--- a/pkg/client/proposal.go
+++ b/pkg/client/proposal.go
@@ -90,6 +90,7 @@ func (proposal *Proposal) Evaluate() ([]byte, error) {
 		TransactionId:       proposal.proposedTransaction.TransactionId,
 		ChannelId:           proposal.channelID,
 		ProposedTransaction: proposal.proposedTransaction.Proposal,
+		TargetOrganizations: proposal.proposedTransaction.EndorsingOrganizations,
 	}
 	response, err := proposal.client.Evaluate(ctx, evaluateRequest)
 	if err != nil {

--- a/scenario/features/privatedata.feature
+++ b/scenario/features/privatedata.feature
@@ -40,3 +40,15 @@ Feature: Private data
         And I invoke the transaction
         Then the response should be "success"
 
+    Scenario: Evaluate on org1
+        When I prepare to evaluate a getPeerOrg transaction
+        And I set the endorsing organizations to ["Org1MSP"]
+        And I invoke the transaction
+        Then the response should be "Org1MSP"
+
+    Scenario: Evaluate on org2
+        When I prepare to evaluate a getPeerOrg transaction
+        And I set the endorsing organizations to ["Org2MSP"]
+        And I invoke the transaction
+        Then the response should be "Org2MSP"
+


### PR DESCRIPTION
Add SDK support for setting the orgs that are allowed to be invoked by the evaluate() method.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>