### PR TITLE
Use accessors for protobuf fields in Go client

### DIFF
--- a/pkg/client/chaincodeevents.go
+++ b/pkg/client/chaincodeevents.go
@@ -33,7 +33,7 @@ func (events *ChaincodeEventsRequest) Bytes() ([]byte, error) {
 
 // Digest of the chaincode events request. This is used to generate a digital signature.
 func (events *ChaincodeEventsRequest) Digest() []byte {
-	return events.signingID.Hash(events.signedRequest.Request)
+	return events.signingID.Hash(events.signedRequest.GetRequest())
 }
 
 // Events returns a channel from which chaincode events can be read.
@@ -98,13 +98,13 @@ type ChaincodeEvent struct {
 }
 
 func deliverChaincodeEvents(response *gateway.ChaincodeEventsResponse, send chan<- *ChaincodeEvent) {
-	for _, event := range response.Events {
+	for _, event := range response.GetEvents() {
 		send <- &ChaincodeEvent{
-			BlockNumber:   response.BlockNumber,
-			TransactionID: event.TxId,
-			ChaincodeID:   event.ChaincodeId,
-			EventName:     event.EventName,
-			Payload:       event.Payload,
+			BlockNumber:   response.GetBlockNumber(),
+			TransactionID: event.GetTxId(),
+			ChaincodeID:   event.GetChaincodeId(),
+			EventName:     event.GetEventName(),
+			Payload:       event.GetPayload(),
 		}
 	}
 }

--- a/pkg/client/commit.go
+++ b/pkg/client/commit.go
@@ -51,7 +51,7 @@ func (commit *Commit) Bytes() ([]byte, error) {
 
 // Digest of the commit status request. This is used to generate a digital signature.
 func (commit *Commit) Digest() []byte {
-	return commit.signingID.Hash(commit.signedRequest.Request)
+	return commit.signingID.Hash(commit.signedRequest.GetRequest())
 }
 
 // Status of the committed transaction. If the transaction has not yet committed, this call blocks until the commit
@@ -62,7 +62,7 @@ func (commit *Commit) Status() (peer.TxValidationCode, error) {
 		return 0, err
 	}
 
-	return response.Result, nil
+	return response.GetResult(), nil
 }
 
 // Successful returns true if the transaction committed successfully; otherwise false. If the transaction has not yet
@@ -89,7 +89,7 @@ func (commit *Commit) BlockNumber() (uint64, error) {
 		return 0, err
 	}
 
-	return response.BlockNumber, nil
+	return response.GetBlockNumber(), nil
 }
 
 func (commit *Commit) commitStatus() (*gateway.CommitStatusResponse, error) {
@@ -129,7 +129,7 @@ func (commit *Commit) sign() error {
 }
 
 func (commit *Commit) isSigned() bool {
-	return len(commit.signedRequest.Signature) > 0
+	return len(commit.signedRequest.GetSignature()) > 0
 }
 
 func (commit *Commit) setSignature(signature []byte) {

--- a/pkg/client/proposal.go
+++ b/pkg/client/proposal.go
@@ -40,7 +40,7 @@ func (proposal *Proposal) Digest() []byte {
 
 // TransactionID for the proposal.
 func (proposal *Proposal) TransactionID() string {
-	return proposal.proposedTransaction.TransactionId
+	return proposal.proposedTransaction.GetTransactionId()
 }
 
 // Endorse the proposal to obtain an endorsed transaction for submission to the orderer.
@@ -53,10 +53,10 @@ func (proposal *Proposal) Endorse() (*Transaction, error) {
 	defer cancel()
 
 	endorseRequest := &gateway.EndorseRequest{
-		TransactionId:          proposal.proposedTransaction.TransactionId,
+		TransactionId:          proposal.proposedTransaction.GetTransactionId(),
 		ChannelId:              proposal.channelID,
-		ProposedTransaction:    proposal.proposedTransaction.Proposal,
-		EndorsingOrganizations: proposal.proposedTransaction.EndorsingOrganizations,
+		ProposedTransaction:    proposal.proposedTransaction.GetProposal(),
+		EndorsingOrganizations: proposal.proposedTransaction.GetEndorsingOrganizations(),
 	}
 	response, err := proposal.client.Endorse(ctx, endorseRequest)
 	if err != nil {
@@ -64,9 +64,9 @@ func (proposal *Proposal) Endorse() (*Transaction, error) {
 	}
 
 	preparedTransaction := &gateway.PreparedTransaction{
-		TransactionId: proposal.proposedTransaction.TransactionId,
-		Envelope:      response.PreparedTransaction,
-		Result:        response.Result,
+		TransactionId: proposal.proposedTransaction.GetTransactionId(),
+		Envelope:      response.GetPreparedTransaction(),
+		Result:        response.GetResult(),
 	}
 	result := &Transaction{
 		client:              proposal.client,
@@ -87,17 +87,17 @@ func (proposal *Proposal) Evaluate() ([]byte, error) {
 	defer cancel()
 
 	evaluateRequest := &gateway.EvaluateRequest{
-		TransactionId:       proposal.proposedTransaction.TransactionId,
+		TransactionId:       proposal.proposedTransaction.GetTransactionId(),
 		ChannelId:           proposal.channelID,
-		ProposedTransaction: proposal.proposedTransaction.Proposal,
-		TargetOrganizations: proposal.proposedTransaction.EndorsingOrganizations,
+		ProposedTransaction: proposal.proposedTransaction.GetProposal(),
+		TargetOrganizations: proposal.proposedTransaction.GetEndorsingOrganizations(),
 	}
 	response, err := proposal.client.Evaluate(ctx, evaluateRequest)
 	if err != nil {
 		return nil, err
 	}
 
-	return response.Result.Payload, nil
+	return response.GetResult().GetPayload(), nil
 }
 
 func (proposal *Proposal) setSignature(signature []byte) {
@@ -105,7 +105,7 @@ func (proposal *Proposal) setSignature(signature []byte) {
 }
 
 func (proposal *Proposal) isSigned() bool {
-	return len(proposal.proposedTransaction.Proposal.Signature) > 0
+	return len(proposal.proposedTransaction.GetProposal().GetSignature()) > 0
 }
 
 func (proposal *Proposal) sign() error {

--- a/pkg/client/transaction.go
+++ b/pkg/client/transaction.go
@@ -25,7 +25,7 @@ type Transaction struct {
 
 // Result of the proposed transaction invocation.
 func (transaction *Transaction) Result() []byte {
-	return transaction.preparedTransaction.Result.Payload
+	return transaction.preparedTransaction.GetResult().GetPayload()
 }
 
 // Bytes of the serialized transaction.
@@ -40,12 +40,12 @@ func (transaction *Transaction) Bytes() ([]byte, error) {
 
 // Digest of the transaction. This is used to generate a digital signature.
 func (transaction *Transaction) Digest() []byte {
-	return transaction.signingID.Hash(transaction.preparedTransaction.Envelope.Payload)
+	return transaction.signingID.Hash(transaction.preparedTransaction.GetEnvelope().GetPayload())
 }
 
 // TransactionID of the transaction.
 func (transaction *Transaction) TransactionID() string {
-	return transaction.preparedTransaction.TransactionId
+	return transaction.preparedTransaction.GetTransactionId()
 }
 
 // Submit the transaction to the orderer for commit to the ledger.
@@ -66,7 +66,7 @@ func (transaction *Transaction) Submit() (*Commit, error) {
 	submitRequest := &gateway.SubmitRequest{
 		TransactionId:       transaction.TransactionID(),
 		ChannelId:           transaction.channelID,
-		PreparedTransaction: transaction.preparedTransaction.Envelope,
+		PreparedTransaction: transaction.preparedTransaction.GetEnvelope(),
 	}
 	_, err = transaction.client.Submit(ctx, submitRequest)
 	if err != nil {
@@ -93,7 +93,7 @@ func (transaction *Transaction) sign() error {
 }
 
 func (transaction *Transaction) isSigned() bool {
-	return len(transaction.preparedTransaction.Envelope.Signature) > 0
+	return len(transaction.preparedTransaction.GetEnvelope().GetSignature()) > 0
 }
 
 func (transaction *Transaction) setSignature(signature []byte) {


### PR DESCRIPTION
Using getters to access fields on protobuf structs reduces the chance of runtime panics in the event that malformed protobuf messages are received from the Fabric Gateway peer. Results returned to the application will still not be correct but the chance of application failure is reduced.

Note: this is **not** a fix for #193 but may make diagnosis of bugs of this type easier in the Go client, since the client is more likely to remain running for debugging or results analysis.