### PR TITLE
Refactor Go scenario tests

### DIFF
--- a/scenario/go/connection_test.go
+++ b/scenario/go/connection_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scenario
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/hyperledger/fabric-gateway/pkg/client"
+	"github.com/hyperledger/fabric-gateway/pkg/identity"
+	"google.golang.org/grpc"
+)
+
+func NewGatewayConnection(user string, mspID string) (*GatewayConnection, error) {
+	id, err := newIdentity(mspID, certificatePath(user, mspID))
+	if err != nil {
+		return nil, err
+	}
+
+	connection := GatewayConnection{
+		id: id,
+	}
+	return &connection, nil
+}
+
+func NewGatewayConnectionWithSigner(user string, mspID string) (*GatewayConnection, error) {
+	connection, err := NewGatewayConnection(user, mspID)
+	if err != nil {
+		return nil, err
+	}
+
+	sign, err := NewSign(PrivateKeyPath(user, mspID))
+	if err != nil {
+		return nil, err
+	}
+
+	connection.AddOptions(client.WithSign(sign))
+
+	return connection, nil
+}
+
+func newIdentity(mspID string, certPath string) (*identity.X509Identity, error) {
+	certificatePEM, err := ioutil.ReadFile(certPath)
+	if err != nil {
+		return nil, err
+	}
+
+	certificate, err := identity.CertificateFromPEM(certificatePEM)
+	if err != nil {
+		return nil, err
+	}
+
+	return identity.NewX509Identity(mspID, certificate)
+}
+
+func NewSign(keyPath string) (identity.Sign, error) {
+	privateKeyPEM, err := ioutil.ReadFile(keyPath)
+	if err != nil {
+		return nil, err
+	}
+
+	privateKey, err := identity.PrivateKeyFromPEM(privateKeyPEM)
+	if err != nil {
+		return nil, err
+	}
+
+	return identity.NewPrivateKeySign(privateKey)
+}
+func certificatePath(user string, mspID string) string {
+	org := GetOrgForMSP(mspID)
+	return credentialsDirectory(user, org) + "/signcerts/" + user + "@" + org + "-cert.pem"
+}
+
+func PrivateKeyPath(user string, mspID string) string {
+	return credentialsDirectory(user, GetOrgForMSP(mspID)) + "/keystore/key.pem"
+}
+
+func credentialsDirectory(user string, org string) string {
+	return fixturesDir + "/crypto-material/crypto-config/peerOrganizations/" + org + "/users/" +
+		user + "@" + org + "/msp"
+}
+
+type GatewayConnection struct {
+	id         identity.Identity
+	options    []client.ConnectOption
+	grpcClient *grpc.ClientConn
+	gateway    *client.Gateway
+	network    *client.Network
+	contract   *client.Contract
+}
+
+func (connection *GatewayConnection) AddOptions(options ...client.ConnectOption) {
+	connection.options = append(connection.options, options...)
+}
+
+func (connection *GatewayConnection) Connect(grpcClient *grpc.ClientConn) error {
+	options := make([]client.ConnectOption, 0, len(connection.options)+1)
+	options = append(options, connection.options...)
+	options = append(options, client.WithClientConnection(grpcClient))
+
+	gateway, err := client.Connect(connection.id, options...)
+	if err != nil {
+		grpcClient.Close()
+		return err
+	}
+
+	connection.grpcClient = grpcClient
+	connection.gateway = gateway
+	return nil
+}
+
+func (connection *GatewayConnection) UseContract(contractName string) error {
+	if connection.network == nil {
+		return fmt.Errorf("no network selected")
+	}
+
+	connection.contract = connection.network.GetContract(contractName)
+	return nil
+}
+
+func (connection *GatewayConnection) UseNetwork(channelName string) error {
+	if connection.gateway == nil {
+		return fmt.Errorf("gateway not connected")
+	}
+
+	connection.network = connection.gateway.GetNetwork(channelName)
+	return nil
+}
+
+func (connection *GatewayConnection) PrepareTransaction(txnType TransactionType, name string) (*Transaction, error) {
+	if connection.network == nil {
+		return nil, fmt.Errorf("no network selected")
+	}
+	if connection.contract == nil {
+		return nil, fmt.Errorf("no contract selected")
+	}
+
+	return NewTransaction(connection.network, connection.contract, txnType, name), nil
+}
+
+func (connection *GatewayConnection) Close() {
+	if connection.gateway != nil {
+		connection.gateway.Close()
+	}
+	if connection.grpcClient != nil {
+		connection.grpcClient.Close()
+	}
+}

