### PR TITLE
Allow specified start block for chaincode events in Go client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GO_TAGS ?=
 
 build: build-protos build-go build-node
 
-fabric_protos_commit = ef707fbbf8bf90dccb2808b6f1543af3068c1caa
+fabric_protos_commit = 0135abbbff7054cb55974595bda8901442acfa95
 pb_files = protos/gateway/gateway.pb.go protos/gateway/gateway_grpc.pb.go
 
 .PHONEY: build-protos

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/go-version v1.0.0 // indirect
 	github.com/hyperledger/fabric v2.1.1+incompatible
 	github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a // indirect
-	github.com/hyperledger/fabric-protos-go v0.0.0-20210528200356-82833ecdac31
+	github.com/hyperledger/fabric-protos-go v0.0.0-20210903093419-e9e1b9f969d8
 	github.com/miekg/pkcs11 v1.0.3
 	github.com/mitchellh/mapstructure v1.4.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
@@ -22,6 +22,6 @@ require (
 	github.com/sykesm/zap-logfmt v0.0.4 // indirect
 	go.uber.org/zap v1.16.0 // indirect
 	google.golang.org/grpc v1.40.0
-	google.golang.org/protobuf v1.26.0
+	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -165,8 +165,8 @@ github.com/hyperledger/fabric v2.1.1+incompatible h1:cYYRv3vVg4kA6DmrixLxwn1nwBE
 github.com/hyperledger/fabric v2.1.1+incompatible/go.mod h1:tGFAOCT696D3rG0Vofd2dyWYLySHlh0aQjf7Q1HAju0=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a h1:JAKZdGuUIjVmES0X31YUD7UqMR2rz/kxLluJuGvsXPk=
 github.com/hyperledger/fabric-amcl v0.0.0-20200424173818-327c9e2cf77a/go.mod h1:X+DIyUsaTmalOpmpQfIvFZjKHQedrURQ5t4YqquX7lE=
-github.com/hyperledger/fabric-protos-go v0.0.0-20210528200356-82833ecdac31 h1:T/uwoFIUioDDLffuJ/XgMLOWCUcx95/xXidv5igafl8=
-github.com/hyperledger/fabric-protos-go v0.0.0-20210528200356-82833ecdac31/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
+github.com/hyperledger/fabric-protos-go v0.0.0-20210903093419-e9e1b9f969d8 h1:6Qt3MdBqww+aJCDaUDIOhA6EcDhQln5l8wqBXehM96A=
+github.com/hyperledger/fabric-protos-go v0.0.0-20210903093419-e9e1b9f969d8/go.mod h1:xVYTjK4DtZRBxZ2D9aE4y6AbLaPwue2o/criQyQbVD0=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jcmturner/gofork v1.0.0 h1:J7uCkflzTEhUZ64xqKnkDxq3kzc96ajM1Gli5ktUem8=
 github.com/jcmturner/gofork v1.0.0/go.mod h1:MK8+TM0La+2rjBD4jE12Kj1pCCxK7d2LK/UM3ncEo0o=
@@ -449,8 +449,9 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/client/chaincodeeventsbuilder.go
+++ b/pkg/client/chaincodeeventsbuilder.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/gateway"
+	"github.com/hyperledger/fabric-protos-go/orderer"
+)
+
+type chaincodeEventsBuilder struct {
+	client        gateway.GatewayClient
+	signingID     *signingIdentity
+	channelName   string
+	chaincodeID   string
+	startPosition *orderer.SeekPosition
+}
+
+func (builder *chaincodeEventsBuilder) build() (*ChaincodeEventsRequest, error) {
+	signedRequest, err := builder.newSignedChaincodeEventsRequestProto()
+	if err != nil {
+		return nil, err
+	}
+
+	result := &ChaincodeEventsRequest{
+		client:        builder.client,
+		signingID:     builder.signingID,
+		signedRequest: signedRequest,
+	}
+	return result, nil
+}
+
+func (builder *chaincodeEventsBuilder) newSignedChaincodeEventsRequestProto() (*gateway.SignedChaincodeEventsRequest, error) {
+	request, err := builder.newChaincodeEventsRequestProto()
+	if err != nil {
+		return nil, err
+	}
+
+	requestBytes, err := proto.Marshal(request)
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize chaincode events request: %w", err)
+	}
+
+	signedRequest := &gateway.SignedChaincodeEventsRequest{
+		Request: requestBytes,
+	}
+	return signedRequest, nil
+}
+
+func (builder *chaincodeEventsBuilder) newChaincodeEventsRequestProto() (*gateway.ChaincodeEventsRequest, error) {
+	creator, err := builder.signingID.Creator()
+	if err != nil {
+		return nil, fmt.Errorf("failed to serialize identity: %w", err)
+	}
+
+	request := &gateway.ChaincodeEventsRequest{
+		ChannelId:     builder.channelName,
+		Identity:      creator,
+		ChaincodeId:   builder.chaincodeID,
+		StartPosition: builder.getStartPosition(),
+	}
+	return request, nil
+}
+
+func (builder *chaincodeEventsBuilder) getStartPosition() *orderer.SeekPosition {
+	if builder.startPosition != nil {
+		return builder.startPosition
+	}
+
+	return &orderer.SeekPosition{
+		Type: &orderer.SeekPosition_NextCommit{
+			NextCommit: &orderer.SeekNextCommit{},
+		},
+	}
+}
+
+// ChaincodeEventsOption implements an option for a chaincode events request.
+type ChaincodeEventsOption = func(builder *chaincodeEventsBuilder) error
+
+// WithStartBlock reads chaincode events starting at the specified block number.
+func WithStartBlock(blockNumber uint64) ChaincodeEventsOption {
+	return func(builder *chaincodeEventsBuilder) error {
+		builder.startPosition = &orderer.SeekPosition{
+			Type: &orderer.SeekPosition_Specified{
+				Specified: &orderer.SeekSpecified{
+					Number: blockNumber,
+				},
+			},
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
Unit test coverage only. Scenario tests will come later when all client language implementations are complete.