### PR TITLE
Refer to chaincodeName instead of chaincodeId in API

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEvent.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEvent.java
@@ -26,9 +26,9 @@ public interface ChaincodeEvent {
 
     /**
      * Chaincode that emitted this event.
-     * @return Chaincode ID.
+     * @return Chaincode name.
      */
-    String getChaincodeId();
+    String getChaincodeName();
 
     /**
      * Name of the emitted event.

--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventImpl.java
@@ -14,7 +14,7 @@ import org.hyperledger.fabric.protos.peer.ChaincodeEventPackage;
 final class ChaincodeEventImpl implements ChaincodeEvent {
     private final long blockNumber;
     private final String transactionId;
-    private final String chaincodeId;
+    private final String chaincodeName;
     private final String eventName;
     private final byte[] payload;
     private final int hash;
@@ -22,10 +22,10 @@ final class ChaincodeEventImpl implements ChaincodeEvent {
     ChaincodeEventImpl(final long blockNumber, final ChaincodeEventPackage.ChaincodeEvent event) {
         this.blockNumber = blockNumber;
         this.transactionId = event.getTxId();
-        this.chaincodeId = event.getChaincodeId();
+        this.chaincodeName = event.getChaincodeId();
         this.eventName = event.getEventName();
         this.payload = event.getPayload().toByteArray();
-        this.hash = Objects.hash(blockNumber, transactionId, chaincodeId, eventName); // Ignore potentially large payload; this is good enough
+        this.hash = Objects.hash(blockNumber, transactionId, chaincodeName, eventName); // Ignore potentially large payload; this is good enough
     }
 
     @Override
@@ -39,8 +39,8 @@ final class ChaincodeEventImpl implements ChaincodeEvent {
     }
 
     @Override
-    public String getChaincodeId() {
-        return chaincodeId;
+    public String getChaincodeName() {
+        return chaincodeName;
     }
 
     @Override
@@ -63,7 +63,7 @@ final class ChaincodeEventImpl implements ChaincodeEvent {
 
         return this.blockNumber == that.blockNumber
                 && Objects.equals(this.transactionId, that.transactionId)
-                && Objects.equals(this.chaincodeId, that.chaincodeId)
+                && Objects.equals(this.chaincodeName, that.chaincodeName)
                 && Objects.equals(this.eventName, that.eventName)
                 && Arrays.equals(this.payload, that.payload);
     }
@@ -78,7 +78,7 @@ final class ChaincodeEventImpl implements ChaincodeEvent {
         return GatewayUtils.toString(this,
                 "blockNumber: " + blockNumber,
                 "transactionId: " + transactionId,
-                "chaincodeId: " + chaincodeId,
+                "chaincodeName: " + chaincodeName,
                 "eventName: " + eventName,
                 "payload: " + Arrays.toString(payload));
     }

--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsBuilder.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsBuilder.java
@@ -16,19 +16,19 @@ final class ChaincodeEventsBuilder implements ChaincodeEventsRequest.Builder {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
     private final String channelName;
-    private final String chaincodeId;
+    private final String chaincodeName;
     private final Ab.SeekPosition.Builder startPositionBuilder = Ab.SeekPosition.newBuilder()
             .setNextCommit(Ab.SeekNextCommit.getDefaultInstance());
 
     ChaincodeEventsBuilder(final GatewayClient client, final SigningIdentity signingIdentity, final String channelName,
-                           final String chaincodeId) {
+                           final String chaincodeName) {
         Objects.requireNonNull(channelName, "channel name");
-        Objects.requireNonNull(chaincodeId, "chaincode ID");
+        Objects.requireNonNull(chaincodeName, "chaincode name");
 
         this.client = client;
         this.signingIdentity = signingIdentity;
         this.channelName = channelName;
-        this.chaincodeId = chaincodeId;
+        this.chaincodeName = chaincodeName;
     }
 
     @Override
@@ -40,22 +40,22 @@ final class ChaincodeEventsBuilder implements ChaincodeEventsRequest.Builder {
 
     @Override
     public ChaincodeEventsRequest build() {
-        SignedChaincodeEventsRequest signedRequest = newSignedChaincodeEventsRequestProto(chaincodeId);
+        SignedChaincodeEventsRequest signedRequest = newSignedChaincodeEventsRequestProto(chaincodeName);
         return new ChaincodeEventsRequestImpl(client, signingIdentity, signedRequest);
     }
 
-    private SignedChaincodeEventsRequest newSignedChaincodeEventsRequestProto(final String chaincodeId) {
-        org.hyperledger.fabric.protos.gateway.ChaincodeEventsRequest request = newChaincodeEventsRequestProto(chaincodeId);
+    private SignedChaincodeEventsRequest newSignedChaincodeEventsRequestProto(final String chaincodeName) {
+        org.hyperledger.fabric.protos.gateway.ChaincodeEventsRequest request = newChaincodeEventsRequestProto(chaincodeName);
         return SignedChaincodeEventsRequest.newBuilder()
                 .setRequest(request.toByteString())
                 .build();
     }
 
-    private org.hyperledger.fabric.protos.gateway.ChaincodeEventsRequest newChaincodeEventsRequestProto(final String chaincodeId) {
+    private org.hyperledger.fabric.protos.gateway.ChaincodeEventsRequest newChaincodeEventsRequestProto(final String chaincodeName) {
         ByteString creator = ByteString.copyFrom(signingIdentity.getCreator());
         return org.hyperledger.fabric.protos.gateway.ChaincodeEventsRequest.newBuilder()
                 .setChannelId(channelName)
-                .setChaincodeId(chaincodeId)
+                .setChaincodeId(chaincodeName)
                 .setIdentity(creator)
                 .setStartPosition(startPositionBuilder.build())
                 .build();

--- a/java/src/main/java/org/hyperledger/fabric/client/Contract.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Contract.java
@@ -111,10 +111,10 @@ import com.google.protobuf.InvalidProtocolBufferException;
  */
 public interface Contract {
     /**
-     * Get the identifier of the chaincode that contains the smart contract.
-     * @return Chaincode ID.
+     * Get the name of the chaincode that contains the smart contract.
+     * @return Chaincode name.
      */
-    String getChaincodeId();
+    String getChaincodeName();
 
     /**
      * Get the name of the smart contract within the chaincode. An empty value indicates that this Contract refers to

--- a/java/src/main/java/org/hyperledger/fabric/client/ContractImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ContractImpl.java
@@ -17,21 +17,21 @@ final class ContractImpl implements Contract {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
     private final String channelName;
-    private final String chaincodeId;
+    private final String chaincodeName;
     private final String contractName;
 
-    ContractImpl(final GatewayClient client, final SigningIdentity signingIdentity, final String channelName, final String chaincodeId) {
-        this(client, signingIdentity, channelName, chaincodeId, null);
+    ContractImpl(final GatewayClient client, final SigningIdentity signingIdentity, final String channelName, final String chaincodeName) {
+        this(client, signingIdentity, channelName, chaincodeName, null);
     }
 
     ContractImpl(final GatewayClient client, final SigningIdentity signingIdentity,
-                 final String channelName, final String chaincodeId, final String contractName) {
-        Objects.requireNonNull(chaincodeId, "chaincode ID");
+                 final String channelName, final String chaincodeName, final String contractName) {
+        Objects.requireNonNull(chaincodeName, "chaincode name");
 
         this.client = client;
         this.signingIdentity = signingIdentity;
         this.channelName = channelName;
-        this.chaincodeId = chaincodeId;
+        this.chaincodeName = chaincodeName;
         this.contractName = contractName;
     }
 
@@ -87,7 +87,7 @@ final class ContractImpl implements Contract {
     @Override
     public Proposal.Builder newProposal(final String transactionName) {
         String qualifiedTxName = qualifiedTransactionName(transactionName);
-        return new ProposalBuilder(client, signingIdentity, channelName, chaincodeId, qualifiedTxName);
+        return new ProposalBuilder(client, signingIdentity, channelName, chaincodeName, qualifiedTxName);
     }
 
     @Override
@@ -109,8 +109,8 @@ final class ContractImpl implements Contract {
     }
 
     @Override
-    public String getChaincodeId() {
-        return chaincodeId;
+    public String getChaincodeName() {
+        return chaincodeName;
     }
 
     @Override

--- a/java/src/main/java/org/hyperledger/fabric/client/Network.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Network.java
@@ -44,22 +44,22 @@ import com.google.protobuf.InvalidProtocolBufferException;
 public interface Network {
     /**
      * Get an instance of a contract on the current network.
-     * @param chaincodeId The name of the chaincode that implements the smart contract.
+     * @param chaincodeName The name of the chaincode that implements the smart contract.
      * @return The contract object.
-     * @throws NullPointerException if the chaincode ID is null.
+     * @throws NullPointerException if the chaincode name is null.
      */
-    Contract getContract(String chaincodeId);
+    Contract getContract(String chaincodeName);
 
     /**
      * Get an instance of a contract on the current network.  If the chaincode instance contains more
      * than one smart contract class (available using the latest chaincode programming model), then an
      * individual class can be selected.
-     * @param chaincodeId The name of the chaincode that implements the smart contract.
+     * @param chaincodeName The name of the chaincode that implements the smart contract.
      * @param contractName The name of the smart contract within the chaincode.
      * @return The contract object.
-     * @throws NullPointerException if the chaincode ID is null.
+     * @throws NullPointerException if the chaincode name is null.
      */
-    Contract getContract(String chaincodeId, String contractName);
+    Contract getContract(String chaincodeName, String contractName);
 
     /**
      * Get the name of the network channel.
@@ -82,21 +82,21 @@ public interface Network {
      * implementation may not begin reading events until the first use of the returned iterator.
      * <p>Note that the returned iterator may throw {@link io.grpc.StatusRuntimeException} during iteration if a gRPC connection error
      * occurs.</p>
-     * @param chaincodeId A chaincode ID.
+     * @param chaincodeName A chaincode name.
      * @return Ordered sequence of events.
-     * @throws NullPointerException if the chaincode ID is null.
+     * @throws NullPointerException if the chaincode name is null.
      * @see #newChaincodeEventsRequest(String)
      */
-    CloseableIterator<ChaincodeEvent> getChaincodeEvents(String chaincodeId);
+    CloseableIterator<ChaincodeEvent> getChaincodeEvents(String chaincodeName);
 
     /**
      * Build a new chaincode events request, which can be used to obtain events emitted by transaction functions of a
      * specific chaincode. This can be used to specify a specific ledger start position. Supports offline signing flow.
-     * @param chaincodeId A chaincode ID.
+     * @param chaincodeName A chaincode name.
      * @return A chaincode events request builder.
-     * @throws NullPointerException if the chaincode ID is null.
+     * @throws NullPointerException if the chaincode name is null.
      */
-    ChaincodeEventsRequest.Builder newChaincodeEventsRequest(String chaincodeId);
+    ChaincodeEventsRequest.Builder newChaincodeEventsRequest(String chaincodeName);
 
     /**
      * Create a chaincode events request with the specified digital signature, which can be used to obtain events

--- a/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
@@ -27,13 +27,13 @@ final class NetworkImpl implements Network {
     }
 
     @Override
-    public Contract getContract(final String chaincodeId, final String contractName) {
-        return new ContractImpl(client, signingIdentity, contractName, chaincodeId, contractName);
+    public Contract getContract(final String chaincodeName, final String contractName) {
+        return new ContractImpl(client, signingIdentity, contractName, chaincodeName, contractName);
     }
 
     @Override
-    public Contract getContract(final String chaincodeId) {
-        return new ContractImpl(client, signingIdentity, channelName, chaincodeId);
+    public Contract getContract(final String chaincodeName) {
+        return new ContractImpl(client, signingIdentity, channelName, chaincodeName);
     }
 
     @Override
@@ -52,13 +52,13 @@ final class NetworkImpl implements Network {
     }
 
     @Override
-    public CloseableIterator<ChaincodeEvent> getChaincodeEvents(final String chaincodeId) {
-        return newChaincodeEventsRequest(chaincodeId).build().getEvents();
+    public CloseableIterator<ChaincodeEvent> getChaincodeEvents(final String chaincodeName) {
+        return newChaincodeEventsRequest(chaincodeName).build().getEvents();
     }
 
     @Override
-    public ChaincodeEventsRequest.Builder newChaincodeEventsRequest(final String chaincodeId) {
-        return new ChaincodeEventsBuilder(client, signingIdentity, channelName, chaincodeId);
+    public ChaincodeEventsRequest.Builder newChaincodeEventsRequest(final String chaincodeName) {
+        return new ChaincodeEventsBuilder(client, signingIdentity, channelName, chaincodeName);
     }
 
     @Override

--- a/java/src/main/java/org/hyperledger/fabric/client/ProposalBuilder.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ProposalBuilder.java
@@ -31,12 +31,12 @@ final class ProposalBuilder implements Proposal.Builder {
     private Set<String> endorsingOrgs = Collections.emptySet();
 
     ProposalBuilder(final GatewayClient client, final SigningIdentity signingIdentity,
-                    final String channelName, final String chaincodeId, final String transactionName) {
+                    final String channelName, final String chaincodeName, final String transactionName) {
         this.client = client;
         this.signingIdentity = signingIdentity;
         this.channelName = channelName;
         this.chaincodeId = Chaincode.ChaincodeID.newBuilder()
-                .setName(chaincodeId)
+                .setName(chaincodeName)
                 .build();
 
         inputBuilder.addArgs(ByteString.copyFrom(transactionName, StandardCharsets.UTF_8));

--- a/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
@@ -53,10 +53,10 @@ public final class ChaincodeEventsTest {
     }
 
     @Test
-    void throws_NullPointerException_on_null_chaincode_ID() {
+    void throws_NullPointerException_on_null_CHAINCODE_NAME() {
         assertThatThrownBy(() -> network.getChaincodeEvents(null))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("chaincode ID");
+                .hasMessageContaining("chaincode name");
     }
 
     @Test
@@ -64,7 +64,7 @@ public final class ChaincodeEventsTest {
         doThrow(new StatusRuntimeException(Status.UNAVAILABLE)).when(stub).chaincodeEvents(any());
 
         assertThatThrownBy(() -> {
-            try (CloseableIterator<ChaincodeEvent> events = network.getChaincodeEvents("CHAINCODE_ID")) {
+            try (CloseableIterator<ChaincodeEvent> events = network.getChaincodeEvents("CHAINCODE_NAME")) {
                 events.forEachRemaining(event -> {});
             }
         }).isInstanceOf(StatusRuntimeException.class);
@@ -72,7 +72,7 @@ public final class ChaincodeEventsTest {
 
     @Test
     void sends_valid_request_with_default_start_position() throws Exception {
-        try (CloseableIterator<ChaincodeEvent> iter = network.getChaincodeEvents("CHAINCODE_ID")) {
+        try (CloseableIterator<ChaincodeEvent> iter = network.getChaincodeEvents("CHAINCODE_NAME")) {
             // Need to interact with iterator before asserting to ensure async request has been made
             iter.forEachRemaining(event -> {});
         }
@@ -81,7 +81,7 @@ public final class ChaincodeEventsTest {
         ChaincodeEventsRequest request = ChaincodeEventsRequest.parseFrom(signedRequest.getRequest());
 
         assertThat(request.getChannelId()).isEqualTo("NETWORK");
-        assertThat(request.getChaincodeId()).isEqualTo("CHAINCODE_ID");
+        assertThat(request.getChaincodeId()).isEqualTo("CHAINCODE_NAME");
 
         assertThat(request.getStartPosition().getTypeCase()).isEqualTo(Ab.SeekPosition.TypeCase.NEXT_COMMIT);
     }
@@ -89,7 +89,7 @@ public final class ChaincodeEventsTest {
     @Test
     void sends_valid_request_with_specified_start_block_number() throws Exception {
         long startBlock = 101;
-        org.hyperledger.fabric.client.ChaincodeEventsRequest eventsRequest = network.newChaincodeEventsRequest("CHAINCODE_ID")
+        org.hyperledger.fabric.client.ChaincodeEventsRequest eventsRequest = network.newChaincodeEventsRequest("CHAINCODE_NAME")
                 .startBlock(startBlock)
                 .build();
 
@@ -102,7 +102,7 @@ public final class ChaincodeEventsTest {
         ChaincodeEventsRequest request = ChaincodeEventsRequest.parseFrom(signedRequest.getRequest());
 
         assertThat(request.getChannelId()).isEqualTo("NETWORK");
-        assertThat(request.getChaincodeId()).isEqualTo("CHAINCODE_ID");
+        assertThat(request.getChaincodeId()).isEqualTo("CHAINCODE_NAME");
 
         assertThat(request.getStartPosition().getTypeCase()).isEqualTo(Ab.SeekPosition.TypeCase.SPECIFIED);
         assertThat(request.getStartPosition().getSpecified().getNumber()).isEqualTo(startBlock);
@@ -111,7 +111,7 @@ public final class ChaincodeEventsTest {
     @Test
     void sends_valid_request_with_specified_start_block_number_using_sign_bit_for_unsigned_64bit_value() throws Exception {
         long startBlock = -1;
-        org.hyperledger.fabric.client.ChaincodeEventsRequest eventsRequest = network.newChaincodeEventsRequest("CHAINCODE_ID")
+        org.hyperledger.fabric.client.ChaincodeEventsRequest eventsRequest = network.newChaincodeEventsRequest("CHAINCODE_NAME")
                 .startBlock(startBlock)
                 .build();
 
@@ -124,7 +124,7 @@ public final class ChaincodeEventsTest {
         ChaincodeEventsRequest request = ChaincodeEventsRequest.parseFrom(signedRequest.getRequest());
 
         assertThat(request.getChannelId()).isEqualTo("NETWORK");
-        assertThat(request.getChaincodeId()).isEqualTo("CHAINCODE_ID");
+        assertThat(request.getChaincodeId()).isEqualTo("CHAINCODE_NAME");
 
         assertThat(request.getStartPosition().getTypeCase()).isEqualTo(Ab.SeekPosition.TypeCase.SPECIFIED);
         assertThat(request.getStartPosition().getSpecified().getNumber()).isEqualTo(startBlock);
@@ -133,19 +133,19 @@ public final class ChaincodeEventsTest {
     @Test
     void returns_events() {
         ChaincodeEventPackage.ChaincodeEvent event1 = ChaincodeEventPackage.ChaincodeEvent.newBuilder()
-                .setChaincodeId("CHAINCODE_ID")
+                .setChaincodeId("CHAINCODE_NAME")
                 .setTxId("tx1")
                 .setEventName("event1")
                 .setPayload(ByteString.copyFromUtf8("payload1"))
                 .build();
         ChaincodeEventPackage.ChaincodeEvent event2 = ChaincodeEventPackage.ChaincodeEvent.newBuilder()
-                .setChaincodeId("CHAINCODE_ID")
+                .setChaincodeId("CHAINCODE_NAME")
                 .setTxId("tx2")
                 .setEventName("event2")
                 .setPayload(ByteString.copyFromUtf8("payload2"))
                 .build();
         ChaincodeEventPackage.ChaincodeEvent event3 = ChaincodeEventPackage.ChaincodeEvent.newBuilder()
-                .setChaincodeId("CHAINCODE_ID")
+                .setChaincodeId("CHAINCODE_NAME")
                 .setTxId("tx3")
                 .setEventName("event3")
                 .setPayload(ByteString.copyFromUtf8("payload3"))
@@ -164,7 +164,7 @@ public final class ChaincodeEventsTest {
         );
         doReturn(responses).when(stub).chaincodeEvents(any());
 
-        try (CloseableIterator<ChaincodeEvent> actual = network.getChaincodeEvents("CHAINCODE_ID")) {
+        try (CloseableIterator<ChaincodeEvent> actual = network.getChaincodeEvents("CHAINCODE_NAME")) {
             List<ChaincodeEvent> expected = Arrays.asList(
                     new ChaincodeEventImpl(1, event1),
                     new ChaincodeEventImpl(1, event2),
@@ -177,13 +177,13 @@ public final class ChaincodeEventsTest {
     @Test
     void close_stops_receiving_events() {
         ChaincodeEventPackage.ChaincodeEvent event1 = ChaincodeEventPackage.ChaincodeEvent.newBuilder()
-                .setChaincodeId("CHAINCODE_ID")
+                .setChaincodeId("CHAINCODE_NAME")
                 .setTxId("tx1")
                 .setEventName("event1")
                 .setPayload(ByteString.copyFromUtf8("payload1"))
                 .build();
         ChaincodeEventPackage.ChaincodeEvent event2 = ChaincodeEventPackage.ChaincodeEvent.newBuilder()
-                .setChaincodeId("CHAINCODE_ID")
+                .setChaincodeId("CHAINCODE_NAME")
                 .setTxId("tx2")
                 .setEventName("event2")
                 .setPayload(ByteString.copyFromUtf8("payload2"))
@@ -201,7 +201,7 @@ public final class ChaincodeEventsTest {
         );
         doReturn(responses).when(stub).chaincodeEvents(any());
 
-        CloseableIterator<ChaincodeEvent> eventIter = network.getChaincodeEvents("CHAINCODE_ID");
+        CloseableIterator<ChaincodeEvent> eventIter = network.getChaincodeEvents("CHAINCODE_NAME");
         ChaincodeEvent event = eventIter.next();
         assertThat(event).isEqualTo(new ChaincodeEventImpl(1, event1));
 

--- a/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
@@ -58,7 +58,7 @@ public final class EvaluateTransactionTest {
 
     @Test
     void throws_NullPointerException_on_null_transaction_name() {
-        Contract contract = network.getContract("CHAINCODE_ID", "CONTRACT_NAME");
+        Contract contract = network.getContract("CHAINCODE_NAME", "CONTRACT_NAME");
 
         assertThatThrownBy(() -> contract.evaluateTransaction(null))
                 .isInstanceOf(NullPointerException.class)
@@ -70,26 +70,26 @@ public final class EvaluateTransactionTest {
         doReturn(utils.newEvaluateResponse("MY_RESULT"))
                 .when(stub).evaluate(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         byte[] actual = contract.evaluateTransaction("TRANSACTION_NAME");
 
         assertThat(actual).asString(StandardCharsets.UTF_8).isEqualTo("MY_RESULT");
     }
 
     @Test
-    void sends_chaincode_ID() throws InvalidProtocolBufferException {
-        Contract contract = network.getContract("MY_CHAINCODE_ID");
+    void sends_chaincode_name() throws InvalidProtocolBufferException {
+        Contract contract = network.getContract("MY_CHAINCODE_NAME");
         contract.evaluateTransaction("TRANSACTION_NAME");
 
         EvaluateRequest request = mocker.captureEvaluate();
         String actual = mocker.getChaincodeSpec(request.getProposedTransaction()).getChaincodeId().getName();
 
-        assertThat(actual).isEqualTo("MY_CHAINCODE_ID");
+        assertThat(actual).isEqualTo("MY_CHAINCODE_NAME");
     }
 
     @Test
     void sends_transaction_name_for_default_contract() throws InvalidProtocolBufferException {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.evaluateTransaction("MY_TRANSACTION_NAME");
 
         EvaluateRequest request = mocker.captureEvaluate();
@@ -102,7 +102,7 @@ public final class EvaluateTransactionTest {
 
     @Test
     void sends_transaction_name_for_specified_contract() throws InvalidProtocolBufferException {
-        Contract contract = network.getContract("CHAINCODE_ID", "MY_CONTRACT");
+        Contract contract = network.getContract("CHAINCODE_NAME", "MY_CONTRACT");
         contract.evaluateTransaction("MY_TRANSACTION_NAME");
 
         EvaluateRequest request = mocker.captureEvaluate();
@@ -115,7 +115,7 @@ public final class EvaluateTransactionTest {
 
     @Test
     void sends_transaction_string_arguments() throws InvalidProtocolBufferException {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.evaluateTransaction("TRANSACTION_NAME", "one", "two", "three");
 
         EvaluateRequest request = mocker.captureEvaluate();
@@ -132,7 +132,7 @@ public final class EvaluateTransactionTest {
         byte[][] arguments = Stream.of("one", "two", "three")
                 .map(s -> s.getBytes(StandardCharsets.UTF_8))
                 .toArray(byte[][]::new);
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.evaluateTransaction("TRANSACTION_NAME", arguments);
 
         EvaluateRequest request = mocker.captureEvaluate();
@@ -150,7 +150,7 @@ public final class EvaluateTransactionTest {
         try (Gateway gateway = mocker.getGatewayBuilder().signer(signer).connect()) {
             network = gateway.getNetwork("NETWORK");
 
-            Contract contract = network.getContract("CHAINCODE_ID");
+            Contract contract = network.getContract("CHAINCODE_NAME");
             contract.evaluateTransaction("TRANSACTION_NAME");
 
             EvaluateRequest request = mocker.captureEvaluate();
@@ -172,7 +172,7 @@ public final class EvaluateTransactionTest {
         try (Gateway gateway = mocker.getGatewayBuilder().hash(hash).signer(signer).connect()) {
             network = gateway.getNetwork("NETWORK");
 
-            Contract contract = network.getContract("CHAINCODE_ID");
+            Contract contract = network.getContract("CHAINCODE_NAME");
             contract.evaluateTransaction("TRANSACTION_NAME");
 
             assertThat(actual.get()).isEqualTo("MY_DIGEST");
@@ -183,7 +183,7 @@ public final class EvaluateTransactionTest {
     void throws_on_connection_error() {
         doThrow(new StatusRuntimeException(Status.UNAVAILABLE)).when(stub).evaluate(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
 
         assertThatThrownBy(() -> contract.evaluateTransaction("TRANSACTION_NAME"))
                 .isInstanceOf(StatusRuntimeException.class);
@@ -195,7 +195,7 @@ public final class EvaluateTransactionTest {
         try (Gateway gateway = mocker.getGatewayBuilder().identity(identity).connect()) {
             network = gateway.getNetwork("NETWORK");
 
-            Contract contract = network.getContract("CHAINCODE_ID");
+            Contract contract = network.getContract("CHAINCODE_NAME");
             contract.evaluateTransaction("TRANSACTION_NAME");
 
             EvaluateRequest request = mocker.captureEvaluate();
@@ -210,7 +210,7 @@ public final class EvaluateTransactionTest {
     void sends_network_name_in_proposal() throws InvalidProtocolBufferException {
         network = gateway.getNetwork("MY_NETWORK");
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.evaluateTransaction("TRANSACTION_NAME");
 
         EvaluateRequest request = mocker.captureEvaluate();
@@ -223,7 +223,7 @@ public final class EvaluateTransactionTest {
     void sends_network_name_in_proposed_transaction() {
         network = gateway.getNetwork("MY_NETWORK");
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.evaluateTransaction("TRANSACTION_NAME");
 
         EvaluateRequest request = mocker.captureEvaluate();
@@ -235,7 +235,7 @@ public final class EvaluateTransactionTest {
     @Test
     void sends_transaction_ID_in_proposed_transaction() throws InvalidProtocolBufferException {
         network = gateway.getNetwork("MY_NETWORK");
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Proposal proposal = contract.newProposal("TRANSACTION_NAME").build();
 
         proposal.evaluate();
@@ -251,7 +251,7 @@ public final class EvaluateTransactionTest {
 
     @Test
     void sends_byte_array_transient_data() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.newProposal("TRANSACTION_NAME")
                 .putTransient("uno", "one".getBytes(StandardCharsets.UTF_8))
                 .putTransient("dos", "two".getBytes(StandardCharsets.UTF_8))
@@ -267,7 +267,7 @@ public final class EvaluateTransactionTest {
 
     @Test
     void sends_string_transient_data() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.newProposal("TRANSACTION_NAME")
                 .putTransient("uno", "one")
                 .putTransient("dos", "two")
@@ -283,7 +283,7 @@ public final class EvaluateTransactionTest {
 
     @Test
     void sets_endorsing_orgs() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.newProposal("TRANSACTION_NAME")
                 .setEndorsingOrganizations("Org1MSP", "Org3MSP")
                 .build()
@@ -296,7 +296,7 @@ public final class EvaluateTransactionTest {
 
     @Test
     void sets_endorsing_orgs_offline_signing() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME")
                 .setEndorsingOrganizations("Org1MSP", "Org3MSP")
                 .build();

--- a/java/src/test/java/org/hyperledger/fabric/client/GatewayServiceStub.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/GatewayServiceStub.java
@@ -52,7 +52,7 @@ public class GatewayServiceStub {
     }
 
     private String newPayload(SignedProposal requestProposal) {
-        // create a mock payload string by concatenating the chaincode id, tx name and arguments from the request
+        // create a mock payload string by concatenating the chaincode name, tx name and arguments from the request
         try {
             ProposalPackage.Proposal proposal = ProposalPackage.Proposal.parseFrom(requestProposal.getProposalBytes());
             ProposalPackage.ChaincodeProposalPayload chaincodeProposalPayload = ProposalPackage.ChaincodeProposalPayload.parseFrom(proposal.getPayload());

--- a/java/src/test/java/org/hyperledger/fabric/client/NetworkTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/NetworkTest.java
@@ -38,23 +38,23 @@ public final class NetworkTest {
     }
 
     @Test
-    void getContract_using_only_chaincode_ID_returns_correctly_named_Contract() {
-        Contract contract = network.getContract("CHAINCODE_ID");
-        assertThat(contract.getChaincodeId()).isEqualTo("CHAINCODE_ID");
+    void getContract_using_only_chaincode_name_returns_correctly_named_Contract() {
+        Contract contract = network.getContract("CHAINCODE_NAME");
+        assertThat(contract.getChaincodeName()).isEqualTo("CHAINCODE_NAME");
         assertThat(contract.getContractName()).isEmpty();
     }
 
     @Test
     void getContract_using_contract_name_returns_correctly_named_Contract() {
-        Contract contract = network.getContract("CHAINCODE_ID", "CONTRACT");
-        assertThat(contract.getChaincodeId()).isEqualTo("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME", "CONTRACT");
+        assertThat(contract.getChaincodeName()).isEqualTo("CHAINCODE_NAME");
         assertThat(contract.getContractName()).get().isEqualTo("CONTRACT");
     }
 
     @Test
-    void getContract_throws_NullPointerException_on_null_chaincode_ID() {
+    void getContract_throws_NullPointerException_on_null_chaincode_name() {
         assertThatThrownBy(() -> network.getContract(null))
                 .isInstanceOf(NullPointerException.class)
-                .hasMessageContaining("chaincode ID");
+                .hasMessageContaining("chaincode name");
     }
 }

--- a/java/src/test/java/org/hyperledger/fabric/client/OfflineSignTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/OfflineSignTest.java
@@ -36,7 +36,7 @@ public final class OfflineSignTest {
         mocker = new GatewayMocker(newBuilderWithoutSigner());
         gateway = mocker.getGatewayBuilder().connect();
         network = gateway.getNetwork("NETWORK");
-        contract = network.getContract("CHAINCODE_ID");
+        contract = network.getContract("CHAINCODE_NAME");
     }
 
     private Gateway.Builder newBuilderWithoutSigner() {
@@ -243,7 +243,7 @@ public final class OfflineSignTest {
     void chaincode_events_uses_offline_signature() throws Exception {
         byte[] expected = "MY_SIGNATURE".getBytes(StandardCharsets.UTF_8);
 
-        ChaincodeEventsRequest unsignedRequest = network.newChaincodeEventsRequest("CHAINCODE_ID").build();
+        ChaincodeEventsRequest unsignedRequest = network.newChaincodeEventsRequest("CHAINCODE_NAME").build();
         ChaincodeEventsRequest signedRequest = network.newSignedChaincodeEventsRequest(unsignedRequest.getBytes(), expected);
         try (CloseableIterator<ChaincodeEvent> iter = signedRequest.getEvents()) {
             // Need to interact with iterator before asserting to ensure async request has been made
@@ -258,7 +258,7 @@ public final class OfflineSignTest {
 
     @Test
     void signed_chaincode_events_keep_same_digest() throws Exception {
-        ChaincodeEventsRequest unsignedRequest = network.newChaincodeEventsRequest("CHAINCODE_ID").build();
+        ChaincodeEventsRequest unsignedRequest = network.newChaincodeEventsRequest("CHAINCODE_NAME").build();
         byte[] expected = unsignedRequest.getDigest();
 
         ChaincodeEventsRequest signedRequest = network.newSignedChaincodeEventsRequest(unsignedRequest.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));

--- a/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
@@ -62,7 +62,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void throws_NullPointerException_on_null_transaction_name() {
-        Contract contract = network.getContract("CHAINCODE_ID", "CONTRACT_NAME");
+        Contract contract = network.getContract("CHAINCODE_NAME", "CONTRACT_NAME");
 
         assertThatThrownBy(() -> contract.submitTransaction(null))
                 .isInstanceOf(NullPointerException.class)
@@ -74,26 +74,26 @@ public final class SubmitTransactionTest {
         doReturn(utils.newEndorseResponse("MY_RESULT"))
                 .when(stub).endorse(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         byte[] actual = contract.submitTransaction("TRANSACTION_NAME");
 
         assertThat(actual).asString(StandardCharsets.UTF_8).isEqualTo("MY_RESULT");
     }
 
     @Test
-    void sends_chaincode_ID() throws Exception {
-        Contract contract = network.getContract("MY_CHAINCODE_ID");
+    void sends_chaincode_name() throws Exception {
+        Contract contract = network.getContract("MY_CHAINCODE_NAME");
         contract.submitTransaction("TRANSACTION_NAME");
 
         EndorseRequest request = mocker.captureEndorse();
         String actual = mocker.getChaincodeSpec(request.getProposedTransaction()).getChaincodeId().getName();
 
-        assertThat(actual).isEqualTo("MY_CHAINCODE_ID");
+        assertThat(actual).isEqualTo("MY_CHAINCODE_NAME");
     }
 
     @Test
     void sends_transaction_name_for_default_contract() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.submitTransaction("MY_TRANSACTION_NAME");
 
         EndorseRequest request = mocker.captureEndorse();
@@ -106,7 +106,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void sends_transaction_name_for_specified_contract() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID", "MY_CONTRACT");
+        Contract contract = network.getContract("CHAINCODE_NAME", "MY_CONTRACT");
         contract.submitTransaction("MY_TRANSACTION_NAME");
 
         EndorseRequest request = mocker.captureEndorse();
@@ -119,7 +119,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void sends_transaction_string_arguments() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.submitTransaction("TRANSACTION_NAME", "one", "two", "three");
 
         EndorseRequest request = mocker.captureEndorse();
@@ -136,7 +136,7 @@ public final class SubmitTransactionTest {
         byte[][] arguments = Stream.of("one", "two", "three")
                 .map(s -> s.getBytes(StandardCharsets.UTF_8))
                 .toArray(byte[][]::new);
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.submitTransaction("TRANSACTION_NAME", arguments);
 
         EndorseRequest request = mocker.captureEndorse();
@@ -150,7 +150,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void sends_transient_data() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.newProposal("TRANSACTION_NAME")
                 .putTransient("uno", "one".getBytes(StandardCharsets.UTF_8))
                 .putTransient("dos", "two".getBytes(StandardCharsets.UTF_8))
@@ -167,7 +167,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void sets_endorsing_orgs() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.newProposal("TRANSACTION_NAME")
                 .setEndorsingOrganizations("Org1MSP", "Org3MSP")
                 .build()
@@ -181,7 +181,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void sets_endorsing_orgs_offline_signing() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME")
                 .setEndorsingOrganizations("Org1MSP", "Org3MSP")
                 .build();
@@ -199,7 +199,7 @@ public final class SubmitTransactionTest {
         try (Gateway gateway = mocker.getGatewayBuilder().signer(signer).connect()) {
             network = gateway.getNetwork("NETWORK");
 
-            Contract contract = network.getContract("CHAINCODE_ID");
+            Contract contract = network.getContract("CHAINCODE_NAME");
             contract.submitTransaction("TRANSACTION_NAME");
 
             EndorseRequest request = mocker.captureEndorse();
@@ -215,7 +215,7 @@ public final class SubmitTransactionTest {
         try (Gateway gateway = mocker.getGatewayBuilder().identity(identity).connect()) {
             network = gateway.getNetwork("NETWORK");
 
-            Contract contract = network.getContract("CHAINCODE_ID");
+            Contract contract = network.getContract("CHAINCODE_NAME");
             contract.submitTransaction("TRANSACTION_NAME");
 
             EndorseRequest request = mocker.captureEndorse();
@@ -230,7 +230,7 @@ public final class SubmitTransactionTest {
     void sends_network_name_in_proposal() throws Exception {
         network = gateway.getNetwork("MY_NETWORK");
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.submitTransaction("TRANSACTION_NAME");
 
         EndorseRequest request = mocker.captureEndorse();
@@ -243,7 +243,7 @@ public final class SubmitTransactionTest {
     void sends_network_name_in_proposed_transaction() throws Exception {
         network = gateway.getNetwork("MY_NETWORK");
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.submitTransaction("TRANSACTION_NAME");
 
         EndorseRequest request = mocker.captureEndorse();
@@ -255,7 +255,7 @@ public final class SubmitTransactionTest {
     @Test
     void sends_transaction_ID_in_proposed_transaction() throws Exception {
         network = gateway.getNetwork("MY_NETWORK");
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
 
         Proposal proposal = contract.newProposal("TRANSACTION_NAME").build();
         proposal.endorse().submit();
@@ -272,7 +272,7 @@ public final class SubmitTransactionTest {
     @Test
     void proposals_built_by_same_builder_have_different_transaction_IDs() {
         network = gateway.getNetwork("MY_NETWORK");
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Proposal.Builder builder = contract.newProposal("TRANSACTION_NAME");
 
         Proposal proposal1 = builder.build();
@@ -287,7 +287,7 @@ public final class SubmitTransactionTest {
         try (Gateway gateway = mocker.getGatewayBuilder().signer(signer).connect()) {
             network = gateway.getNetwork("NETWORK");
 
-            Contract contract = network.getContract("CHAINCODE_ID");
+            Contract contract = network.getContract("CHAINCODE_NAME");
             contract.submitTransaction("TRANSACTION_NAME");
 
             SubmitRequest request = mocker.captureSubmit();
@@ -309,7 +309,7 @@ public final class SubmitTransactionTest {
         try (Gateway gateway = mocker.getGatewayBuilder().hash(hash).signer(signer).connect()) {
             network = gateway.getNetwork("NETWORK");
 
-            Contract contract = network.getContract("CHAINCODE_ID");
+            Contract contract = network.getContract("CHAINCODE_NAME");
             contract.submitTransaction("TRANSACTION_NAME");
 
             assertThat(actual).hasSameElementsAs(Arrays.asList("MY_DIGEST", "MY_DIGEST"));
@@ -320,7 +320,7 @@ public final class SubmitTransactionTest {
     void throws_on_endorse_connection_error() {
         doThrow(new StatusRuntimeException(io.grpc.Status.UNAVAILABLE)).when(stub).endorse(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
 
         assertThatThrownBy(() -> contract.submitTransaction("TRANSACTION_NAME"))
                 .isInstanceOf(StatusRuntimeException.class);
@@ -330,7 +330,7 @@ public final class SubmitTransactionTest {
     void throws_on_submit_connection_error() {
         doThrow(new StatusRuntimeException(io.grpc.Status.UNAVAILABLE)).when(stub).submit(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
 
         assertThatThrownBy(() -> contract.submitTransaction("TRANSACTION_NAME"))
                 .isInstanceOf(StatusRuntimeException.class);
@@ -341,7 +341,7 @@ public final class SubmitTransactionTest {
         doReturn(utils.newCommitStatusResponse(TxValidationCode.MVCC_READ_CONFLICT))
                 .when(stub).commitStatus(any());
 
-        Transaction transaction = network.getContract("CHAINCODE_ID")
+        Transaction transaction = network.getContract("CHAINCODE_NAME")
                 .newProposal("TRANSACTION_NAME")
                 .build()
                 .endorse();
@@ -356,7 +356,7 @@ public final class SubmitTransactionTest {
     @Test
     void sends_transaction_ID_in_commit_status_request() throws Exception {
         network = gateway.getNetwork("MY_NETWORK");
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Proposal proposal = contract.newProposal("TRANSACTION_NAME").build();
 
         proposal.endorse().submit();
@@ -375,7 +375,7 @@ public final class SubmitTransactionTest {
     void sends_network_name_in_commit_status_request() throws Exception {
         network = gateway.getNetwork("MY_NETWORK");
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         contract.submitTransaction("TRANSACTION_NAME");
 
         SignedCommitStatusRequest signedRequest = mocker.captureCommitStatus();
@@ -390,7 +390,7 @@ public final class SubmitTransactionTest {
         doReturn(utils.newCommitStatusResponse(TxValidationCode.MVCC_READ_CONFLICT))
                 .when(stub).commitStatus(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Status status = contract.newProposal("TRANSACTION_NAME")
                 .build()
                 .endorse()
@@ -402,7 +402,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void commit_returns_successful_for_successful_transaction() {
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Status status = contract.newProposal("TRANSACTION_NAME")
                 .build()
                 .endorse()
@@ -417,7 +417,7 @@ public final class SubmitTransactionTest {
         doReturn(utils.newCommitStatusResponse(TxValidationCode.MVCC_READ_CONFLICT))
                 .when(stub).commitStatus(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Status status = contract.newProposal("TRANSACTION_NAME")
                 .build()
                 .endorse()
@@ -432,7 +432,7 @@ public final class SubmitTransactionTest {
         doReturn(utils.newCommitStatusResponse(TxValidationCode.MVCC_READ_CONFLICT, 101))
                 .when(stub).commitStatus(any());
 
-        Contract contract = network.getContract("CHAINCODE_ID");
+        Contract contract = network.getContract("CHAINCODE_NAME");
         Status status = contract.newProposal("TRANSACTION_NAME")
                 .build()
                 .endorse()

--- a/node/src/chaincodeevent.ts
+++ b/node/src/chaincodeevent.ts
@@ -25,7 +25,7 @@ export interface ChaincodeEvent {
     /**
      * Chaincode that emitted this event.
      */
-    chaincodeId: string;
+    chaincodeName: string;
 
     /**
      * Name of the emitted event.
@@ -64,7 +64,7 @@ export function newChaincodeEvents(responses: CloseableAsyncIterable<ChaincodeEv
 function newChaincodeEvent(blockNumber: bigint, event: ChaincodeEventProto): ChaincodeEvent {
     return {
         blockNumber,
-        chaincodeId: event.getChaincodeId() ?? '',
+        chaincodeName: event.getChaincodeId() ?? '',
         eventName: event.getEventName() ?? '',
         transactionId: event.getTxId() ?? '',
         payload: event.getPayload_asU8() || new Uint8Array(),

--- a/node/src/chaincodeevents.test.ts
+++ b/node/src/chaincodeevents.test.ts
@@ -23,7 +23,7 @@ function assertDecodeChaincodeEventsRequest(signedRequest: SignedChaincodeEvents
 function newChaincodeEvent(blockNumber: number, event: ChaincodeEventProto): ChaincodeEvent {
     return {
         blockNumber: BigInt(blockNumber),
-        chaincodeId: event.getChaincodeId() ?? '',
+        chaincodeName: event.getChaincodeId() ?? '',
         eventName: event.getEventName() ?? '',
         transactionId: event.getTxId() ?? '',
         payload: event.getPayload_asU8() ?? new Uint8Array(),

--- a/node/src/chaincodeeventsbuilder.ts
+++ b/node/src/chaincodeeventsbuilder.ts
@@ -24,7 +24,7 @@ export interface ChaincodeEventsBuilderOptions extends Readonly<ChaincodeEventsO
     readonly client: GatewayClient;
     readonly signingIdentity: SigningIdentity;
     readonly channelName: string;
-    readonly chaincodeId: string;
+    readonly chaincodeName: string;
 }
 
 export class ChaincodeEventsBuilder {
@@ -45,7 +45,7 @@ export class ChaincodeEventsBuilder {
     private newChaincodeEventsRequestProto(): ChaincodeEventsRequestProto {
         const result = new ChaincodeEventsRequestProto();
         result.setChannelId(this.#options.channelName);
-        result.setChaincodeId(this.#options.chaincodeId);
+        result.setChaincodeId(this.#options.chaincodeName);
         result.setIdentity(this.#options.signingIdentity.getCreator());
         result.setStartPosition(this.getStartPosition());
 

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -88,9 +88,10 @@ import { Transaction, TransactionImpl } from './transaction';
  */
 export interface Contract {
     /**
-     * Get the ID of the chaincode that contains this smart contract.
+     * Get the name of the chaincode that contains this smart contract.
+     * @returns The chaincode name.
      */
-    getChaincodeId(): string;
+    getChaincodeName(): string;
     
     /**
      * Get the name of the smart contract within the chaincode.
@@ -201,7 +202,7 @@ export interface ContractOptions {
     readonly client: GatewayClient;
     readonly signingIdentity: SigningIdentity;
     readonly channelName: string;
-    readonly chaincodeId: string;
+    readonly chaincodeName: string;
     readonly contractName?: string;
 }
 
@@ -209,19 +210,19 @@ export class ContractImpl implements Contract {
     readonly #client: GatewayClient;
     readonly #signingIdentity: SigningIdentity;
     readonly #channelName: string;
-    readonly #chaincodeId: string;
+    readonly #chaincodeName: string;
     readonly #contractName?: string;
 
     constructor(options: ContractOptions) {
         this.#client = options.client;
         this.#signingIdentity = options.signingIdentity;
         this.#channelName = options.channelName;
-        this.#chaincodeId = options.chaincodeId;
+        this.#chaincodeName = options.chaincodeName;
         this.#contractName = options.contractName;
     }
 
-    getChaincodeId(): string {
-        return this.#chaincodeId;
+    getChaincodeName(): string {
+        return this.#chaincodeName;
     }
 
     getContractName(): string | undefined {
@@ -257,19 +258,16 @@ export class ContractImpl implements Contract {
     }
 
     newProposal(transactionName: string, options: ProposalOptions = {}): Proposal {
-        const builderOptions = Object.assign(
+        return new ProposalBuilder(Object.assign(
             {
                 client: this.#client,
                 signingIdentity: this.#signingIdentity,
                 channelName: this.#channelName,
-                chaincodeId: this.#chaincodeId,
+                chaincodeName: this.#chaincodeName,
                 transactionName: this.getQualifiedTransactionName(transactionName),
-                options,
             },
             options,
-        );
-        
-        return new ProposalBuilder(builderOptions).build();
+        )).build();
     }
 
     newSignedProposal(bytes: Uint8Array, signature: Uint8Array): Proposal {

--- a/node/src/network.test.ts
+++ b/node/src/network.test.ts
@@ -31,16 +31,16 @@ describe ('Network', () => {
 
     describe('getContract', () => {
         it('returns correctly named default contract', () => {
-            const contract = network.getContract('CHAINCODE_ID');
+            const contract = network.getContract('CHAINCODE_NAME');
 
-            expect(contract.getChaincodeId()).toBe('CHAINCODE_ID');
+            expect(contract.getChaincodeName()).toBe('CHAINCODE_NAME');
             expect(contract.getContractName()).toBeUndefined();
         });
 
         it('returns correctly named non-default contract', () => {
-            const contract = network.getContract('CHAINCODE_ID', 'CONTRACT_NAME');
+            const contract = network.getContract('CHAINCODE_NAME', 'CONTRACT_NAME');
 
-            expect(contract.getChaincodeId()).toBe('CHAINCODE_ID');
+            expect(contract.getChaincodeName()).toBe('CHAINCODE_NAME');
             expect(contract.getContractName()).toBe('CONTRACT_NAME');
         });
     });

--- a/node/src/offlinesign.test.ts
+++ b/node/src/offlinesign.test.ts
@@ -60,7 +60,7 @@ describe('Offline sign', () => {
         };
         gateway = internalConnect(options);
         network = gateway.getNetwork('CHANNEL_NAME');
-        contract = network.getContract('CHAINCODE_ID');
+        contract = network.getContract('CHAINCODE_NAME');
     });
 
     describe('evaluate', () => {

--- a/node/src/proposal.test.ts
+++ b/node/src/proposal.test.ts
@@ -88,7 +88,7 @@ describe('Proposal', () => {
         };
         gateway = internalConnect(options);
         network = gateway.getNetwork('CHANNEL_NAME');
-        contract = network.getContract('CHAINCODE_ID');
+        contract = network.getContract('CHAINCODE_NAME');
     });
 
     describe('evaluate', () => {
@@ -126,18 +126,18 @@ describe('Proposal', () => {
             expect(channelHeader.getChannelId()).toBe(network.getName());
         });
 
-        it('includes chaincode ID in proposal', async () => {
+        it('includes chaincode name in proposal', async () => {
             await contract.evaluateTransaction('TRANSACTION_NAME');
 
             const evaluateRequest = client.evaluate.mock.calls[0][0];
             const proposal = assertDecodeEvaluateRequest(evaluateRequest);
             const chaincodeSpec = assertDecodeChaincodeSpec(proposal);
             expect(chaincodeSpec.getChaincodeId()).toBeDefined();
-            expect(chaincodeSpec.getChaincodeId()?.getName()).toBe(contract.getChaincodeId());
+            expect(chaincodeSpec.getChaincodeId()?.getName()).toBe(contract.getChaincodeName());
         });
 
         it('includes transaction name in proposal for default smart contract', async () => {
-            contract = network.getContract('CHAINCODE_ID');
+            contract = network.getContract('CHAINCODE_NAME');
 
             await contract.evaluateTransaction('MY_TRANSACTION');
 
@@ -148,7 +148,7 @@ describe('Proposal', () => {
         });
 
         it('includes transaction name in proposal for named smart contract', async () => {
-            contract = network.getContract('CHAINCODE_ID', 'MY_CONTRACT');
+            contract = network.getContract('CHAINCODE_NAME', 'MY_CONTRACT');
 
             await contract.evaluateTransaction('MY_TRANSACTION');
 
@@ -322,18 +322,18 @@ describe('Proposal', () => {
             expect(channelHeader.getChannelId()).toBe(network.getName());
         });
 
-        it('includes chaincode ID in proposal', async () => {
+        it('includes chaincode name in proposal', async () => {
             await contract.submitTransaction('TRANSACTION_NAME');
 
             const endorseRequest = client.endorse.mock.calls[0][0];
             const proposal = assertDecodeEndorseRequest(endorseRequest);
             const chaincodeSpec = assertDecodeChaincodeSpec(proposal);
             expect(chaincodeSpec.getChaincodeId()).toBeDefined();
-            expect(chaincodeSpec.getChaincodeId()?.getName()).toBe(contract.getChaincodeId());
+            expect(chaincodeSpec.getChaincodeId()?.getName()).toBe(contract.getChaincodeName());
         });
 
         it('includes transaction name in proposal for default smart contract', async () => {
-            contract = network.getContract('CHAINCODE_ID');
+            contract = network.getContract('CHAINCODE_NAME');
 
             await contract.submitTransaction('MY_TRANSACTION');
 
@@ -344,7 +344,7 @@ describe('Proposal', () => {
         });
 
         it('includes transaction name in proposal for named smart contract', async () => {
-            contract = network.getContract('CHAINCODE_ID', 'MY_CONTRACT');
+            contract = network.getContract('CHAINCODE_NAME', 'MY_CONTRACT');
 
             await contract.submitTransaction('MY_TRANSACTION');
 

--- a/node/src/proposalbuilder.ts
+++ b/node/src/proposalbuilder.ts
@@ -40,7 +40,7 @@ export interface ProposalBuilderOptions extends Readonly<ProposalOptions> {
     readonly client: GatewayClient;
     readonly signingIdentity: SigningIdentity;
     readonly channelName: string;
-    readonly chaincodeId: string;
+    readonly chaincodeName: string;
     readonly transactionName: string;
 }
 
@@ -111,7 +111,7 @@ export class ProposalBuilder {
 
     private newChaincodeID(): ChaincodeID {
         const result = new ChaincodeID();
-        result.setName(this.#options.chaincodeId);
+        result.setName(this.#options.chaincodeName);
         return result;
     }
 

--- a/node/src/transaction.test.ts
+++ b/node/src/transaction.test.ts
@@ -63,7 +63,7 @@ describe('Transaction', () => {
         };
         gateway = internalConnect(options);
         network = gateway.getNetwork('CHANNEL_NAME');
-        contract = network.getContract('CHAINCODE_ID');
+        contract = network.getContract('CHAINCODE_NAME');
     });
 
     it('throws on submit error', async () => {

--- a/pkg/client/chaincodeevents.go
+++ b/pkg/client/chaincodeevents.go
@@ -92,7 +92,7 @@ func (events *ChaincodeEventsRequest) setSignature(signature []byte) {
 type ChaincodeEvent struct {
 	BlockNumber   uint64
 	TransactionID string
-	ChaincodeID   string
+	ChaincodeName string
 	EventName     string
 	Payload       []byte
 }
@@ -102,7 +102,7 @@ func deliverChaincodeEvents(response *gateway.ChaincodeEventsResponse, send chan
 		send <- &ChaincodeEvent{
 			BlockNumber:   response.GetBlockNumber(),
 			TransactionID: event.GetTxId(),
-			ChaincodeID:   event.GetChaincodeId(),
+			ChaincodeName: event.GetChaincodeId(),
 			EventName:     event.GetEventName(),
 			Payload:       event.GetPayload(),
 		}

--- a/pkg/client/chaincodeevents_test.go
+++ b/pkg/client/chaincodeevents_test.go
@@ -31,7 +31,7 @@ func TestChaincodeEvents(t *testing.T) {
 		for _, event := range events {
 			blockNumber = event.BlockNumber
 			peerEvents = append(peerEvents, &peer.ChaincodeEvent{
-				ChaincodeId: event.ChaincodeID,
+				ChaincodeId: event.ChaincodeName,
 				TxId:        event.TransactionID,
 				EventName:   event.EventName,
 				Payload:     event.Payload,
@@ -54,7 +54,7 @@ func TestChaincodeEvents(t *testing.T) {
 		defer cancel()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClient(mockClient))
-		_, err := network.ChaincodeEvents(ctx, "CHAINCODE_ID")
+		_, err := network.ChaincodeEvents(ctx, "CHAINCODE")
 
 		require.Equal(t, expected, err)
 	})
@@ -83,7 +83,7 @@ func TestChaincodeEvents(t *testing.T) {
 		defer cancel()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClient(mockClient))
-		_, err := network.ChaincodeEvents(ctx, "CHAINCODE_ID")
+		_, err := network.ChaincodeEvents(ctx, "CHAINCODE")
 		require.NoError(t, err)
 
 		creator, err := network.signingID.Creator()
@@ -91,7 +91,7 @@ func TestChaincodeEvents(t *testing.T) {
 
 		expected := &gateway.ChaincodeEventsRequest{
 			ChannelId:   "NETWORK",
-			ChaincodeId: "CHAINCODE_ID",
+			ChaincodeId: "CHAINCODE",
 			Identity:    creator,
 			StartPosition: &orderer.SeekPosition{
 				Type: &orderer.SeekPosition_NextCommit{
@@ -126,7 +126,7 @@ func TestChaincodeEvents(t *testing.T) {
 		defer cancel()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClient(mockClient))
-		_, err := network.ChaincodeEvents(ctx, "CHAINCODE_ID", WithStartBlock(418))
+		_, err := network.ChaincodeEvents(ctx, "CHAINCODE", WithStartBlock(418))
 		require.NoError(t, err)
 
 		creator, err := network.signingID.Creator()
@@ -134,7 +134,7 @@ func TestChaincodeEvents(t *testing.T) {
 
 		expected := &gateway.ChaincodeEventsRequest{
 			ChannelId:   "NETWORK",
-			ChaincodeId: "CHAINCODE_ID",
+			ChaincodeId: "CHAINCODE",
 			Identity:    creator,
 			StartPosition: &orderer.SeekPosition{
 				Type: &orderer.SeekPosition_Specified{
@@ -175,12 +175,12 @@ func TestChaincodeEvents(t *testing.T) {
 		defer cancel()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClient(mockClient))
-		_, err := network.ChaincodeEvents(ctx, "CHAINCODE_ID")
+		_, err := network.ChaincodeEvents(ctx, "CHAINCODE")
 		require.NoError(t, err)
 
 		expected := &gateway.ChaincodeEventsRequest{
 			ChannelId:   "NETWORK",
-			ChaincodeId: "CHAINCODE_ID",
+			ChaincodeId: "CHAINCODE",
 		}
 		require.True(t, proto.Equal(expected, actual), "Expected %v, got %v", expected, actual)
 	})
@@ -201,7 +201,7 @@ func TestChaincodeEvents(t *testing.T) {
 		defer cancel()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClient(mockClient))
-		receive, err := network.ChaincodeEvents(ctx, "CHAINCODE_ID")
+		receive, err := network.ChaincodeEvents(ctx, "CHAINCODE")
 		require.NoError(t, err)
 
 		actual, ok := <-receive
@@ -220,21 +220,21 @@ func TestChaincodeEvents(t *testing.T) {
 		expected := []*ChaincodeEvent{
 			{
 				BlockNumber:   1,
-				ChaincodeID:   "CHAINCODE_ID",
+				ChaincodeName: "CHAINCODE",
 				EventName:     "EVENT_1",
 				Payload:       []byte("PAYLOAD_1"),
 				TransactionID: "TRANSACTION_ID_1",
 			},
 			{
 				BlockNumber:   1,
-				ChaincodeID:   "CHAINCODE_ID",
+				ChaincodeName: "CHAINCODE",
 				EventName:     "EVENT_2",
 				Payload:       []byte("PAYLOAD_2"),
 				TransactionID: "TRANSACTION_ID_2",
 			},
 			{
 				BlockNumber:   2,
-				ChaincodeID:   "CHAINCODE_ID",
+				ChaincodeName: "CHAINCODE",
 				EventName:     "EVENT_3",
 				Payload:       []byte("PAYLOAD_3"),
 				TransactionID: "TRANSACTION_ID_3",
@@ -261,7 +261,7 @@ func TestChaincodeEvents(t *testing.T) {
 		defer cancel()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClient(mockClient))
-		receive, err := network.ChaincodeEvents(ctx, "CHAINCODE_ID")
+		receive, err := network.ChaincodeEvents(ctx, "CHAINCODE")
 		require.NoError(t, err)
 
 		for _, event := range expected {

--- a/pkg/client/chaincodeeventsbuilder.go
+++ b/pkg/client/chaincodeeventsbuilder.go
@@ -18,7 +18,7 @@ type chaincodeEventsBuilder struct {
 	client        gateway.GatewayClient
 	signingID     *signingIdentity
 	channelName   string
-	chaincodeID   string
+	chaincodeName string
 	startPosition *orderer.SeekPosition
 }
 
@@ -62,7 +62,7 @@ func (builder *chaincodeEventsBuilder) newChaincodeEventsRequestProto() (*gatewa
 	request := &gateway.ChaincodeEventsRequest{
 		ChannelId:     builder.channelName,
 		Identity:      creator,
-		ChaincodeId:   builder.chaincodeID,
+		ChaincodeId:   builder.chaincodeName,
 		StartPosition: builder.getStartPosition(),
 	}
 	return request, nil

--- a/pkg/client/contract.go
+++ b/pkg/client/contract.go
@@ -35,20 +35,20 @@ import (
 // using the Contract's NewSignedProposal() or NewSignedTransaction() methods respectively, or creating a signed
 // commit using the Network's NewSignedCommit() method.
 type Contract struct {
-	client       gateway.GatewayClient
-	signingID    *signingIdentity
-	channelName  string
-	chaincodeID  string
-	contractName string
+	client        gateway.GatewayClient
+	signingID     *signingIdentity
+	channelName   string
+	chaincodeName string
+	contractName  string
 }
 
-// ChaincodeID of the chaincode that contains this smart contract.
-func (contract *Contract) ChaincodeID() string {
-	return contract.chaincodeID
+// ChaincodeName of the chaincode that contains this smart contract.
+func (contract *Contract) ChaincodeName() string {
+	return contract.chaincodeName
 }
 
-// Name of the contract within the chaincode, or an empty string for the default smart contract.
-func (contract *Contract) Name() string {
+// ContractName of the contract within the chaincode, or an empty string for the default smart contract.
+func (contract *Contract) ContractName() string {
 	return contract.contractName
 }
 
@@ -137,7 +137,7 @@ func (contract *Contract) NewProposal(transactionName string, options ...Proposa
 		client:          contract.client,
 		signingID:       contract.signingID,
 		channelName:     contract.channelName,
-		chaincodeID:     contract.chaincodeID,
+		chaincodeName:   contract.chaincodeName,
 		transactionName: contract.qualifiedTransactionName(transactionName),
 	}
 

--- a/pkg/client/contract_test.go
+++ b/pkg/client/contract_test.go
@@ -10,14 +10,14 @@ import (
 	"testing"
 )
 
-func AssertNewTestContract(t *testing.T, chaincodeID string, options ...ConnectOption) *Contract {
+func AssertNewTestContract(t *testing.T, chaincodeName string, options ...ConnectOption) *Contract {
 	network := AssertNewTestNetwork(t, "network", options...)
-	return network.GetContract(chaincodeID)
+	return network.GetContract(chaincodeName)
 }
 
-func AssertNewTestContractWithName(t *testing.T, chaincodeID string, contractName string, options ...ConnectOption) *Contract {
+func AssertNewTestContractWithName(t *testing.T, chaincodeName string, contractName string, options ...ConnectOption) *Contract {
 	network := AssertNewTestNetwork(t, "network", options...)
-	return network.GetContractWithName(chaincodeID, contractName)
+	return network.GetContractWithName(chaincodeName, contractName)
 }
 
 func bytesAsStrings(bytes [][]byte) []string {

--- a/pkg/client/evaluate_test.go
+++ b/pkg/client/evaluate_test.go
@@ -83,7 +83,7 @@ func TestEvaluateTransaction(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
-	t.Run("Includes chaincode ID in proposal", func(t *testing.T) {
+	t.Run("Includes chaincode name in proposal", func(t *testing.T) {
 		var actual string
 		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
@@ -98,7 +98,7 @@ func TestEvaluateTransaction(t *testing.T) {
 		_, err := contract.EvaluateTransaction("transaction")
 		require.NoError(t, err)
 
-		expected := contract.chaincodeID
+		expected := contract.chaincodeName
 		require.Equal(t, expected, actual)
 	})
 

--- a/pkg/client/network.go
+++ b/pkg/client/network.go
@@ -28,18 +28,18 @@ func (network *Network) Name() string {
 }
 
 // GetContract returns a Contract representing the default smart contract for the named chaincode.
-func (network *Network) GetContract(chaincodeID string) *Contract {
-	return network.GetContractWithName(chaincodeID, "")
+func (network *Network) GetContract(chaincodeName string) *Contract {
+	return network.GetContractWithName(chaincodeName, "")
 }
 
 // GetContractWithName returns a Contract representing a smart contract within a named chaincode.
-func (network *Network) GetContractWithName(chaincodeID string, contractName string) *Contract {
+func (network *Network) GetContractWithName(chaincodeName string, contractName string) *Contract {
 	return &Contract{
-		client:       network.client,
-		signingID:    network.signingID,
-		channelName:  network.name,
-		chaincodeID:  chaincodeID,
-		contractName: contractName,
+		client:        network.client,
+		signingID:     network.signingID,
+		channelName:   network.name,
+		chaincodeName: chaincodeName,
+		contractName:  contractName,
 	}
 }
 
@@ -63,8 +63,8 @@ func (network *Network) NewSignedCommit(bytes []byte, signature []byte) (*Commit
 
 // ChaincodeEvents returns a channel from which chaincode events emitted by transaction functions in the specified
 // chaincode can be read.
-func (network *Network) ChaincodeEvents(ctx context.Context, chaincodeID string, options ...ChaincodeEventsOption) (<-chan *ChaincodeEvent, error) {
-	events, err := network.NewChaincodeEventsRequest(chaincodeID, options...)
+func (network *Network) ChaincodeEvents(ctx context.Context, chaincodeName string, options ...ChaincodeEventsOption) (<-chan *ChaincodeEvent, error) {
+	events, err := network.NewChaincodeEventsRequest(chaincodeName, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -74,12 +74,12 @@ func (network *Network) ChaincodeEvents(ctx context.Context, chaincodeID string,
 
 // NewChaincodeEventsRequest creates a request to read events emitted by the specified chaincode. Supports off-line
 // signing flow.
-func (network *Network) NewChaincodeEventsRequest(chaincodeID string, options ...ChaincodeEventsOption) (*ChaincodeEventsRequest, error) {
+func (network *Network) NewChaincodeEventsRequest(chaincodeName string, options ...ChaincodeEventsOption) (*ChaincodeEventsRequest, error) {
 	builder := &chaincodeEventsBuilder{
-		client:      network.client,
-		signingID:   network.signingID,
-		channelName: network.name,
-		chaincodeID: chaincodeID,
+		client:        network.client,
+		signingID:     network.signingID,
+		channelName:   network.name,
+		chaincodeName: chaincodeName,
 	}
 
 	for _, option := range options {

--- a/pkg/client/network_test.go
+++ b/pkg/client/network_test.go
@@ -20,27 +20,27 @@ func AssertNewTestNetwork(t *testing.T, networkName string, options ...ConnectOp
 
 func TestNetwork(t *testing.T) {
 	t.Run("GetContract returns correctly named Contract", func(t *testing.T) {
-		chaincodeID := "chaincode"
+		chaincodeName := "chaincode"
 		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		network := AssertNewTestNetwork(t, "network", WithClient(mockClient))
 
-		contract := network.GetContract(chaincodeID)
+		contract := network.GetContract(chaincodeName)
 
 		require.NotNil(t, contract)
-		require.Equal(t, chaincodeID, contract.ChaincodeID(), "chaincodeID")
-		require.Equal(t, "", contract.Name(), "name")
+		require.Equal(t, chaincodeName, contract.ChaincodeName(), "chaincode name")
+		require.Equal(t, "", contract.ContractName(), "contract name")
 	})
 
 	t.Run("GetContractWithName returns correctly named Contract", func(t *testing.T) {
-		chaincodeID := "chaincode"
+		chaincodeName := "chaincode"
 		contractName := "contract"
 		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		network := AssertNewTestNetwork(t, "network", WithClient(mockClient))
 
-		contract := network.GetContractWithName(chaincodeID, contractName)
+		contract := network.GetContractWithName(chaincodeName, contractName)
 
 		require.NotNil(t, contract)
-		require.Equal(t, chaincodeID, contract.ChaincodeID(), "chaincodeID")
-		require.Equal(t, contractName, contract.Name(), "name")
+		require.Equal(t, chaincodeName, contract.ChaincodeName(), "chaincode name")
+		require.Equal(t, contractName, contract.ContractName(), "contract name")
 	})
 }

--- a/pkg/client/proposalbuilder.go
+++ b/pkg/client/proposalbuilder.go
@@ -20,7 +20,7 @@ type proposalBuilder struct {
 	client          gateway.GatewayClient
 	signingID       *signingIdentity
 	channelName     string
-	chaincodeID     string
+	chaincodeName   string
 	transactionName string
 	transient       map[string][]byte
 	endorsingOrgs   []string
@@ -61,7 +61,7 @@ func (builder *proposalBuilder) newProposalProto() (*peer.Proposal, string, erro
 	invocationSpec := &peer.ChaincodeInvocationSpec{
 		ChaincodeSpec: &peer.ChaincodeSpec{
 			Type:        peer.ChaincodeSpec_NODE,
-			ChaincodeId: &peer.ChaincodeID{Name: builder.chaincodeID},
+			ChaincodeId: &peer.ChaincodeID{Name: builder.chaincodeName},
 			Input:       &peer.ChaincodeInput{Args: builder.chaincodeArgs()},
 		},
 	}

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -160,7 +160,7 @@ func TestSubmitTransaction(t *testing.T) {
 		require.Equal(t, expected, actual)
 	})
 
-	t.Run("Includes chaincode ID in proposal", func(t *testing.T) {
+	t.Run("Includes chaincode name in proposal", func(t *testing.T) {
 		var actual string
 		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
@@ -179,7 +179,7 @@ func TestSubmitTransaction(t *testing.T) {
 		_, err := contract.SubmitTransaction("transaction")
 		require.NoError(t, err)
 
-		expected := contract.chaincodeID
+		expected := contract.chaincodeName
 		require.Equal(t, expected, actual)
 	})
 


### PR DESCRIPTION
This is always the name property of the protobuf ChaincodeID message, so chaincodeName is both more strictly correct and reads better in documentation.