### PR TITLE
Update repository ID in Java pom.xml

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -42,7 +42,7 @@
 
     <repositories>
         <repository>
-            <id>maven-artifactory</id>
+            <id>fabric-maven</id>
             <url>https://hyperledger-fabric.jfrog.io/artifactory/fabric-maven</url>
             <releases>
                 <enabled>true</enabled>
@@ -323,7 +323,7 @@
 
     <distributionManagement>
         <repository>
-            <id>maven-artifactory</id>
+            <id>fabric-maven</id>
             <name>Hyperledger Artifactory Repository</name>
             <url>https://hyperledger-fabric.jfrog.io/artifactory/fabric-maven</url>
         </repository>


### PR DESCRIPTION
maven-artifactory didn’t fix the 401 problem so reverting to maven-artifactory which
was the ID for the last successful publish.

Signed-off-by: James Taylor <jamest@uk.ibm.com>