### PR TITLE
Fix bad unit test for CommitStatus error in Go client

### DIFF
--- a/pkg/client/commit.go
+++ b/pkg/client/commit.go
@@ -103,7 +103,7 @@ func (commit *Commit) commitStatus() (*gateway.CommitStatusResponse, error) {
 
 		response, err := commit.client.CommitStatus(ctx, commit.signedRequest)
 		if err != nil {
-			return nil, fmt.Errorf("failed to obtain transaction commit status: %w", err)
+			return nil, err
 		}
 
 		commit.response = response

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -77,6 +77,8 @@ func TestSubmitTransaction(t *testing.T) {
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Return(newEndorseResponse("TRANSACTION_RESULT"), nil)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
+			Return(nil, nil)
+		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
 			Return(nil, expected)
 
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))


### PR DESCRIPTION
The error handling is also wrong and wasn't picked up because of the bad unit test.

Resolves #158