### PR TITLE
Update repository ID in Java pom.xml

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -42,7 +42,7 @@
 
     <repositories>
         <repository>
-            <id>nightly-repo</id>
+            <id>maven-artifactory</id>
             <url>https://hyperledger-fabric.jfrog.io/artifactory/fabric-maven</url>
             <releases>
                 <enabled>true</enabled>
@@ -323,7 +323,7 @@
 
     <distributionManagement>
         <repository>
-            <id>fabric-maven</id>
+            <id>maven-artifactory</id>
             <name>Hyperledger Artifactory Repository</name>
             <url>https://hyperledger-fabric.jfrog.io/artifactory/fabric-maven</url>
         </repository>


### PR DESCRIPTION
Java publish is broken due to a 401 error

Attempting to fix by changing the id to match the maven service connection ID…

“You should set the repositories in your project's pom.xml to have the same <id> as the name specified in the task for Maven to be able to correctly authenticate the task.”

https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/maven-authenticate?view=azure-devops
Signed-off-by: James Taylor <jamest@uk.ibm.com>