### PR TITLE
Use testify for all assertions in Go unit tests

### DIFF
--- a/pkg/client/evaluate_test.go
+++ b/pkg/client/evaluate_test.go
@@ -7,9 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
-	"bytes"
 	"context"
-	"reflect"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -17,6 +15,7 @@ import (
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -24,9 +23,7 @@ import (
 
 func NewStatusError(t *testing.T, code codes.Code, message string, details ...proto.Message) error {
 	s, err := status.New(code, message).WithDetails(details...)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	return s.Err()
 }
@@ -50,9 +47,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		_, err := contract.EvaluateTransaction("transaction")
 
-		if err != expected {
-			t.Fatalf("Expected unmodified invocation error, got: %v", err)
-		}
+		require.Equal(t, expected, err)
 	})
 
 	t.Run("Returns result", func(t *testing.T) {
@@ -64,13 +59,9 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
 		actual, err := contract.EvaluateTransaction("transaction")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !bytes.Equal(actual, expected) {
-			t.Fatalf("Expected %s, got %s", expected, actual)
-		}
+		require.EqualValues(t, expected, actual)
 	})
 
 	t.Run("Includes channel name in proposal", func(t *testing.T) {
@@ -86,14 +77,10 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
 		_, err := contract.EvaluateTransaction("transaction")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		expected := contract.channelName
-		if actual != expected {
-			t.Fatalf("Expected %s, got %s", expected, actual)
-		}
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Includes chaincode ID in proposal", func(t *testing.T) {
@@ -109,14 +96,10 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
 		_, err := contract.EvaluateTransaction("transaction")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		expected := contract.chaincodeID
-		if actual != expected {
-			t.Fatalf("Expected %s, got %s", expected, actual)
-		}
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Includes transaction name in proposal for default smart contract", func(t *testing.T) {
@@ -133,14 +116,10 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		expected := "TRANSACTION_NAME"
 		_, err := contract.EvaluateTransaction(expected)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		actual := string(args[0])
-		if actual != expected {
-			t.Fatalf("Expected Args[0] to be %s, got Args: %s", expected, args)
-		}
+		require.Equal(t, expected, actual, "got Args: %s", args)
 	})
 
 	t.Run("Includes transaction name in proposal for named smart contract", func(t *testing.T) {
@@ -156,15 +135,11 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContractWithName(t, "chaincode", "CONTRACT_NAME", WithClient(mockClient))
 
 		_, err := contract.EvaluateTransaction("TRANSACTION_NAME")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		actual := string(args[0])
 		expected := "CONTRACT_NAME:TRANSACTION_NAME"
-		if actual != expected {
-			t.Fatalf("Expected Args[0] to be %s, got Args: %s", expected, args)
-		}
+		require.Equal(t, expected, actual, "got Args: %s", args)
 	})
 
 	t.Run("Includes arguments in proposal", func(t *testing.T) {
@@ -181,14 +156,10 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		expected := []string{"one", "two", "three"}
 		_, err := contract.EvaluateTransaction("transaction", expected...)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		actual := bytesAsStrings(args[1:])
-		if !reflect.DeepEqual(actual, expected) {
-			t.Fatalf("Expected Args[1:] to be %s, got Args: %s", expected, args)
-		}
+		require.EqualValues(t, expected, actual, "got Args: %s", args)
 	})
 
 	t.Run("Includes channel name in proposed transaction", func(t *testing.T) {
@@ -204,14 +175,10 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
 		_, err := contract.EvaluateTransaction("transaction")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		expected := contract.channelName
-		if actual != expected {
-			t.Fatalf("Expected %s, got %s", expected, actual)
-		}
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Includes transaction ID in proposed transaction", func(t *testing.T) {
@@ -229,13 +196,9 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient))
 
 		_, err := contract.EvaluateTransaction("transaction")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if actual != expected {
-			t.Fatalf("Expected %s, got %s", expected, actual)
-		}
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Uses sign", func(t *testing.T) {
@@ -255,13 +218,9 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient), WithSign(sign))
 
 		_, err := contract.EvaluateTransaction("transaction")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !bytes.Equal(actual, expected) {
-			t.Fatalf("Expected %s, got %s", expected, actual)
-		}
+		require.EqualValues(t, expected, actual)
 	})
 
 	t.Run("Uses hash", func(t *testing.T) {
@@ -281,13 +240,9 @@ func TestEvaluateTransaction(t *testing.T) {
 		contract := AssertNewTestContract(t, "chaincode", WithClient(mockClient), WithSign(sign), WithHash(hash))
 
 		_, err := contract.EvaluateTransaction("transaction")
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if !bytes.Equal(actual, expected) {
-			t.Fatalf("Expected %s, got %s", expected, actual)
-		}
+		require.EqualValues(t, expected, actual)
 	})
 
 	t.Run("Sends private data with evaluate", func(t *testing.T) {
@@ -311,16 +266,9 @@ func TestEvaluateTransaction(t *testing.T) {
 		}
 
 		_, err := contract.Evaluate("transaction", WithTransient(privateData), WithEndorsingOrganizations("MY_ORG"))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if len(actualOrgs) != 1 && expectedOrgs[0] != actualOrgs[0] {
-			t.Fatalf("Expected %v, got %v", expectedOrgs, actualOrgs)
-		}
-
-		if !bytes.Equal(actualPrice, expectedPrice) {
-			t.Fatalf("Expected %s, got %s", expectedPrice, actualPrice)
-		}
+		require.EqualValues(t, expectedOrgs, actualOrgs)
+		require.EqualValues(t, expectedPrice, actualPrice)
 	})
 }