--- a/scenario/go/transaction_test.go
+++ b/scenario/go/transaction_test.go
@@ -1,0 +1,195 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package scenario
+
+import (
+	"fmt"
+
+	"github.com/hyperledger/fabric-gateway/pkg/client"
+	"github.com/hyperledger/fabric-gateway/pkg/identity"
+	"github.com/hyperledger/fabric-protos-go/peer"
+)
+
+type Transaction struct {
+	network     *client.Network
+	contract    *client.Contract
+	txType      TransactionType
+	name        string
+	options     []client.ProposalOption
+	offlineSign identity.Sign
+	result      []byte
+}
+
+func NewTransaction(network *client.Network, contract *client.Contract, txType TransactionType, name string) *Transaction {
+	return &Transaction{
+		network:  network,
+		contract: contract,
+		txType:   txType,
+		name:     name,
+	}
+}
+
+func (transaction *Transaction) AddOptions(options ...client.ProposalOption) {
+	transaction.options = append(transaction.options, options...)
+}
+
+func (transaction *Transaction) Invoke() error {
+	var result []byte
+	var err error
+
+	switch transaction.txType {
+	case Submit:
+		result, err = transaction.submit()
+	case Evaluate:
+		result, err = transaction.evaluate()
+	default:
+		panic(fmt.Errorf("unknown transaction type: %v", transaction.txType))
+	}
+
+	transaction.result = result
+	return err
+}
+
+func (transaction *Transaction) SetOfflineSign(sign identity.Sign) {
+	transaction.offlineSign = sign
+}
+
+func (transaction *Transaction) Result() []byte {
+	return transaction.result
+}
+
+func (transaction *Transaction) evaluate() ([]byte, error) {
+	proposal, err := transaction.contract.NewProposal(transaction.name, transaction.options...)
+	if err != nil {
+		return nil, err
+	}
+
+	proposal, err = transaction.offlineSignProposal(proposal)
+	if err != nil {
+		return nil, err
+	}
+
+	return proposal.Evaluate()
+}
+
+func (transaction *Transaction) submit() ([]byte, error) {
+	proposal, err := transaction.contract.NewProposal(transaction.name, transaction.options...)
+	if err != nil {
+		return nil, err
+	}
+
+	proposal, err = transaction.offlineSignProposal(proposal)
+	if err != nil {
+		return nil, err
+	}
+
+	unsignedTransaction, err := proposal.Endorse()
+	if err != nil {
+		return nil, err
+	}
+
+	signedTransaction, err := transaction.offlineSignTransaction(unsignedTransaction)
+	if err != nil {
+		return nil, err
+	}
+
+	result := signedTransaction.Result()
+
+	unsignedCommit, err := signedTransaction.Submit()
+	if err != nil {
+		return result, err
+	}
+
+	signedCommit, err := transaction.offlineSignCommit(unsignedCommit)
+	if err != nil {
+		return result, err
+	}
+
+	status, err := signedCommit.Status()
+	if err != nil {
+		return result, err
+	}
+	if status != peer.TxValidationCode_VALID {
+		return result, fmt.Errorf("commit failed with status %v (%v)", status, peer.TxValidationCode_name[int32(status)])
+	}
+
+	return result, nil
+}
+
+func (transaction *Transaction) offlineSignProposal(proposal *client.Proposal) (*client.Proposal, error) {
+	if nil == transaction.offlineSign {
+		return proposal, nil
+	}
+
+	bytes, signature, err := transaction.bytesAndSignature(proposal)
+	if err != nil {
+		return nil, err
+	}
+
+	proposal, err = transaction.contract.NewSignedProposal(bytes, signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return proposal, nil
+}
+
+func (transaction *Transaction) offlineSignTransaction(clientTransaction *client.Transaction) (*client.Transaction, error) {
+	if nil == transaction.offlineSign {
+		return clientTransaction, nil
+	}
+
+	bytes, signature, err := transaction.bytesAndSignature(clientTransaction)
+	if err != nil {
+		return nil, err
+	}
+
+	clientTransaction, err = transaction.contract.NewSignedTransaction(bytes, signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return clientTransaction, nil
+}
+
+func (transaction *Transaction) offlineSignCommit(commit *client.Commit) (*client.Commit, error) {
+	if nil == transaction.offlineSign {
+		return commit, nil
+	}
+
+	bytes, signature, err := transaction.bytesAndSignature(commit)
+	if err != nil {
+		return nil, err
+	}
+
+	commit, err = transaction.network.NewSignedCommit(bytes, signature)
+	if err != nil {
+		return nil, err
+	}
+
+	return commit, nil
+}
+
+type Signable interface {
+	Digest() []byte
+	Bytes() ([]byte, error)
+}
+
+func (transaction *Transaction) bytesAndSignature(signable Signable) ([]byte, []byte, error) {
+	digest := signable.Digest()
+	bytes, err := signable.Bytes()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	signature, err := transaction.offlineSign(digest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return bytes, signature, nil
+}


### PR DESCRIPTION
- Split units of functionality into different files for clarity.
- Better abstraction of Gateway connection and transaction invocation.
- Correctly initialise and clean up state before and after scenarios, including closing gRPC connections.
