### PR TITLE
Remove references to tech preview

### DIFF
--- a/hsm-samples/README.md
+++ b/hsm-samples/README.md
@@ -3,29 +3,19 @@
 The samples in this repo show how to create client applications that invoke transactions with HSM Identities using the
 new embedded Gateway in Fabric.
 
-The samples will only run against the latest version of Fabric - v2.4.0-alpha.  The easiest way of setting up a gateway
+The samples will only run against Fabric v2.4 and higher.  The easiest way of setting up a gateway
 enabled Fabric network is to use the scenario test framework that is part of this `fabric-gateway` repository using the
 following command:
 
 ```
-export PEER_IMAGE_PULL=hyperledger/fabric-peer:2.4.0-alpha
+export PEER_IMAGE_PULL=hyperledger/fabric-peer:2.4.0-beta
 make sample-network
 ```
 
 This will create a local docker network comprising five peers across three organisations and a single ordering node.
-One of the peers (`peer0.org1.example.com`) has been configured with the gateway enabled.
 
-A simple smart contract (named `basic`) will have been instantiated on all the peers.  The source code for the smart
-contract can examined [here](https://github.com/hyperledger/fabric-gateway/blob/main/scenario/fixtures/chaincode/golang/basic/main.go).
-
-A sample client application is provided for each of the supported SDKs.
-Note that the SDKs implement the Fabric 'Gateway' programming model which has been in use since
-Fabric v1.4, but these are new implementations that target the embedded peer gateway and they share no common code with
-existing Fabric SDKs.
-
-In each of the language samples, the client application submits a transaction (`put`) to update the ledger followed by
-evaluating a transaction (`get`) to retrieve the value from the ledger (query).
-The value that is being updated and retrieved is the current timestamp to demonstrate that the update is working.
+Sample client applications are available to demonstrate the features of the Fabric Gateway and associated SDKs using this network.
+More details of the samples can be found on the [samples page](https://github.com/hyperledger/fabric-gateway/tree/main/samples).
 
 ## C Compilers
 

--- a/java/README.md
+++ b/java/README.md
@@ -5,7 +5,7 @@ The Fabric Gateway SDK allows applications to interact with a Fabric blockchain 
 
 The Gateway SDK implements the Fabric programming model as described in the [Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html) chapter of the Fabric documentation.
 
-## How to use 
+## How to use
 
 Samples showing how to create a client application that updates and queries the ledger
 are available for each of the supported SDK languages here:
@@ -38,5 +38,4 @@ Add the following dependency to your project's `pom.xml` file:
 
 ### Compatibility
 
-This SDK requires Fabric 2.4 Tech Preview with a Gateway enabled Peer.
-
+This SDK requires Fabric 2.4 with a Gateway enabled Peer.

--- a/node/README.md
+++ b/node/README.md
@@ -5,7 +5,7 @@ The Fabric Gateway SDK allows applications to interact with a Fabric blockchain 
 
 The Gateway SDK implements the Fabric programming model as described in the [Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html) chapter of the Fabric documentation.
 
-## How to use 
+## How to use
 
 Samples showing how to create a client application that updates and queries the ledger
 are available for each of the supported SDK languages here:
@@ -22,5 +22,4 @@ https://hyperledger.github.io/fabric-gateway/main/api/node/
 
 ### Compatibility
 
-This SDK requires Fabric 2.4 Tech Preview with a Gateway enabled Peer.
-
+This SDK requires Fabric 2.4 with a Gateway enabled Peer.

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -5,9 +5,9 @@ The Fabric Gateway SDK allows applications to interact with a Fabric blockchain 
 
 The Gateway SDK implements the Fabric programming model as described in the [Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html) chapter of the Fabric documentation.
 
-## How to use 
+## How to use
 
-Samples showing how to create a client application that updates and queries the ledger 
+Samples showing how to create a client application that updates and queries the ledger
 are available for each of the supported SDK languages here:
 https://github.com/hyperledger/fabric-gateway/tree/main/samples
 
@@ -22,5 +22,4 @@ https://pkg.go.dev/github.com/hyperledger/fabric-gateway/pkg/client
 
 ### Compatibility
 
-This SDK requires Fabric 2.4 Tech Preview with a Gateway enabled Peer.
-
+This SDK requires Fabric 2.4 with a Gateway enabled Peer.


### PR DESCRIPTION
Remove references to gateway "tech preview", as well as
references to "alpha" and "beta" where possible, since
we expect gateway to work with all Fabric v2.4 releases and later.

Also cleanup duplicate sample content in the hsm sample page.

Signed-off-by: David Enyeart <enyeart@us.ibm.com>