### PR TITLE
Fix TypeScript error in Node scenario tests

### DIFF
--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -15,18 +15,19 @@
     "author": "",
     "license": "Apache-2.0",
     "dependencies": {
-        "@cucumber/cucumber": "^7.0.0",
-        "@tsconfig/node12": "^1.0.7",
-        "cucumber-console-formatter": "^1.0.0",
-        "expect": "^26.6.2",
-        "fabric-gateway": "file:../../node/fabric-gateway-dev.tgz",
-        "npm-run-all": "^4.1.5",
-        "typescript": "^4.1.3",
-        "ts-node": "^9.1.1"
+        "fabric-gateway": "file:../../node/fabric-gateway-dev.tgz"
     },
     "devDependencies": {
+        "@cucumber/cucumber": "^7.0.0",
+        "@tsconfig/node12": "^1.0.7",
+        "@types/node": "^12.20.16",
         "@typescript-eslint/eslint-plugin": "^4.14.0",
         "@typescript-eslint/parser": "^4.14.0",
-        "eslint": "^7.18.0"
+        "cucumber-console-formatter": "^1.0.0",
+        "eslint": "^7.18.0",
+        "expect": "^27.0.6",
+        "npm-run-all": "^4.1.5",
+        "ts-node": "^10.1.0",
+        "typescript": "^4.1.3"
     }
 }

--- a/scenario/node/src/fabric.ts
+++ b/scenario/node/src/fabric.ts
@@ -69,7 +69,7 @@ function dockerCommandWithTLS(...args: string[]): string {
 }
 
 async function sleep(ms: number): Promise<void> {
-    await new Promise(resolve => setTimeout(resolve, ms));
+    await new Promise<void>(resolve => setTimeout(resolve, ms));
 }
 
 export class Fabric {


### PR DESCRIPTION
Error introduced by a dependency update. More explicitly declaring a Promise generic type to avoid issues.

Also explicitly depend on a version of @types/node to avoid transient dependencies on potentially breaking newer versions.