### PR TITLE
Update Go API documentation

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/Contract.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Contract.java
@@ -130,7 +130,7 @@ public interface Contract {
      * <pre>{@code
      *     contract.newProposal(name)
      *             .build()
-     *             .submitSync();
+     *             .submit();
      * }</pre>
      * @param name Transaction function name.
      * @return Payload response from the transaction function.
@@ -149,7 +149,7 @@ public interface Contract {
      *     contract.newProposal(name)
      *             .addArguments(arg1, arg2)
      *             .build()
-     *             .submitSync();
+     *             .submit();
      * }</pre>
      * @param name Transaction function name.
      * @param args Transaction function arguments.
@@ -170,7 +170,7 @@ public interface Contract {
      *     contract.newProposal(name)
      *             .addArguments(arg1, arg2)
      *             .build()
-     *             .submitSync();
+     *             .submit();
      * }</pre>
      * @param name Transaction function name.
      * @param args Transaction function arguments.

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -56,7 +56,7 @@ import { Transaction, TransactionImpl } from './transaction';
  * // Update UI or reply to REST request before waiting for commit status
  * const status = await commit.getStatus();
  * if (!status.successful) {
- *     throw new Error(`${status.transactionId} failed with status code ${status.code}`);
+ *     throw new Error(`transaction ${status.transactionId} failed with status code ${status.code}`);
  * }
  * ```
  *
@@ -140,16 +140,6 @@ export interface Contract {
      * Submit a transaction to the ledger and return its result only after it is committed to the ledger. The
      * transaction function will be evaluated on endorsing peers and then submitted to the ordering service to be
      * committed to the ledger.
-     * 
-     * This method is equivalent to:
-     * ```
-     * const commit = await contract.submitAsync(transactionName, options);
-     * const status = await commit.getStatus();
-     * if (!status.successful) {
-     *     throw new Error(`Transaction ${status.transactionId} failed to commit with status code ${status.code}`);
-     * }
-     * const result = commit.getResult();
-     * ```
      * @param transactionName - Name of the transaction to invoke.
      * @param options - Transaction invocation options.
      * @returns The result returned by the transaction function.

--- a/pkg/client/contract.go
+++ b/pkg/client/contract.go
@@ -55,6 +55,10 @@ func (contract *Contract) Name() string {
 // EvaluateTransaction will evaluate a transaction function and return its results. A transaction proposal will be
 // evaluated on endorsing peers but the transaction will not be sent to the ordering service and so will not be
 // committed to the ledger. This can be used for querying the world state.
+//
+// This method is equivalent to:
+//
+//     contract.Evaluate(name, WithArguments(args...))
 func (contract *Contract) EvaluateTransaction(name string, args ...string) ([]byte, error) {
 	return contract.Evaluate(name, WithArguments(args...))
 }
@@ -74,6 +78,10 @@ func (contract *Contract) Evaluate(transactionName string, options ...ProposalOp
 // SubmitTransaction will submit a transaction to the ledger and return its result only after it is committed to the
 // ledger. The transaction function will be evaluated on endorsing peers and then submitted to the ordering service to
 // be committed to the ledger.
+//
+// This method is equivalent to:
+//
+//     contract.Submit(name, client.WithArguments(args...))
 func (contract *Contract) SubmitTransaction(name string, args ...string) ([]byte, error) {
 	return contract.Submit(name, WithArguments(args...))
 }
@@ -94,7 +102,7 @@ func (contract *Contract) Submit(transactionName string, options ...ProposalOpti
 	}
 
 	if !status.Successful {
-		return nil, fmt.Errorf("transaction commit failed with status: %d (%s)", int32(status.Code), peer.TxValidationCode_name[int32(status.Code)])
+		return nil, fmt.Errorf("transaction %s failed to commit with status code %d (%s)", status.TransactionID, int32(status.Code), peer.TxValidationCode_name[int32(status.Code)])
 	}
 
 	return result, nil

--- a/pkg/client/example_network_test.go
+++ b/pkg/client/example_network_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hyperledger/fabric-gateway/pkg/client"
+)
+
+func ExampleNetwork_ChaincodeEvents() {
+	var network *client.Network // Obtained from Gateway.
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events, err := network.ChaincodeEvents(ctx, "chaincodeName", client.WithStartBlock(101))
+	if err != nil {
+		panic(err)
+	}
+
+	for event := range events {
+		fmt.Printf("Event: %#v\n", event)
+	}
+}

--- a/samples/go/sample.go
+++ b/samples/go/sample.go
@@ -273,7 +273,7 @@ func exampleChaincodeEvents(gateway *client.Gateway) {
 	}
 
 	fmt.Printf("Read chaincode events starting at block number %d\n", status.BlockNumber)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	events, err := network.ChaincodeEvents(ctx, "basic", client.WithStartBlock(status.BlockNumber))
 	if err != nil {


### PR DESCRIPTION
- Async submit example
- Chaincode events example
- Modified off-line signing examples to demonstrate end-to-end flow
- Added examples of equivalent calls using alternative Contract methods
- Renamed some code examples to ensure they are associated with the correct methods
- Minor corrections to Java equivalent call examples
- Removed Node submit/submitAsync equivalent call examples as they are unnecessarily complex and used for different use-cases

Resolves #219 
Resolves #218 
Resolves #179 