### PR TITLE
Java API documentation updates

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/Network.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Network.java
@@ -22,7 +22,16 @@ import com.google.protobuf.InvalidProtocolBufferException;
  *     or {@link #newChaincodeEventsRequest(String)}.</li>
  * </ul>
  *
- * @see <a href="https://hyperledger-fabric.readthedocs.io/en/release-1.4/developapps/application.html#network-channel">Developing Fabric Applications - Network Channel</a>
+ * <h3>Chaincode events example</h3>
+ * <pre>{@code
+ *     Iterator<ChaincodeEvent> events = network.newChaincodeEventsRequest("basic")
+ *             .startBlock(101)
+ *             .build()
+ *             .getEvents();
+ *     events.forEachRemaining(event -> {
+ *         // Process event
+ *     });
+ * }</pre>
  */
 public interface Network {
     /**
@@ -38,11 +47,11 @@ public interface Network {
      * than one smart contract class (available using the latest chaincode programming model), then an
      * individual class can be selected.
      * @param chaincodeId The name of the chaincode that implements the smart contract.
-     * @param name The class name of the smart contract within the chaincode.
+     * @param contractName The name of the smart contract within the chaincode.
      * @return The contract object.
      * @throws NullPointerException if the chaincode ID is null.
      */
-    Contract getContract(String chaincodeId, String name);
+    Contract getContract(String chaincodeId, String contractName);
 
     /**
      * Get the name of the network channel.

--- a/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
@@ -29,8 +29,8 @@ final class NetworkImpl implements Network {
     }
 
     @Override
-    public Contract getContract(final String chaincodeId, final String name) {
-        return new ContractImpl(client, signingIdentity, name, chaincodeId, name);
+    public Contract getContract(final String chaincodeId, final String contractName) {
+        return new ContractImpl(client, signingIdentity, contractName, chaincodeId, contractName);
     }
 
     @Override

--- a/java/src/main/javadoc/overview.html
+++ b/java/src/main/javadoc/overview.html
@@ -4,51 +4,60 @@
     <title>API Overview</title>
   </head>
   <body>
-	<p>
-	The Fabric Gateway SDK allows applications to interact with a Fabric blockchain network. 
-	It provides a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.
-	 The Gateway SDK implements the Fabric programming model as described in the
-	 <a href="https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html">Developing Applications</a>
-	 chapter of the Fabric documentation.</p>
-	 <p>The following shows a complete code sample of how to connect to a fabric network,
-	 submit a transaction and query the ledger state using an instantiated smart contract (fabcar sample).
-	 </p>
+	<p>The Fabric Gateway SDK allows applications to interact with a Fabric blockchain network. It provides a simple API
+    to submit transactions to a ledger or query the contents of a ledger with minimal code. The Gateway SDK implements
+    the Fabric programming model as described in the
+    <a href="https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html">Developing Applications</a>
+	chapter of the Fabric documentation.</p>
+
+    <p>Client applications interact with the blockchain network using a Fabric Gateway. A session for a given client
+    identity is established by building and connecting to a Fabric Gateway using a gRPC connection to the Gateway
+    endpoint, client identity, and client signing implementation. The returned <code>Gateway</code> enables interaction
+    with any of the blockchain <code>Networks</code> (channels) accessible through the Fabric Gateway. This in turn
+    provides access to Smart <code>Contracts</code> within chaincode deployed to that blockchain network, and to which
+    transactions can be submitted or queries can be evaluated.
+
+    <p>gRPC connections to a Fabric Gateway may be shared by all <code>Gateway</code> instances interacting with that
+    Fabric Gateway.</p>
+
+	<p>The following shows a complete code sample of how to connect to a fabric network, submit a transaction and query
+    the ledger state using an instantiated smart contract.</p>
 
     <pre><code>
-    public static void main(String[] args) throws IOException {
+    import io.grpc.ManagedChannel;
+    import io.grpc.ManagedChannelBuilder;
+    import org.hyperledger.fabric.client.*;
+    import org.hyperledger.fabric.client.identity.*;
 
-        // Create gRPC channel, which should be shared by all gateway connections to this endpoint.
-        Channel grpcChannel = ManagedChannelBuilder.forAddress("gateway.example.org", 1337)
+    public static void main(final String[] args) throws CommitException, InterruptedException {
+        Reader certReader = Files.newBufferedReader(certificatePath);
+        X509Certificate certificate = Identities.readX509Certificate(certReader);
+        Identity identity = new X509Identity("mspId", certificate);
+
+        Reader keyReader = Files.newBufferedReader(privateKeyPath);
+        PrivateKey privateKey = Identities.readPrivateKey(keyReader);
+        Signer signer = Signers.newPrivateKeySigner(privateKey);
+
+        ManagedChannel grpcChannel = ManagedChannelBuilder.forAddress("gateway.example.org", 1337)
                 .usePlaintext()
                 .build();
 
-        // Create client identity and signing implementation based on X.509 certificate and private key.
-        Identity identity = new X509Identity("mspId", certificate);
-        Signer signer = Signers.newPrivateKeySigner(privateKey);
-
-        // Configure gateway connection used to access the network.
         Gateway.Builder builder = Gateway.newInstance()
                 .identity(identity)
                 .signer(signer)
                 .connection(grpcChannel);
 
-        // Create gateway connection.
         try (Gateway gateway = builder.connect()) {
+            Network network = gateway.getNetwork("channelName");
+            Contract contract = network.getContract("chaincodeName");
 
-            // Obtain smart contract deployed on the network.
-            Network network = gateway.getNetwork("mychannel");
-            Contract contract = network.getContract("fabcar");
+            byte[] putResult = contract.submitTransaction("put", "time", LocalDateTime.now().toString());
+            System.out.println(new String(putResult, StandardCharsets.UTF_8));
 
-            // Submit transactions that store state to the ledger.
-            byte[] createCarResult = contract.submitTransaction("createCar", "VW", "Polo", "Grey", "Mary");
-            System.out.println(new String(createCarResult, StandardCharsets.UTF_8));
-
-            // Evaluate transactions that query state from the ledger.
-            byte[] queryAllCarsResult = contract.evaluateTransaction("queryAllCars");
-            System.out.println(new String(queryAllCarsResult, StandardCharsets.UTF_8));
-
-        } catch (ContractException | TimeoutException | InterruptedException e) {
-            e.printStackTrace();
+            byte[] getResult = contract.evaluateTransaction("get", "time");
+            System.out.println(new String(getResult, StandardCharsets.UTF_8));
+        } finally {
+            grpcChannel.shutdownNow().awaitTermination(5, TimeUnit.SECONDS);
         }
     }
     </code></pre>

--- a/node/src/README.md
+++ b/node/src/README.md
@@ -23,9 +23,6 @@ The following complete example shows how to connect to a Fabric network, submit 
     const utf8Decoder = new TextDecoder();
 
     async function main(): Promise<void> {
-        const GrpcClient = grpc.makeGenericClientConstructor({}, '');
-        const client = new GrpcClient('gateway.example.org:1337', grpc.credentials.createInsecure());
-
         const credentials = await fs.readFile('path/to/certificate.pem');
         const identity: Identity = { mspId: 'myorg', credentials };
 
@@ -33,7 +30,10 @@ The following complete example shows how to connect to a Fabric network, submit 
         const privateKey = crypto.createPrivateKey(privateKeyPem);
         const signer = signers.newPrivateKeySigner(privateKey);
 
-        const gateway = connect({ client, identity, signer });
+        const GrpcClient = grpc.makeGenericClientConstructor({}, '');
+        const client = new GrpcClient('gateway.example.org:1337', grpc.credentials.createInsecure());
+
+        const gateway = connect({ identity, signer, client });
         try {
             const network = gateway.getNetwork('channelName');
             const contract = network.getContract('chaincodeName');

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -80,7 +80,7 @@ import { Transaction, TransactionImpl } from './transaction';
  * // Generate signature from digest
  * const signedCommit = network.newSignedCommit(commitBytes, commitDigest);
  * 
- * const result = signedCommit.getResult();
+ * const result = signedTransaction.getResult();
  * const status = await signedCommit.getStatus();
  * ```
  */


### PR DESCRIPTION
- Async submit example in Contract class doc
- Add equivalent call examples to Contract methods to help relate different API methods
- Chaincode events example in Network class doc
- Tidy-up of package-level code example
- Consistency of top-level description between Node and Java documentation

Resolves #215 
Resolves #216 
Contributes to #179 