### PR TITLE
Provide enumeration of commit status codes in Node client

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -12,7 +12,7 @@
         "clean": "rm -rf apidocs dist src/protos",
         "compile": "tsc",
         "copy-non-ts-source": "rsync -rv --prune-empty-dirs --include='*.d.ts' --exclude='*.ts' src/ dist",
-        "generate-apidoc": "typedoc --out apidocs src/index.ts",
+        "generate-apidoc": "typedoc --treatWarningsAsErrors --out apidocs src/index.ts",
         "lint": "eslint . --ext .ts",
         "proto:prepare": "mkdir -p src/protos",
         "proto:gen": "grpc_tools_node_protoc --proto_path=../fabric-protos --js_out=import_style=commonjs,binary:src/protos --ts_out=service=grpc-node,mode=grpc-js:src/protos --grpc_out=grpc_js:src/protos $(find ../fabric-protos -name *.proto -type f -print)",
@@ -24,7 +24,7 @@
         "@grpc/grpc-js": "^1.3.7",
         "asn1.js": "^5.4.1",
         "elliptic": "^6.5.3",
-        "google-protobuf": "^3.17.3"
+        "google-protobuf": "^3.18.0"
     },
     "optionalDependencies": {
         "pkcs11js": "^1.2.5"
@@ -34,18 +34,18 @@
         "@types/elliptic": "^6.4.13",
         "@types/google-protobuf": "^3.15.5",
         "@types/jest": "^27.0.1",
-        "@types/node": "^12.20.21",
-        "@typescript-eslint/eslint-plugin": "^4.30.0",
-        "@typescript-eslint/parser": "^4.30.0",
+        "@types/node": "^12.20.25",
+        "@typescript-eslint/eslint-plugin": "^4.31.1",
+        "@typescript-eslint/parser": "^4.31.1",
         "eslint": "^7.32.0",
-        "eslint-plugin-jest": "^24.4.0",
+        "eslint-plugin-jest": "^24.4.2",
         "eslint-plugin-tsdoc": "^0.2.14",
         "grpc-tools": "^1.11.2",
-        "jest": "^27.1.0",
+        "jest": "^27.2.0",
         "npm-run-all": "^4.1.5",
         "ts-jest": "^27.0.5",
         "ts-protoc-gen": "^0.15.0",
-        "typedoc": "^0.21.9",
+        "typedoc": "^0.22.3",
         "typescript": "~4.4.2"
     }
 }

--- a/node/src/chaincodeeventsrequest.ts
+++ b/node/src/chaincodeeventsrequest.ts
@@ -9,9 +9,9 @@ import { GatewayClient } from './client';
 import { ChaincodeEventsRequest as ChaincodeEventsRequestProto, SignedChaincodeEventsRequest as SignedChaincodeEventsRequestProto } from './protos/gateway/gateway_pb';
 import { Signable } from './signable';
 import { SigningIdentity } from './signingidentity';
-import { Callback } from './utils';
+import { ErrorFirstCallback } from './utils';
 
-export type ChaincodeEventCallback = Callback<ChaincodeEvent>
+export type ChaincodeEventCallback = ErrorFirstCallback<ChaincodeEvent>
 
 /**
  * Delivers events emitted by transaction functions in a specific chaincode.
@@ -20,6 +20,16 @@ export interface ChaincodeEventsRequest extends Signable {
     /**
      * Get chaincode events emitted by transaction functions of a specific chaincode.
      * @param callback - Event callback function.
+     * @example
+     * ```
+     * await request.onEvent((err, event) => {
+     *     if (err) {
+     *         // Handle connection error
+     *     } else {
+     *         // Process event
+     *     }
+     * });
+     * ```
      */
     onEvent(callback: ChaincodeEventCallback): Promise<void>;
 

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -5,7 +5,7 @@
  */
 
 import { GatewayClient } from './client';
-import { TxStatusString } from './commit';
+import { CommitStatusNames } from './commit';
 import { Proposal, ProposalImpl } from './proposal';
 import { ProposalBuilder, ProposalOptions } from './proposalbuilder';
 import { PreparedTransaction, ProposedTransaction } from './protos/gateway/gateway_pb';
@@ -204,7 +204,7 @@ export class ContractImpl implements Contract {
         const successful = await submitted.isSuccessful();
         if (!successful) {
             const status = await submitted.getStatus();
-            throw new Error(`Transaction ${submitted.getTransactionId()} failed to commit with status code ${status} (${TxStatusString[status]})`)
+            throw new Error(`Transaction ${submitted.getTransactionId()} failed to commit with status code ${status} (${CommitStatusNames[status]})`)
         }
 
         return submitted.getResult();

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -5,8 +5,9 @@
  */
 
 export { ChaincodeEvent } from './chaincodeevent';
+export { ChaincodeEventsOptions } from './chaincodeeventsbuilder';
 export { ChaincodeEventCallback, ChaincodeEventsRequest } from './chaincodeeventsrequest';
-export { Commit } from './commit';
+export { Commit, CommitStatus } from './commit';
 export { Contract } from './contract';
 export { connect, ConnectOptions, Gateway } from './gateway';
 export { Hash } from './hash/hash';
@@ -18,7 +19,8 @@ export * as signers from './identity/signers';
 export { Network } from './network';
 export { Proposal } from './proposal';
 export { ProposalOptions } from './proposalbuilder';
+export { TxValidationCodeMap as CommitStatusCodes } from './protos/peer/transaction_pb';
 export { Signable } from './signable';
 export { SubmittedTransaction } from './submittedtransaction';
 export { Transaction } from './transaction';
-
+export { ErrorFirstCallback } from './utils';

--- a/node/src/network.ts
+++ b/node/src/network.ts
@@ -46,7 +46,7 @@ export interface Network {
      * @returns Chaincode events.
      * @example
      * ```
-     * const events = await network.getChaincodeEvents(chaincodeId);
+     * const events = await network.getChaincodeEvents(chaincodeId, { startBlock: BigInt(101) });
      * for async (const event of events) {
      *     // Process event
      * }

--- a/node/src/utils.d.ts
+++ b/node/src/utils.d.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export interface Callback<T> {
-    (err: unknown, event: undefined): Promise<void>;
+export interface ErrorFirstCallback<T> {
     (err: undefined, event: T): Promise<void>;
+    (err: unknown, event: undefined): Promise<void>;
 }

--- a/scenario/node/src/transactioninvocation.ts
+++ b/scenario/node/src/transactioninvocation.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Contract, Network, ProposalOptions, Signable, Signer } from 'fabric-gateway';
+import { CommitStatus, Contract, Network, ProposalOptions, Signable, Signer } from 'fabric-gateway';
 import { bytesAsString, toError, toString } from './utils';
 
 export class TransactionInvocation {
@@ -80,9 +80,8 @@ export class TransactionInvocation {
         const submitted = await signedTransaction.submit();
         const signedCommit = await this.sign(submitted, this.network.newSignedCommit.bind(this.network));
 
-        const successful = await signedCommit.isSuccessful();
-        if (!successful) {
-            const status = await signedCommit.getStatus();
+        const status = await signedCommit.getStatus();
+        if (status !== CommitStatus.VALID) {
             throw new Error(`Transaction commit failed with status: ${status}`)
         }
 


### PR DESCRIPTION
Allows client applications to interpret the numeric status code values and check them against specific values of interest.

Note the scenario test change, which demonstrates how commit status values can be referenced by client application code.