--- a/pkg/client/network_test.go
+++ b/pkg/client/network_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 )
 
 func AssertNewTestNetwork(t *testing.T, networkName string, options ...ConnectOption) *Network {
@@ -25,15 +26,9 @@ func TestNetwork(t *testing.T) {
 
 		contract := network.GetContract(chaincodeID)
 
-		if nil == contract {
-			t.Fatal("Expected network, got nil")
-		}
-		if contract.ChaincodeID() != chaincodeID {
-			t.Fatalf("Expected a network with chaincode ID %s, got %s", chaincodeID, contract.ChaincodeID())
-		}
-		if len(contract.Name()) > 0 {
-			t.Fatalf("Expected a network with empty contract name, got %s", contract.Name())
-		}
+		require.NotNil(t, contract)
+		require.Equal(t, chaincodeID, contract.ChaincodeID(), "chaincodeID")
+		require.Equal(t, "", contract.Name(), "name")
 	})
 
 	t.Run("GetContractWithName returns correctly named Contract", func(t *testing.T) {
@@ -44,14 +39,8 @@ func TestNetwork(t *testing.T) {
 
 		contract := network.GetContractWithName(chaincodeID, contractName)
 
-		if nil == contract {
-			t.Fatal("Expected network, got nil")
-		}
-		if contract.ChaincodeID() != chaincodeID {
-			t.Fatalf("Expected a network with chaincode ID %s, got %s", chaincodeID, contract.ChaincodeID())
-		}
-		if contract.Name() != contractName {
-			t.Fatalf("Expected a network with contract name %s, got %s", contractName, contract.Name())
-		}
+		require.NotNil(t, contract)
+		require.Equal(t, chaincodeID, contract.ChaincodeID(), "chaincodeID")
+		require.Equal(t, contractName, contract.Name(), "name")
 	})
 }

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -27,9 +27,7 @@ func TestOfflineSign(t *testing.T) {
 
 	newNetworkWithNoSign := func(t *testing.T, options ...ConnectOption) *Network {
 		gateway, err := Connect(TestCredentials.identity, options...)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		return gateway.GetNetwork("network")
 	}
@@ -63,13 +61,10 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			proposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := proposal.Evaluate(); nil == err {
-				t.Fatal("Expected signing error but got nil")
-			}
+			_, err = proposal.Evaluate()
+			require.Error(t, err)
 		})
 
 		t.Run("Uses off-line signature", func(t *testing.T) {
@@ -86,27 +81,18 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := signedProposal.Evaluate(); err != nil {
-				t.Fatal(err)
-			}
+			_, err = signedProposal.Evaluate()
+			require.NoError(t, err)
 
-			if !bytes.Equal(actual, expected) {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 
 		t.Run("Uses off-line signature with endorsing orgs", func(t *testing.T) {
@@ -124,27 +110,18 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction", WithEndorsingOrganizations("MY_ORG"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := signedProposal.Evaluate(); err != nil {
-				t.Fatal(err)
-			}
+			_, err = signedProposal.Evaluate()
+			require.NoError(t, err)
 
-			if len(actual) != 1 || expected[0] != actual[0] {
-				t.Fatalf("Expected %v, got %v", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 	})
 
@@ -158,13 +135,10 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			proposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := proposal.Endorse(); nil == err {
-				t.Fatal("Expected signing error but got nil")
-			}
+			_, err = proposal.Endorse()
+			require.Error(t, err)
 		})
 
 		t.Run("Uses off-line signature", func(t *testing.T) {
@@ -181,27 +155,18 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := signedProposal.Endorse(); err != nil {
-				t.Fatal(err)
-			}
+			_, err = signedProposal.Endorse()
+			require.NoError(t, err)
 
-			if !bytes.Equal(actual, expected) {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 
 		t.Run("Uses off-line signature with endorsing orgs", func(t *testing.T) {
@@ -219,27 +184,18 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction", WithEndorsingOrganizations("MY_ORG"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := signedProposal.Endorse(); err != nil {
-				t.Fatal(err)
-			}
+			_, err = signedProposal.Endorse()
+			require.NoError(t, err)
 
-			if len(actual) != 1 && expected[0] != actual[0] {
-				t.Fatalf("Expected %v, got %v", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 	})
 
@@ -256,28 +212,19 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			transaction, err := signedProposal.Endorse()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := transaction.Submit(); nil == err {
-				t.Fatal("Expected signing error but got nil")
-			}
+			_, err = transaction.Submit()
+			require.Error(t, err)
 		})
 
 		t.Run("Uses off-line signature", func(t *testing.T) {
@@ -296,42 +243,27 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := signedTransaction.Submit(); err != nil {
-				t.Fatal(err)
-			}
+			_, err = signedTransaction.Submit()
+			require.NoError(t, err)
 
-			if !bytes.Equal(actual, expected) {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 	})
 
@@ -351,43 +283,28 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			commit, err := signedTransaction.Submit()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := commit.Status(); nil == err {
-				t.Fatal("Expected signing error but got nil")
-			}
+			_, err = commit.Status()
+			require.Error(t, err)
 		})
 
 		t.Run("Uses off-line signature", func(t *testing.T) {
@@ -410,57 +327,36 @@ func TestOfflineSign(t *testing.T) {
 			contract := network.GetContract("chaincode")
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			unsignedCommit, err := signedTransaction.Submit()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			commitBytes, err := unsignedCommit.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedCommit, err := network.NewSignedCommit(commitBytes, expected)
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
-			if _, err := signedCommit.Status(); err != nil {
-				t.Fatal(err)
-			}
+			_, err = signedCommit.Status()
+			require.NoError(t, err)
 
-			if !bytes.Equal(actual, expected) {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 	})
 
@@ -470,26 +366,18 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			expected := unsignedProposal.Digest()
 			actual := signedProposal.Digest()
 
-			if !bytes.Equal(actual, expected) {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 
 		t.Run("Proposal keeps same transaction ID", func(t *testing.T) {
@@ -497,26 +385,18 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			expected := unsignedProposal.TransactionID()
 			actual := signedProposal.TransactionID()
 
-			if actual != expected {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 
 		t.Run("Transaction keeps same digest", func(t *testing.T) {
@@ -528,41 +408,27 @@ func TestOfflineSign(t *testing.T) {
 			contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			expected := unsignedTransaction.Digest()
 			actual := signedTransaction.Digest()
 
-			if !bytes.Equal(actual, expected) {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 
 		t.Run("Commit keeps same digest", func(t *testing.T) {
@@ -578,56 +444,36 @@ func TestOfflineSign(t *testing.T) {
 			contract := network.GetContract("chaincode")
 
 			unsignedProposal, err := contract.NewProposal("transaction")
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			proposalBytes, err := unsignedProposal.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			unsignedCommit, err := signedTransaction.Submit()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			commitBytes, err := unsignedCommit.Bytes()
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			signedCommit, err := network.NewSignedCommit(commitBytes, []byte("signature"))
-			if err != nil {
-				t.Fatal(err)
-			}
+			require.NoError(t, err)
 
 			expected := unsignedCommit.Digest()
 			actual := signedCommit.Digest()
 
-			if !bytes.Equal(actual, expected) {
-				t.Fatalf("Expected %s, got %s", expected, actual)
-			}
+			require.EqualValues(t, expected, actual)
 		})
 	})
 }

--- a/pkg/client/sign_test.go
+++ b/pkg/client/sign_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
-	"bytes"
 	"context"
 	"testing"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -52,13 +52,10 @@ func TestSign(t *testing.T) {
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithSign(sign))
 
-		if _, err := contract.EvaluateTransaction("transaction"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := contract.EvaluateTransaction("transaction")
+		require.NoError(t, err)
 
-		if !bytes.Equal(actual, expected) {
-			t.Fatalf("Expected signature: %v\nGot: %v", expected, actual)
-		}
+		require.EqualValues(t, expected, actual)
 	})
 
 	t.Run("Submit signs proposal using client signing implementation", func(t *testing.T) {
@@ -81,13 +78,10 @@ func TestSign(t *testing.T) {
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithSign(sign))
 
-		if _, err := contract.SubmitTransaction("transaction"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := contract.SubmitTransaction("transaction")
+		require.NoError(t, err)
 
-		if !bytes.Equal(actual, expected) {
-			t.Fatalf("Expected signature: %v\nGot: %v", expected, actual)
-		}
+		require.EqualValues(t, expected, actual)
 	})
 
 	t.Run("Submit signs transaction using client signing implementation", func(t *testing.T) {
@@ -110,13 +104,10 @@ func TestSign(t *testing.T) {
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithSign(sign))
 
-		if _, err := contract.SubmitTransaction("transaction"); err != nil {
-			t.Fatal(err)
-		}
+		_, err := contract.SubmitTransaction("transaction")
+		require.NoError(t, err)
 
-		if !bytes.Equal(actual, expected) {
-			t.Fatalf("Expected signature: %v\nGot: %v", expected, actual)
-		}
+		require.EqualValues(t, expected, actual)
 	})
 
 	t.Run("Default error implementation is used if no signing implementation supplied", func(t *testing.T) {
@@ -126,14 +117,11 @@ func TestSign(t *testing.T) {
 			AnyTimes()
 
 		gateway, err := Connect(TestCredentials.identity, WithClient(mockClient))
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		contract := gateway.GetNetwork("network").GetContract("chaincode")
 
-		if _, err := contract.EvaluateTransaction("transaction"); nil == err {
-			t.Fatal("Expected signing error but got nil")
-		}
+		_, err = contract.EvaluateTransaction("transaction")
+		require.Error(t, err)
 	})
 }

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -7,8 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package hash
 
 import (
-	"bytes"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestHash(t *testing.T) {
@@ -19,9 +20,7 @@ func TestHash(t *testing.T) {
 			hash1 := SHA256(message)
 			hash2 := SHA256(message)
 
-			if !bytes.Equal(hash1, hash2) {
-				t.Fatalf("Hashes of %s were not identical:\n%v\n%v", message, hash1, hash2)
-			}
+			require.EqualValues(t, hash1, hash2)
 		})
 
 		t.Run("Hashes of different data are not identical", func(t *testing.T) {
@@ -31,9 +30,7 @@ func TestHash(t *testing.T) {
 			fooHash := SHA256(foo)
 			barHash := SHA256(bar)
 
-			if bytes.Equal(fooHash, barHash) {
-				t.Fatalf("Hashes of %s and %s were identical: %v", foo, bar, fooHash)
-			}
+			require.NotEqualValues(t, fooHash, barHash)
 		})
 	})
 }

--- a/pkg/identity/hsmsign_test.go
+++ b/pkg/identity/hsmsign_test.go
@@ -17,7 +17,6 @@ import (
 )
 
 func findSoftHSMLibrary(t *testing.T) string {
-
 	libraryLocations := []string{
 		"/usr/lib/softhsm/libsofthsm2.so",
 		"/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so",
@@ -26,19 +25,16 @@ func findSoftHSMLibrary(t *testing.T) string {
 	}
 
 	for _, libraryLocation := range libraryLocations {
-		if _, err := os.Stat(libraryLocation); errors.Is(err, os.ErrNotExist) {
-			// file does not exist
-		} else {
+		if _, err := os.Stat(libraryLocation); !errors.Is(err, os.ErrNotExist) {
 			return libraryLocation
 		}
 	}
 
-	t.Fatal("No SoftHSM library can be found. Tests cannot be run.")
+	require.FailNow(t, "No SoftHSM library can be found. Tests cannot be run.")
 	return ""
 }
 
 func TestNewHSMSignerFactory(t *testing.T) {
-
 	t.Run("No library provided", func(t *testing.T) {
 		_, err := NewHSMSignerFactory("")
 		require.EqualError(t, err, "library path not provided", "Expected Error message about no library provided")
@@ -59,7 +55,6 @@ func TestNewHSMSignerFactory(t *testing.T) {
 }
 
 func TestNewHSMSigner(t *testing.T) {
-
 	// SoftHSM must be installed for this to pass
 	hsmSignerFactory, err := NewHSMSignerFactory(findSoftHSMLibrary(t))
 	require.NoError(t, err)
@@ -119,7 +114,7 @@ func TestNewHSMSigner(t *testing.T) {
 		_, _, err := hsmSignerFactory.NewHSMSigner(hsmSignerOptions)
 
 		require.Error(t, err)
-		require.Containsf(t, err.Error(), "CKR_PIN_INCORRECT", "Expected Error message invalid Pin")
+		require.Contains(t, err.Error(), "CKR_PIN_INCORRECT", "Expected Error message invalid Pin")
 	})
 
 	t.Run("Object not found", func(t *testing.T) {

--- a/pkg/identity/identity_test.go
+++ b/pkg/identity/identity_test.go
@@ -10,29 +10,22 @@ import (
 	"testing"
 
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestIdentity(t *testing.T) {
 	const mspID = "mspID"
 
 	privateKey, err := test.NewECDSAPrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	certificate, err := test.NewCertificate(privateKey)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Run("NewX509Identity", func(t *testing.T) {
 		identity, err := NewX509Identity(mspID, certificate)
-		if err != nil {
-			t.Fatalf("Failed to create identity: %v", err)
-		}
+		require.NoError(t, err)
 
-		if identity.MspID() != mspID {
-			t.Fatalf("Expected %s, got %s", mspID, identity.MspID())
-		}
+		require.Equal(t, mspID, identity.MspID())
 	})
 }

--- a/pkg/identity/pem_test.go
+++ b/pkg/identity/pem_test.go
@@ -8,122 +8,72 @@ package identity
 
 import (
 	"crypto"
-	"crypto/ecdsa"
 	"testing"
 
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPEM(t *testing.T) {
 	privateKey, err := test.NewECDSAPrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	certificate, err := test.NewCertificate(privateKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// As in Go 1.15: https://golang.org/pkg/crypto/ecdsa/#PublicKey.Equal
-	ecdsaPublicKeyEqual := func(x *ecdsa.PublicKey, y *ecdsa.PublicKey) bool {
-		return x.X.Cmp(y.X) == 0 && x.Y.Cmp(y.Y) == 0 && x.Curve == y.Curve
-	}
-
-	// As in Go 1.15: https://golang.org/pkg/crypto/ecdsa/#PrivateKey.Equal
-	ecdsaPrivateKeyEqual := func(x *ecdsa.PrivateKey, y *ecdsa.PrivateKey) bool {
-		return ecdsaPublicKeyEqual(&x.PublicKey, &y.PublicKey) && x.D.Cmp(y.D) == 0
-	}
-
-	privateKeyEqual := func(x crypto.PrivateKey, y crypto.PrivateKey) bool {
-		switch xx := x.(type) {
-		case *ecdsa.PrivateKey:
-			yy, ok := y.(*ecdsa.PrivateKey)
-			if !ok {
-				return false
-			}
-			return ecdsaPrivateKeyEqual(xx, yy)
-		default:
-			return false
-		}
-	}
+	require.NoError(t, err)
 
 	t.Run("Certificate PEM conversion", func(t *testing.T) {
 		certificatePEM, err := CertificateToPEM(certificate)
-		if err != nil {
-			t.Fatalf("Failed to create PEM: %v", err)
-		}
+		require.NoError(t, err, "create PEM")
 
 		result, err := CertificateFromPEM(certificatePEM)
-		if err != nil {
-			t.Fatalf("Failed to create certificate: %v", err)
-		}
+		require.NoError(t, err, "create certificate")
 
-		if !certificate.Equal(result) {
-			t.Fatalf("Certificates do not match. Expected:\n%v\nGot:\n%v", certificate, result)
-		}
+		require.True(t, certificate.Equal(result), "Certificates do not match. Expected:\n%v\nGot:\n%v", certificate, result)
 	})
 
 	t.Run("Create certificate from PEM fails with invalid PEM", func(t *testing.T) {
 		pem := []byte("Non-PEM content")
 
 		_, err := CertificateFromPEM(pem)
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("Create certificate from PEM fails with invalid certificate", func(t *testing.T) {
 		pem := []byte("-----BEGIN CERTIFICATE-----\nBAD/DATA-----END CERTIFICATE-----")
 
 		_, err := CertificateFromPEM(pem)
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("Private key PEM conversion", func(t *testing.T) {
 		pem, err := PrivateKeyToPEM(privateKey)
-		if err != nil {
-			t.Fatalf("Failed to create PEM: %v", err)
-		}
+		require.NoError(t, err, "create PEM")
 
 		result, err := PrivateKeyFromPEM(pem)
-		if err != nil {
-			t.Fatalf("Failed to create private key: %v", err)
-		}
+		require.NoError(t, err, "create private key")
 
-		if !privateKeyEqual(privateKey, result) {
-			t.Fatalf("Keys do not match. Expected:\n%v\nGot:\n%v", privateKey, result)
-		}
+		require.True(t, privateKey.Equal(result), "Private keys do not match. Expected:\n%v\nGot:\n%v", privateKey, result)
 	})
 
 	t.Run("Create private key fails with invalid PEM", func(t *testing.T) {
 		pem := []byte("Non-PEM content")
 
 		_, err := PrivateKeyFromPEM(pem)
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
+		require.Error(t, err)
 	})
 
 	t.Run("Create private key from PEM fails with invalid private key data", func(t *testing.T) {
 		certificatePEM, err := CertificateToPEM(certificate)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
-		if _, err = PrivateKeyFromPEM([]byte(certificatePEM)); err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
+		_, err = PrivateKeyFromPEM([]byte(certificatePEM))
+		require.Error(t, err)
 	})
 
 	t.Run("Convert bad private key to PEM fails", func(t *testing.T) {
 		var privateKey crypto.PrivateKey
 
 		_, err := PrivateKeyToPEM(privateKey)
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
+		require.Error(t, err)
 	})
 }

--- a/pkg/identity/sign_test.go
+++ b/pkg/identity/sign_test.go
@@ -9,44 +9,32 @@ package identity
 import (
 	"crypto"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSigner(t *testing.T) {
 	privateKey, err := test.NewECDSAPrivateKey()
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 
 	t.Run("Create signer with unsupported private key type fails", func(t *testing.T) {
 		var privateKey crypto.PrivateKey
 		_, err := NewPrivateKeySign(privateKey)
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
+		require.Error(t, err)
 
 		expectedType := fmt.Sprintf("%T", privateKey)
-		if !strings.Contains(err.Error(), expectedType) {
-			t.Fatalf("Expected error to contain %s: %s", expectedType, err)
-		}
+		require.Contains(t, err.Error(), expectedType)
 	})
 
 	t.Run("Create signer with ECDSA private key", func(t *testing.T) {
 		sign, err := NewPrivateKeySign(privateKey)
-		if err != nil {
-			t.Fatalf("Failed to create identity: %v", err)
-		}
+		require.NoError(t, err)
 
 		signature, err := sign([]byte("digest"))
-		if err != nil {
-			t.Fatalf("Signing error: %v", err)
-		}
+		require.NoError(t, err)
 
-		if signature == nil {
-			t.Fatalf("Signature was nil")
-		}
+		require.NotEmpty(t, signature)
 	})
 }

--- a/pkg/internal/test/transaction.go
+++ b/pkg/internal/test/transaction.go
@@ -12,13 +12,13 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
+	"github.com/stretchr/testify/require"
 )
 
 // AssertUnmarshall ensures that a protobuf is umarshalled without error
 func AssertUnmarshall(t *testing.T, b []byte, m proto.Message) {
-	if err := proto.Unmarshal(b, m); err != nil {
-		t.Fatal(err)
-	}
+	err := proto.Unmarshal(b, m)
+	require.NoError(t, err)
 }
 
 // AssertUnmarshallProposalPayload ensures that a ChaincodeProposalPayload protobuf is umarshalled without error


### PR DESCRIPTION
Testify was already used in a few tests so, rather than mix two assertion frameworks, use testify for all assertions.