### PR TITLE
Stop event listening in Node client using async iterable

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayUtils.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayUtils.java
@@ -66,11 +66,10 @@ final class GatewayUtils {
         if (channel.isShutdown()) {
             return;
         }
-        channel.shutdownNow();
         try {
-            channel.awaitTermination(timeout, timeUnit);
+            channel.shutdownNow().awaitTermination(timeout, timeUnit);
         } catch (InterruptedException e) {
-            // Ignore
+            Thread.currentThread().interrupt();
         }
     }
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/Network.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Network.java
@@ -22,13 +22,14 @@ import com.google.protobuf.InvalidProtocolBufferException;
  *
  * <h3>Chaincode events example</h3>
  * <pre>{@code
- *     Iterator<ChaincodeEvent> events = network.newChaincodeEventsRequest("basic")
- *             .startBlock(101)
- *             .build()
- *             .getEvents();
- *     events.forEachRemaining(event -> {
- *         // Process event
- *     });
+ *     ChaincodeEventsRequest request = network.newChaincodeEventsRequest("chaincodeName")
+ *             .startBlock(blockNumber)
+ *             .build();
+ *     try (CloseableIterator<ChaincodeEvent> events = request.getEvents()) {
+ *         events.forEachRemaining(event -> {
+ *             // Process event
+ *         });
+ *     }
  * }</pre>
  */
 public interface Network {

--- a/node/src/chaincodeevent.ts
+++ b/node/src/chaincodeevent.ts
@@ -4,28 +4,60 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { CloseableAsyncIterable } from './client';
 import { ChaincodeEventsResponse } from './protos/gateway/gateway_pb';
 import { ChaincodeEvent as ChaincodeEventProto } from './protos/peer/chaincode_event_pb';
 
+/**
+ * Chaincode event emitted by a transaction function.
+ */
 export interface ChaincodeEvent {
+    /**
+     * Block number that included this chaincode event.
+     */
     blockNumber: bigint;
+
+    /**
+     * Transaction that emitted this chaincode event.
+     */
     transactionId: string;
+
+    /**
+     * Chaincode that emitted this event.
+     */
     chaincodeId: string;
+
+    /**
+     * Name of the emitted event.
+     */
     eventName: string;
+
+    /**
+     * Application defined payload data associated with this event.
+     */
     payload: Uint8Array;
 }
 
-export function newChaincodeEvents(responses: AsyncIterable<ChaincodeEventsResponse>): AsyncIterable<ChaincodeEvent> {
+export function newChaincodeEvents(responses: CloseableAsyncIterable<ChaincodeEventsResponse>): CloseableAsyncIterable<ChaincodeEvent> {
+    let closed = false;
     return {
         async* [Symbol.asyncIterator]() { // eslint-disable-line @typescript-eslint/require-await
             for await (const response of responses) {
+                if (closed) {
+                    return;
+                }
+                
                 const blockNumber = BigInt(response.getBlockNumber() ?? 0);
                 const events = response.getEventsList() || [];
                 for (const event of events) {
                     yield newChaincodeEvent(blockNumber, event);
                 }
             }
-        }
+        },
+        close: () => {
+            closed = true;
+            responses.close();
+        },
     };
 }
 

--- a/node/src/chaincodeeventsrequest.ts
+++ b/node/src/chaincodeeventsrequest.ts
@@ -5,7 +5,7 @@
  */
 
 import { ChaincodeEvent, newChaincodeEvents } from './chaincodeevent';
-import { GatewayClient } from './client';
+import { CloseableAsyncIterable, GatewayClient } from './client';
 import { ChaincodeEventsRequest as ChaincodeEventsRequestProto, SignedChaincodeEventsRequest as SignedChaincodeEventsRequestProto } from './protos/gateway/gateway_pb';
 import { Signable } from './signable';
 import { SigningIdentity } from './signingidentity';
@@ -44,7 +44,7 @@ export interface ChaincodeEventsRequest extends Signable {
      * }
      * ```
      */
-     getEvents(): Promise<AsyncIterable<ChaincodeEvent>>;
+     getEvents(): Promise<CloseableAsyncIterable<ChaincodeEvent>>;
 }
 
 export interface ChaincodeEventsRequestOptions {
@@ -82,7 +82,7 @@ export class ChaincodeEventsRequestImpl implements ChaincodeEventsRequest {
         })();
     }
 
-    async getEvents(): Promise<AsyncIterable<ChaincodeEvent>> {
+    async getEvents(): Promise<CloseableAsyncIterable<ChaincodeEvent>> {
         await this.sign();
         const responses = this.#client.chaincodeEvents(this.#signedRequest);
         return newChaincodeEvents(responses);

--- a/node/src/client.test.ts
+++ b/node/src/client.test.ts
@@ -6,7 +6,7 @@
 
 /* eslint-disable jest/no-export */
 
-import { GatewayClient } from './client';
+import { CloseableAsyncIterable, GatewayClient } from './client';
 import { ChaincodeEventsResponse, CommitStatusResponse, EndorseRequest, EndorseResponse, EvaluateRequest, EvaluateResponse, SignedChaincodeEventsRequest, SignedCommitStatusRequest, SubmitRequest, SubmitResponse } from './protos/gateway/gateway_pb';
 
 export interface MockGatewayClient extends GatewayClient {
@@ -14,7 +14,7 @@ export interface MockGatewayClient extends GatewayClient {
     evaluate: jest.Mock<Promise<EvaluateResponse>, EvaluateRequest[]>,
     submit: jest.Mock<Promise<SubmitResponse>, SubmitRequest[]>,
     commitStatus: jest.Mock<Promise<CommitStatusResponse>, SignedCommitStatusRequest[]>,
-    chaincodeEvents: jest.Mock<AsyncIterable<ChaincodeEventsResponse>, SignedChaincodeEventsRequest[]>,
+    chaincodeEvents: jest.Mock<CloseableAsyncIterable<ChaincodeEventsResponse>, SignedChaincodeEventsRequest[]>,
 }
 
 export function newMockGatewayClient(): MockGatewayClient {
@@ -27,7 +27,8 @@ export function newMockGatewayClient(): MockGatewayClient {
             return {
                 async* [Symbol.asyncIterator]() {
                     // Nothing
-                }
+                },
+                close: jest.fn(),
             };
         }),
     };

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -53,7 +53,9 @@ import { Transaction, TransactionImpl } from './transaction';
  *     arguments: ['one', 'two']
  * });
  * const result = commit.getResult();
+ * 
  * // Update UI or reply to REST request before waiting for commit status
+ * 
  * const status = await commit.getStatus();
  * if (!status.successful) {
  *     throw new Error(`transaction ${status.transactionId} failed with status code ${status.code}`);

--- a/node/src/gateway.ts
+++ b/node/src/gateway.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import * as grpc from '@grpc/grpc-js';
+import { Client } from '@grpc/grpc-js';
 import { GatewayClient, newGatewayClient } from './client';
 import { Hash } from './hash/hash';
 import { Identity } from './identity/identity';
@@ -20,7 +20,7 @@ export interface ConnectOptions {
      * A gRPC client connection to a Fabric Gateway. This should be shared by all gateway instances connecting to the
      * same Fabric Gateway. The client connection will not be closed when the gateway is closed.
      */
-    client: grpc.Client;
+    client: Client;
 
     /**
      * Client identity used by the gateway.
@@ -50,7 +50,7 @@ export interface InternalConnectOptions {
  * It contains the address of the node as well as the error message it generated.
  */
 export interface ErrorDetail {
-    mspid: string;
+    mspId: string;
     address: string;
     message: string;
 }

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -7,6 +7,7 @@
 export { ChaincodeEvent } from './chaincodeevent';
 export { ChaincodeEventsOptions } from './chaincodeeventsbuilder';
 export { ChaincodeEventCallback, ChaincodeEventsRequest } from './chaincodeeventsrequest';
+export { CloseableAsyncIterable } from './client';
 export { Commit } from './commit';
 export { Contract } from './contract';
 export { connect, ConnectOptions, Gateway, GatewayError, ErrorDetail } from './gateway';

--- a/node/src/network.ts
+++ b/node/src/network.ts
@@ -7,7 +7,7 @@
 import { ChaincodeEvent } from './chaincodeevent';
 import { ChaincodeEventsBuilder, ChaincodeEventsOptions } from './chaincodeeventsbuilder';
 import { ChaincodeEventsRequest, ChaincodeEventsRequestImpl } from './chaincodeeventsrequest';
-import { GatewayClient } from './client';
+import { CloseableAsyncIterable, GatewayClient } from './client';
 import { Commit, CommitImpl } from './commit';
 import { Contract, ContractImpl } from './contract';
 import { ChaincodeEventsRequest as ChaincodeEventsRequestProto, CommitStatusRequest, SignedCommitStatusRequest } from './protos/gateway/gateway_pb';
@@ -47,12 +47,16 @@ export interface Network {
      * @example
      * ```
      * const events = await network.getChaincodeEvents(chaincodeId, { startBlock: BigInt(101) });
-     * for async (const event of events) {
-     *     // Process event
+     * try {
+     *     for async (const event of events) {
+     *         // Process event
+     *     }
+     * } finally {
+     *     events.close();
      * }
      * ```
      */
-    getChaincodeEvents(chaincodeId: string, options?: ChaincodeEventsOptions): Promise<AsyncIterable<ChaincodeEvent>>
+    getChaincodeEvents(chaincodeId: string, options?: ChaincodeEventsOptions): Promise<CloseableAsyncIterable<ChaincodeEvent>>
 
     newChaincodeEventsRequest(chaincodeId: string, options?: ChaincodeEventsOptions): ChaincodeEventsRequest;
     newSignedChaincodeEventsRequest(bytes: Uint8Array, signature: Uint8Array): ChaincodeEventsRequest;
@@ -104,7 +108,7 @@ export class NetworkImpl implements Network {
         return result;
     }
 
-    async getChaincodeEvents(chaincodeId: string, options?: ChaincodeEventsOptions): Promise<AsyncIterable<ChaincodeEvent>> {
+    async getChaincodeEvents(chaincodeId: string, options?: ChaincodeEventsOptions): Promise<CloseableAsyncIterable<ChaincodeEvent>> {
         return this.newChaincodeEventsRequest(chaincodeId, options).getEvents();
     }
 

--- a/samples/java/src/main/java/com/example/Sample.java
+++ b/samples/java/src/main/java/com/example/Sample.java
@@ -24,6 +24,7 @@ import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import org.hyperledger.fabric.client.ChaincodeEvent;
+import org.hyperledger.fabric.client.ChaincodeEventsRequest;
 import org.hyperledger.fabric.client.CloseableIterator;
 import org.hyperledger.fabric.client.CommitException;
 import org.hyperledger.fabric.client.Contract;
@@ -251,10 +252,10 @@ public class Sample {
         long blockNumber = status.getBlockNumber();
 
         System.out.println("Read chaincode events starting at block number " + blockNumber);
-        try (CloseableIterator<ChaincodeEvent> events = network.newChaincodeEventsRequest("basic")
+        ChaincodeEventsRequest request = network.newChaincodeEventsRequest("basic")
                 .startBlock(blockNumber)
-                .build()
-                .getEvents()) {
+                .build();
+        try (CloseableIterator<ChaincodeEvent> events = request.getEvents()) {
             ChaincodeEvent event = events.next();
             System.out.println("Received event name: " + event.getEventName() +
                     ", payload: " + new String(event.getPayload(), StandardCharsets.UTF_8) +

--- a/samples/node/src/sample.ts
+++ b/samples/node/src/sample.ts
@@ -221,10 +221,14 @@ async function exampleChaincodeEvents(gateway: Gateway) {
         startBlock: status.blockNumber,
     });
 
-    for await (const event of events) {
-        const payload = bytesAsString(event.payload);
-        console.log(`Received event name: ${event.eventName}, payload: ${payload}, txID: ${event.transactionId}`);
-        break;
+    try {
+        for await (const event of events) {
+            const payload = bytesAsString(event.payload);
+            console.log(`Received event name: ${event.eventName}, payload: ${payload}, txID: ${event.transactionId}`);
+            break;
+        }
+    } finally {
+        events.close();
     }
 }
 

--- a/scenario/node/src/scenario_steps.ts
+++ b/scenario/node/src/scenario_steps.ts
@@ -161,16 +161,16 @@ Then('the error details should be', function(this: CustomWorld, dataTable: DataT
     const expected: {[key: string]: ErrorDetail} = {};
     rows.forEach(row => {
         expected[row[0]] = {
-            mspid: row[0],
+            mspId: row[0],
             address: row[1],
             message: row[2]
         }
     })
     details!.forEach(detail => {
-        const ee = expected[detail.mspid];
+        const ee = expected[detail.mspId];
         expect(ee).toBeDefined();
         expect(detail.message).toContain(ee.message);
-        delete expected[detail.mspid];
+        delete expected[detail.mspId];
     })
     expect(Object.keys(expected)).toHaveLength(0);
 });


### PR DESCRIPTION
Add a close() method to the AsyncIterable returned when getting chancode events.

Contributes to #213