### PR TITLE
Add Transaction class description to JavaDoc

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/Contract.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Contract.java
@@ -55,7 +55,9 @@ import com.google.protobuf.InvalidProtocolBufferException;
  *             .endorse()
  *             .submitAsync();
  *     byte[] result = commit.getResult();
+ *
  *     // Update UI or reply to REST request before waiting for commit status
+ *
  *     Status status = commit.getStatus();
  *     if (!status.isSuccessful()) {
  *         // Commit failure

--- a/java/src/main/java/org/hyperledger/fabric/client/Transaction.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Transaction.java
@@ -6,6 +6,9 @@
 
 package org.hyperledger.fabric.client;
 
+/**
+ * An endorsed transaction that can be submitted to the orderer for commit to the ledger.
+ */
 public interface Transaction extends Signable {
     /**
      * Get the transaction result. The result is obtained as part of the proposal endorsement so may be read


### PR DESCRIPTION
Also for clarity, add some spacing to async submit example in Contract JavaDoc.