### PR TITLE
Interfaces for ChaincodeEvent and Status in Java API

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEvent.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEvent.java
@@ -6,100 +6,39 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.Arrays;
-import java.util.Objects;
-
-import org.hyperledger.fabric.protos.peer.ChaincodeEventPackage;
-
 /**
  * Chaincode event emitted by a transaction function.
  */
-public final class ChaincodeEvent {
-    private final long blockNumber;
-    private final String transactionId;
-    private final String chaincodeId;
-    private final String eventName;
-    private final byte[] payload;
-    private final int hash;
-
-    ChaincodeEvent(final long blockNumber, final ChaincodeEventPackage.ChaincodeEvent event) {
-        this.blockNumber = blockNumber;
-        this.transactionId = event.getTxId();
-        this.chaincodeId = event.getChaincodeId();
-        this.eventName = event.getEventName();
-        this.payload = event.getPayload().toByteArray();
-        this.hash = Objects.hash(blockNumber, transactionId, chaincodeId, eventName); // Ignore potentially large payload; this is good enough
-    }
-
+public interface ChaincodeEvent {
     /**
      * Block number that included this chaincode event.
      * <p>Note that the block number is an unsigned 64-bit integer, with the sign bit used to hold the top bit of
      * the number.</p>
      * @return A block number.
      */
-    public long getBlockNumber() {
-        return blockNumber;
-    }
+    long getBlockNumber();
 
     /**
      * Transaction that emitted this chaincode event.
      * @return Transaction ID.
      */
-    public String getTransactionId() {
-        return transactionId;
-    }
+    String getTransactionId();
 
     /**
      * Chaincode that emitted this event.
      * @return Chaincode ID.
      */
-    public String getChaincodeId() {
-        return chaincodeId;
-    }
+    String getChaincodeId();
 
     /**
      * Name of the emitted event.
      * @return Event name.
      */
-    public String getEventName() {
-        return eventName;
-    }
+    String getEventName();
 
     /**
      * Application defined payload data associated with this event.
      * @return Event payload.
      */
-    public byte[] getPayload() {
-        return payload;
-    }
-
-    @Override
-    public boolean equals(final Object other) {
-        if (!(other instanceof ChaincodeEvent)) {
-            return false;
-        }
-
-        ChaincodeEvent that = (ChaincodeEvent) other;
-
-        return this.blockNumber == that.blockNumber
-                && Objects.equals(this.transactionId, that.transactionId)
-                && Objects.equals(this.chaincodeId, that.chaincodeId)
-                && Objects.equals(this.eventName, that.eventName)
-                && Arrays.equals(this.payload, that.payload);
-    }
-
-    @Override
-    public int hashCode() {
-        return hash;
-    }
-
-    @Override
-    public String toString() {
-        return GatewayUtils.toString(this,
-                "blockNumber: " + blockNumber,
-                "transactionId: " + transactionId,
-                "chaincodeId: " + chaincodeId,
-                "eventName: " + eventName,
-                "payload: " + Arrays.toString(payload));
-    }
+    byte[] getPayload();
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventImpl.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+import org.hyperledger.fabric.protos.peer.ChaincodeEventPackage;
+
+final class ChaincodeEventImpl implements ChaincodeEvent {
+    private final long blockNumber;
+    private final String transactionId;
+    private final String chaincodeId;
+    private final String eventName;
+    private final byte[] payload;
+    private final int hash;
+
+    ChaincodeEventImpl(final long blockNumber, final ChaincodeEventPackage.ChaincodeEvent event) {
+        this.blockNumber = blockNumber;
+        this.transactionId = event.getTxId();
+        this.chaincodeId = event.getChaincodeId();
+        this.eventName = event.getEventName();
+        this.payload = event.getPayload().toByteArray();
+        this.hash = Objects.hash(blockNumber, transactionId, chaincodeId, eventName); // Ignore potentially large payload; this is good enough
+    }
+
+    @Override
+    public long getBlockNumber() {
+        return blockNumber;
+    }
+
+    @Override
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    @Override
+    public String getChaincodeId() {
+        return chaincodeId;
+    }
+
+    @Override
+    public String getEventName() {
+        return eventName;
+    }
+
+    @Override
+    public byte[] getPayload() {
+        return payload;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if (!(other instanceof ChaincodeEventImpl)) {
+            return false;
+        }
+
+        ChaincodeEventImpl that = (ChaincodeEventImpl) other;
+
+        return this.blockNumber == that.blockNumber
+                && Objects.equals(this.transactionId, that.transactionId)
+                && Objects.equals(this.chaincodeId, that.chaincodeId)
+                && Objects.equals(this.eventName, that.eventName)
+                && Arrays.equals(this.payload, that.payload);
+    }
+
+    @Override
+    public int hashCode() {
+        return hash;
+    }
+
+    @Override
+    public String toString() {
+        return GatewayUtils.toString(this,
+                "blockNumber: " + blockNumber,
+                "transactionId: " + transactionId,
+                "chaincodeId: " + chaincodeId,
+                "eventName: " + eventName,
+                "payload: " + Arrays.toString(payload));
+    }
+}

--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventIterator.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventIterator.java
@@ -27,7 +27,7 @@ final class ChaincodeEventIterator implements Iterator<ChaincodeEvent> {
     @Override
     public ChaincodeEvent next() {
         ChaincodeEventsResponse response = nextResponse();
-        return new ChaincodeEvent(response.getBlockNumber(), response.getEvents(eventIndex++));
+        return new ChaincodeEventImpl(response.getBlockNumber(), response.getEvents(eventIndex++));
     }
 
     private boolean hasNextEvent() {

--- a/java/src/main/java/org/hyperledger/fabric/client/CommitImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/CommitImpl.java
@@ -45,7 +45,7 @@ class CommitImpl implements Commit {
     public Status getStatus() {
         sign();
         CommitStatusResponse response = client.commitStatus(signedRequest);
-        return new Status(transactionId, response);
+        return new StatusImpl(transactionId, response);
     }
 
     void setSignature(final byte[] signature) {

--- a/java/src/main/java/org/hyperledger/fabric/client/Status.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Status.java
@@ -6,31 +6,17 @@
 
 package org.hyperledger.fabric.client;
 
-import org.hyperledger.fabric.protos.gateway.CommitStatusResponse;
-
 import static org.hyperledger.fabric.protos.peer.TransactionPackage.TxValidationCode;
 
 /**
  * Information about a transaction that is committed to the ledger.
  */
-public final class Status {
-    private final String transactionId;
-    private final long blockNumber;
-    private final TxValidationCode code;
-
-    Status(final String transactionId, final CommitStatusResponse response) {
-        this.transactionId = transactionId;
-        this.blockNumber = response.getBlockNumber();
-        this.code = response.getResult();
-    }
-
+public interface Status {
     /**
      * Get the transaction ID.
      * @return A transaction ID.
      */
-    public String getTransactionId() {
-        return transactionId;
-    }
+    String getTransactionId();
 
     /**
      * Get the block number in which the transaction committed.
@@ -38,23 +24,17 @@ public final class Status {
      * the number.</p>
      * @return A block number.
      */
-    public long getBlockNumber() {
-        return blockNumber;
-    }
+    long getBlockNumber();
 
     /**
      * Get the committed transaction status code.
      * @return Transaction status code.
      */
-    public TxValidationCode getCode() {
-        return code;
-    };
+    TxValidationCode getCode();
 
     /**
      * Check whether the transaction committed successfully.
      * @return {@code true} if the transaction committed successfully; otherwise {@code false}.
      */
-    public boolean isSuccessful() {
-        return code == TxValidationCode.VALID;
-    };
+    boolean isSuccessful();
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/StatusImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/StatusImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import org.hyperledger.fabric.protos.gateway.CommitStatusResponse;
+
+import static org.hyperledger.fabric.protos.peer.TransactionPackage.TxValidationCode;
+
+/**
+ * Information about a transaction that is committed to the ledger.
+ */
+final class StatusImpl implements Status {
+    private final String transactionId;
+    private final long blockNumber;
+    private final TxValidationCode code;
+
+    StatusImpl(final String transactionId, final CommitStatusResponse response) {
+        this.transactionId = transactionId;
+        this.blockNumber = response.getBlockNumber();
+        this.code = response.getResult();
+    }
+
+    @Override
+    public String getTransactionId() {
+        return transactionId;
+    }
+
+    @Override
+    public long getBlockNumber() {
+        return blockNumber;
+    }
+
+    @Override
+    public TxValidationCode getCode() {
+        return code;
+    };
+
+    @Override
+    public boolean isSuccessful() {
+        return code == TxValidationCode.VALID;
+    };
+}

--- a/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
@@ -155,9 +155,9 @@ public final class ChaincodeEventsTest {
         Iterator<ChaincodeEvent> actual = network.getChaincodeEvents("CHAINCODE_ID");
 
         List<ChaincodeEvent> expected = Arrays.asList(
-                new ChaincodeEvent(1, event1),
-                new ChaincodeEvent(1, event2),
-                new ChaincodeEvent(2, event3)
+                new ChaincodeEventImpl(1, event1),
+                new ChaincodeEventImpl(1, event2),
+                new ChaincodeEventImpl(2, event3)
         );
         assertThat(Stream.generate(actual::next).limit(3)).hasSameElementsAs(expected);
     }


### PR DESCRIPTION
Exposing concrete implementation classes that could not be instantiated by client code would make unit testing for client application code harder.

Resolves #224 