### PR TITLE
Fixup scenario tests for endorser retry

### DIFF
--- a/java/src/test/java/scenario/ScenarioSteps.java
+++ b/java/src/test/java/scenario/ScenarioSteps.java
@@ -443,10 +443,10 @@ public class ScenarioSteps {
 
         for (Any detail : status.getDetailsList()) {
             ErrorDetail ee = ErrorDetail.parseFrom(detail.getValue());
-            List<String> row = expected.get(ee.getMspId());
+            List<String> row = expected.get(ee.getAddress());
             assertThat(row).isNotNull();
             assertThat(ee.getMessage()).contains(row.get(1));
-            expected.remove(ee.getMspId());
+            expected.remove(ee.getAddress());
         }
         assertThat(expected).isEmpty();
     }

--- a/scenario/features/errors.feature
+++ b/scenario/features/errors.feature
@@ -27,16 +27,17 @@ Feature: Errors
     Scenario: Submit fails with incorrect transaction name
         When I prepare to submit a nonexistent transaction
         Then the transaction invocation should fail
-        And the error message should contain "error in simulation: transaction returned with failure: Error: You've asked to invoke a function that does not exist: nonexistent"
+        And the error message should contain "failed to endorse transaction, see attached details for more info"
         And the error details should be
-            | Org1MSP | peer0.org1.example.com:7051 | error in simulation: transaction returned with failure: Error: You've asked to invoke a function that does not exist: nonexistent |
+            | peer0.org1.example.com:7051 | Org1MSP | error in simulation: transaction returned with failure: Error: You've asked to invoke a function that does not exist: nonexistent |
+            | peer1.org1.example.com:9051 | Org1MSP | error in simulation: transaction returned with failure: Error: You've asked to invoke a function that does not exist: nonexistent |
 
     Scenario: Evaluate crash chaincode
         When I prepare to evaluate a crash transaction
         Then the transaction invocation should fail
         And the error message should contain "error sending: chaincode stream terminated"
         And the error details should be
-            | Org1MSP | peer0.org1.example.com:7051 | error sending: chaincode stream terminated |
+            | peer0.org1.example.com:7051 | Org1MSP | error sending: chaincode stream terminated |
 
     Scenario: Evaluate with signer from unauthorized MSP
         When I prepare to evaluate an exists transaction
@@ -45,23 +46,25 @@ Feature: Errors
         Then the transaction invocation should fail
         And the error message should contain "failed to evaluate transaction: error validating proposal: access denied: channel [mychannel] creator org [Org1MSP]"
         And the error details should be
-            |  Org1MSP | peer0.org1.example.com:7051 |error validating proposal: access denied: channel [mychannel] creator org [Org1MSP] |
+            | peer0.org1.example.com:7051 | Org1MSP | error validating proposal: access denied: channel [mychannel] creator org [Org1MSP] |
 
     Scenario: Org3 fails to endorse
         When I prepare to submit an orgsFail transaction
         And I set the transaction arguments to ["[\"Org3MSP\"]"]
         Then the transaction invocation should fail
-        And the error message should contain "Org3MSP refuses to endorse this"
+        And the error message should contain "failed to endorse transaction, see attached details for more info"
         And the error details should be
-            | Org3MSP | peer0.org3.example.com:22051 | Org3MSP refuses to endorse this |
+            | peer0.org3.example.com:11051 | Org3MSP | Org3MSP refuses to endorse this |
 
     Scenario: Org2 and Org3 fail to endorse
         When I prepare to submit an orgsFail transaction
         And I set the transaction arguments to ["[\"Org2MSP\",\"Org3MSP\"]"]
         Then the transaction invocation should fail
+        And the error message should contain "failed to endorse transaction, see attached details for more info"
         And the error details should be
-            | Org2MSP | peer?.org2.example.com:8051 | Org2MSP refuses to endorse this |
-            | Org3MSP | peer0.org3.example.com:11051 | Org3MSP refuses to endorse this |
+            | peer0.org2.example.com:8051 | Org2MSP | Org2MSP refuses to endorse this |
+            | peer1.org2.example.com:10051 | Org2MSP | Org2MSP refuses to endorse this |
+            | peer0.org3.example.com:11051 | Org3MSP | Org3MSP refuses to endorse this |
 
     Scenario: Submit non-deterministic transaction
         When I prepare to submit a nondet transaction

--- a/scenario/features/transactions.feature
+++ b/scenario/features/transactions.feature
@@ -58,4 +58,7 @@ Feature: Transaction invocation
         When I prepare to submit an errorMessage transaction
         And I set the transaction arguments to ["ALL_YOUR_ERROR_ARE_BELONG_TO_US"]
         Then the transaction invocation should fail
-        And the error message should contain "ALL_YOUR_ERROR_ARE_BELONG_TO_US"
+        And the error message should contain "failed to endorse transaction, see attached details for more info"
+        And the error details should be
+            | peer0.org1.example.com:7051 | Org1MSP | ALL_YOUR_ERROR_ARE_BELONG_TO_US |
+            | peer1.org1.example.com:9051 | Org1MSP | ALL_YOUR_ERROR_ARE_BELONG_TO_US |

--- a/scenario/go/scenario_test.go
+++ b/scenario/go/scenario_test.go
@@ -329,24 +329,24 @@ func theErrorDetailsShouldBe(table *messages.PickleTable) error {
 	details := transaction.ErrDetails()
 	expected := map[string]*gateway.ErrorDetail{}
 	for _, row := range table.Rows {
-		mspid := row.Cells[0].Value
-		address := row.Cells[1].Value
+		address := row.Cells[0].Value
+		mspid := row.Cells[1].Value
 		msg := row.Cells[2].Value
-		expected[mspid] = &gateway.ErrorDetail{
+		expected[address] = &gateway.ErrorDetail{
 			MspId:   mspid,
 			Address: address,
 			Message: msg,
 		}
 	}
 	for _, detail := range details {
-		ee := expected[detail.MspId]
+		ee := expected[detail.Address]
 		if ee == nil {
 			return fmt.Errorf("unexpected error from endpoint: %s", detail.Address)
 		}
 		if !strings.Contains(detail.Message, ee.Message) {
 			return fmt.Errorf("expected error detail %+v, got %+v", ee, detail)
 		}
-		delete(expected, detail.MspId)
+		delete(expected, detail.Address)
 	}
 	if len(expected) > 0 {
 		keys := make([]string, 0, len(expected))

--- a/scenario/node/src/scenario_steps.ts
+++ b/scenario/node/src/scenario_steps.ts
@@ -173,16 +173,16 @@ Then('the error details should be', function(this: CustomWorld, dataTable: DataT
 
     const expectedDetails = new Map<string, ErrorDetail>();
     dataTable.raw().forEach(row => expectedDetails.set(row[0], {
-        mspId: row[0],
-        address: row[1],
+        address: row[0],
+        mspId: row[1],
         message: row[2],
     }));
 
     err.details.forEach(actual => {
-        const expected = expectedDetails.get(actual.mspId);
+        const expected = expectedDetails.get(actual.address);
         expect(expected).toBeDefined();
         expect(actual.message).toContain(expected?.message);
-        expectedDetails.delete(actual.mspId);
+        expectedDetails.delete(actual.address);
     });
     expect(Object.keys(expectedDetails)).toHaveLength(0);
 });


### PR DESCRIPTION
The endorser retry logic has been merged into fabric main branch.  Once the peer docker image has been uploaded, a few fabric-gateway scenario tests will fail (the error details will contain more items where more endorsements have been attempted).  This PR fixes those failures.  It doesn't add any more tests at this stage.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>