### PR TITLE
Clean up eventing

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayClient.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayClient.java
@@ -6,6 +6,9 @@
 
 package org.hyperledger.fabric.client;
 
+import java.util.Iterator;
+import java.util.function.Function;
+
 import io.grpc.Channel;
 import io.grpc.Context;
 import org.hyperledger.fabric.protos.gateway.ChaincodeEventsResponse;
@@ -19,9 +22,6 @@ import org.hyperledger.fabric.protos.gateway.SignedChaincodeEventsRequest;
 import org.hyperledger.fabric.protos.gateway.SignedCommitStatusRequest;
 import org.hyperledger.fabric.protos.gateway.SubmitRequest;
 import org.hyperledger.fabric.protos.gateway.SubmitResponse;
-
-import java.util.Iterator;
-import java.util.function.Function;
 
 final class GatewayClient {
     private final GatewayGrpc.GatewayBlockingStub blockingStub;

--- a/java/src/test/java/org/hyperledger/fabric/client/MockGatewayService.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/MockGatewayService.java
@@ -6,8 +6,6 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.concurrent.CompletableFuture;
-
 import io.grpc.stub.StreamObserver;
 import org.hyperledger.fabric.protos.gateway.ChaincodeEventsResponse;
 import org.hyperledger.fabric.protos.gateway.CommitStatusResponse;
@@ -80,13 +78,11 @@ public class MockGatewayService extends GatewayGrpc.GatewayImplBase {
 
     @Override
     public void chaincodeEvents(final SignedChaincodeEventsRequest request, final StreamObserver<ChaincodeEventsResponse> responseObserver) {
-        CompletableFuture.runAsync(() -> {
-            try {
-                stub.chaincodeEvents(request).forEachOrdered(responseObserver::onNext);
-                responseObserver.onCompleted();
-            } catch (Throwable t) {
-                responseObserver.onError(t);
-            }
-        });
+        try {
+            stub.chaincodeEvents(request).forEachOrdered(responseObserver::onNext);
+            responseObserver.onCompleted();
+        } catch (Throwable t) {
+            responseObserver.onError(t);
+        }
     }
 }

--- a/java/src/test/java/org/hyperledger/fabric/client/TestUtils.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/TestUtils.java
@@ -54,7 +54,7 @@ public final class TestUtils {
 
     public ManagedChannel newChannelForService(GatewayGrpc.GatewayImplBase service) {
         String serverName = InProcessServerBuilder.generateName();
-        Server server = InProcessServerBuilder.forName(serverName).directExecutor().addService(service).build();
+        Server server = InProcessServerBuilder.forName(serverName).addService(service).build();
 
         try {
             server.start();

--- a/node/src/chaincodeevent.ts
+++ b/node/src/chaincodeevent.ts
@@ -39,14 +39,9 @@ export interface ChaincodeEvent {
 }
 
 export function newChaincodeEvents(responses: CloseableAsyncIterable<ChaincodeEventsResponse>): CloseableAsyncIterable<ChaincodeEvent> {
-    let closed = false;
     return {
         async* [Symbol.asyncIterator]() { // eslint-disable-line @typescript-eslint/require-await
             for await (const response of responses) {
-                if (closed) {
-                    return;
-                }
-                
                 const blockNumber = BigInt(response.getBlockNumber() ?? 0);
                 const events = response.getEventsList() || [];
                 for (const event of events) {
@@ -55,7 +50,6 @@ export function newChaincodeEvents(responses: CloseableAsyncIterable<ChaincodeEv
             }
         },
         close: () => {
-            closed = true;
             responses.close();
         },
     };

--- a/node/src/chaincodeevents.test.ts
+++ b/node/src/chaincodeevents.test.ts
@@ -190,16 +190,5 @@ describe('Chaincode Events', () => {
 
             expect(iterable.close).toBeCalled();
         });
-
-        it('stops receiving events when iterator closed', async () => {
-            client.chaincodeEvents.mockReturnValue(newCloseableAsyncIterable([ response1, response2 ]));
-    
-            const events = await network.getChaincodeEvents('CHAINCODE');
-            await readElements(events, 1);
-            events.close();
-
-            const actualEvents = await readElements(events, 1);
-            expect(actualEvents).toHaveLength(0);
-        });
     })
 });


### PR DESCRIPTION
Some code clean up and minimise client API implementation and behaviour beyond what is provided by gRPC.

Java:
- Use async rather than direct in-process service invocation for unit tests to better simulate runtime behaviour.
- Remove explicit closed baheviour from ChaincodeEventIterator, and let the gRPC iterator throw a gRPC error if the iterator is used after the stream is closed.
- Simplify unit test implementations.
- Simplify ChaincodeEventIterator implementation.

Node:
- Remove explicit closed behaviour from chaincode event AsyncIterable and use whatever behaviour the gRPC server stream's AsyncIterable provides.