### PR TITLE
Default timeouts in Java API

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/CallOption.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/CallOption.java
@@ -6,6 +6,7 @@
 
 package org.hyperledger.fabric.client;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.function.UnaryOperator;
 
@@ -28,6 +29,7 @@ public final class CallOption {
      * @return a call option.
      */
     public static CallOption deadline(final Deadline deadline) {
+        Objects.requireNonNull(deadline, "deadline");
         return new CallOption(stub -> stub.withDeadline(deadline));
     }
 
@@ -38,6 +40,7 @@ public final class CallOption {
      * @return a call option.
      */
     public static CallOption deadlineAfter(final long duration, final TimeUnit unit) {
+        Objects.requireNonNull(unit, "unit");
         return new CallOption(stub -> stub.withDeadlineAfter(duration, unit));
     }
 

--- a/java/src/main/java/org/hyperledger/fabric/client/CallOptions.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/CallOptions.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+final class CallOptions {
+    private final List<CallOption> evaluate;
+    private final List<CallOption> endorse;
+    private final List<CallOption> submit;
+    private final List<CallOption> commitStatus;
+    private final List<CallOption> chaincodeEvents;
+
+    private CallOptions(final Builder builder) {
+        this.evaluate = Collections.unmodifiableList(new ArrayList<>(builder.evaluate));
+        this.endorse = Collections.unmodifiableList(new ArrayList<>(builder.endorse));
+        this.submit = Collections.unmodifiableList(new ArrayList<>(builder.submit));
+        this.commitStatus = Collections.unmodifiableList(new ArrayList<>(builder.commitStatus));
+        this.chaincodeEvents = Collections.unmodifiableList(new ArrayList<>(builder.chaincodeEvents));
+    }
+
+    public static Builder newBuiler() {
+        return new Builder();
+    }
+
+    private static List<CallOption> append(final List<CallOption> current, final CallOption... additional) {
+        List<CallOption> result = new ArrayList<>(current);
+        Collections.addAll(result, additional);
+        return result;
+    }
+
+    public List<CallOption> getEvaluate(final CallOption... additional) {
+        return append(evaluate, additional);
+    }
+
+    public List<CallOption> getEndorse(final CallOption... additional) {
+        return append(endorse, additional);
+    }
+
+    public List<CallOption> getSubmit(final CallOption... additional) {
+        return append(submit, additional);
+    }
+
+    public List<CallOption> getCommitStatus(final CallOption... additional) {
+        return append(commitStatus, additional);
+    }
+
+    public List<CallOption> getChaincodeEvents(final CallOption... additional) {
+        return append(chaincodeEvents, additional);
+    }
+
+    public static final class Builder {
+        private List<CallOption> evaluate = Collections.emptyList();
+        private List<CallOption> endorse = Collections.emptyList();
+        private List<CallOption> submit = Collections.emptyList();
+        private List<CallOption> commitStatus = Collections.emptyList();
+        private List<CallOption> chaincodeEvents = Collections.emptyList();
+
+        private Builder() {
+            // Nothing to do
+        }
+
+        public Builder evaluate(final List<CallOption> options) {
+            Objects.requireNonNull(options, "evaluate");
+            evaluate = options;
+            return this;
+        }
+
+        public Builder endorse(final List<CallOption> options) {
+            Objects.requireNonNull(options, "endorse");
+            endorse = options;
+            return this;
+        }
+
+        public Builder submit(final List<CallOption> options) {
+            Objects.requireNonNull(options, "submit");
+            submit = options;
+            return this;
+        }
+
+        public Builder commitStatus(final List<CallOption> options) {
+            Objects.requireNonNull(options, "commitStatus");
+            commitStatus = options;
+            return this;
+        }
+
+        public Builder chaincodeEvents(final List<CallOption> options) {
+            Objects.requireNonNull(options, "chaincodeEvents");
+            chaincodeEvents = options;
+            return this;
+        }
+
+        public CallOptions build() {
+            return new CallOptions(this);
+        }
+    }
+}

--- a/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
@@ -109,6 +109,41 @@ public interface Gateway extends AutoCloseable {
         Builder hash(Function<byte[], byte[]> hash);
 
         /**
+         * Specify the default call options for evaluating transactions.
+         * @param options Call options.
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder evaluateOptions(CallOption... options);
+
+        /**
+         * Specify the default call options for endorsements.
+         * @param options Call options.
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder endorseOptions(CallOption... options);
+
+        /**
+         * Specify the default call options for submit of transactions to the orderer.
+         * @param options Call options.
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder submitOptions(CallOption... options);
+
+        /**
+         * Specify the default call options for retrieving transaction commit status.
+         * @param options Call options.
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder commitStatusOptions(CallOption... options);
+
+        /**
+         * Specify the default call options for chaincode events.
+         * @param options Call options.
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder chaincodeEventsOptions(CallOption... options);
+
+        /**
          * Connects to the gateway using the specified options.
          * @return The connected {@link Gateway} object.
          */

--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayUtils.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayUtils.java
@@ -72,4 +72,10 @@ final class GatewayUtils {
             Thread.currentThread().interrupt();
         }
     }
+
+    public static void requireNonNullArgument(final Object value, final String message) {
+        if (null == value) {
+            throw new IllegalArgumentException(message);
+        }
+    }
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/SigningIdentity.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/SigningIdentity.java
@@ -22,6 +22,11 @@ final class SigningIdentity {
         this.identity = identity;
         this.hash = hash;
         this.signer = signer;
+
+        GatewayUtils.requireNonNullArgument(this.identity, "No identity supplied");
+        GatewayUtils.requireNonNullArgument(this.hash, "No hash implementation supplied");
+        GatewayUtils.requireNonNullArgument(this.signer, "No signing implementation supplied");
+
         this.creator = GatewayUtils.serializeIdentity(identity);
     }
 

--- a/java/src/test/java/org/hyperledger/fabric/client/WrappedManagedChannel.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/WrappedManagedChannel.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+import io.grpc.CallOptions;
+import io.grpc.ClientCall;
+import io.grpc.ManagedChannel;
+import io.grpc.MethodDescriptor;
+
+/**
+ * Wrapper for an existing managed channel to allow mocking of final channel implementation classes.
+ */
+public class WrappedManagedChannel extends ManagedChannel {
+    private final ManagedChannel channel;
+
+    public WrappedManagedChannel(final ManagedChannel channel) {
+        Objects.requireNonNull(channel);
+        this.channel = channel;
+    }
+
+    @Override
+    public ManagedChannel shutdown() {
+        return channel.shutdown();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return channel.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return channel.isTerminated();
+    }
+
+    @Override
+    public ManagedChannel shutdownNow() {
+        return channel.shutdownNow();
+    }
+
+    @Override
+    public boolean awaitTermination(final long l, final TimeUnit timeUnit) throws InterruptedException {
+        return channel.awaitTermination(l, timeUnit);
+    }
+
+    @Override
+    public <RequestT, ResponseT> ClientCall<RequestT, ResponseT> newCall(final MethodDescriptor<RequestT, ResponseT> methodDescriptor, final CallOptions callOptions) {
+        return channel.newCall(methodDescriptor, callOptions);
+    }
+
+    @Override
+    public String authority() {
+        return channel.authority();
+    }
+}


### PR DESCRIPTION
The existing Node SDK has configurable default timeouts for query (evaluate), endorse and submit (submit and commitStatus), so I think having configurable defaults timeouts for each gRPC service invocation is the right thing to do. Some service invocations are likely to take significantly longer than others, and the time the client is prepared to wait for different invocations is likely to vary significantly too, so I don't think there is a good default timeout value that covers all cases.

I would really like to have made use of the gRPC **CallOptions** class directly, rather than the Fabric Gateway API having its own **CallOption** abstraction to maintain. Unfortunately the Java gRPC client stubs expect specific methods to be called for specific options (which update a **CallOptions** object internally) and don't expose a method to just specify or update the existing **CallOptions**.

Contributes to #198 