### PR TITLE
Simplify Java event listening

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javaVersion>8</javaVersion>
-        <grpcVersion>1.39.0</grpcVersion>
+        <grpcVersion>1.40.0</grpcVersion>
         <protobufVersion>3.17.3</protobufVersion>
     </properties>
 

--- a/java/src/test/java/scenario/GatewayContext.java
+++ b/java/src/test/java/scenario/GatewayContext.java
@@ -7,11 +7,9 @@
 package scenario;
 
 import java.util.Iterator;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.LinkedTransferQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TransferQueue;
 
+import io.grpc.ManagedChannel;
 import org.hyperledger.fabric.client.ChaincodeEvent;
 import org.hyperledger.fabric.client.Contract;
 import org.hyperledger.fabric.client.Gateway;
@@ -19,16 +17,13 @@ import org.hyperledger.fabric.client.Network;
 import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.client.identity.Signer;
 
-import io.grpc.ManagedChannel;
-
 public class GatewayContext {
     private final Gateway.Builder gatewayBuilder;
     private ManagedChannel channel;
     private Gateway gateway;
     private Network network;
     private Contract contract;
-    private TransferQueue<ChaincodeEvent> chaincodeEventQueue;
-    private CompletableFuture<Void> chaincodeEventJob;
+    private Iterator<ChaincodeEvent> eventIter;
 
     public GatewayContext(Identity identity) {
         gatewayBuilder = Gateway.newInstance()
@@ -63,33 +58,17 @@ public class GatewayContext {
     }
 
     public void listenForChaincodeEvents(String chaincodeId) {
-        cancelChaincodeEvents();
-
-        Iterator<ChaincodeEvent> eventIter = network.getChaincodeEvents(chaincodeId);
-
-        // The gRPC implementation in Java appears not to start reading events until hasNext() is first called on the
-        // Iterator so immediately start asynchronously reading from it to avoid missing events
-        chaincodeEventQueue = new LinkedTransferQueue<ChaincodeEvent>();
-        chaincodeEventJob = CompletableFuture.runAsync(() -> {
-            eventIter.forEachRemaining(event -> {
-                try {
-                    chaincodeEventQueue.transfer(event);
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        });
+        eventIter = network.getChaincodeEvents(chaincodeId);
     }
 
-    public ChaincodeEvent nextChaincodeEvent() throws InterruptedException {
-        return chaincodeEventQueue.poll(30, TimeUnit.SECONDS);
+    public ChaincodeEvent nextChaincodeEvent() {
+        return eventIter.next();
     }
 
     public void close() {
         if (gateway != null) {
             gateway.close();
         }
-        cancelChaincodeEvents();
         closeChannel();
     }
 
@@ -103,13 +82,6 @@ public class GatewayContext {
             channel.awaitTermination(5, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
             // Ignore
-        }
-    }
-
-    private void cancelChaincodeEvents() {
-        if (chaincodeEventJob != null) {
-            chaincodeEventJob.cancel(true);
-            chaincodeEventJob = null;
         }
     }
 }

--- a/java/src/test/java/scenario/ScenarioSteps.java
+++ b/java/src/test/java/scenario/ScenarioSteps.java
@@ -416,7 +416,7 @@ public class ScenarioSteps {
     }
 
     @Then("I should receive a chaincode event named {string} with payload {string}")
-    public void assertReceiveChaincodeEvent(String eventName, String payload) throws InterruptedException {
+    public void assertReceiveChaincodeEvent(String eventName, String payload) {
         ChaincodeEvent event = currentGateway.nextChaincodeEvent();
         assertThat(event.getEventName()).isEqualTo(eventName);
         assertThat(new String(event.getPayload(), StandardCharsets.UTF_8)).isEqualTo(payload);

--- a/samples/java/src/main/java/com/example/Sample.java
+++ b/samples/java/src/main/java/com/example/Sample.java
@@ -18,7 +18,6 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.time.LocalDateTime;
 import java.util.Iterator;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -240,17 +239,13 @@ public class Sample {
         Contract contract = network.getContract("basic");
 
         System.out.println("Listening for chaincode events");
-
         Iterator<ChaincodeEvent> events = network.getChaincodeEvents("basic");
-        // The Java gRPC implementation may not actually start receiving events until the first read attempt, so start
-        // reading immediately to avoid possibility of missing the chaincode event emitted by the transaction below
-        CompletableFuture<ChaincodeEvent> chaincodeEventJob = CompletableFuture.supplyAsync(() -> events.next());
 
         // Submit a transaction that generates a chaincode event
         System.out.println("Submitting \"event\" transaction with arguments:  \"my-event-name\", \"my-event-payload\"");
         contract.submitTransaction("event", "my-event-name", "my-event-payload");
 
-        ChaincodeEvent event = chaincodeEventJob.get(10, TimeUnit.SECONDS);
+        ChaincodeEvent event = events.next();
         System.out.println("Received event name: " + event.getEventName() +
                 ", payload: " + new String(event.getPayload(), StandardCharsets.UTF_8) +
                 ", txId: " + event.getTransactionId());


### PR DESCRIPTION
Perhaps a gRPC update now appears to start reading events when the event listening connection is established rather than only after the first read of the returned iterator occurs. This allows Java event listening client code to be simplified, both in scenario tests and samples.