### PR TITLE
Dynamic load of optional pkcs11js dependency

### DIFF
--- a/node/src/dependency.test.ts
+++ b/node/src/dependency.test.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { generateKeyPairSync } from 'crypto';
+
+function isLoaded(moduleName: string): boolean {
+    const moduleFile = require.resolve(moduleName);
+    return !!Object.values(require.cache).find(m => m.filename === moduleFile);
+}
+
+describe('optional pkcs11js dependency', () => {
+    it('not loaded when accessing private key signer', async () => {
+        jest.resetModules();
+        expect(isLoaded('pkcs11js')).toBe(false);
+
+        const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
+        const { signers } = await import('.');
+        signers.newPrivateKeySigner(privateKey);
+
+        expect(isLoaded('pkcs11js')).toBe(false);
+    });
+});

--- a/node/src/identity/signers.ts
+++ b/node/src/identity/signers.ts
@@ -7,7 +7,7 @@
 import { KeyObject } from 'crypto';
 import { ec as EC } from 'elliptic';
 import { ecPrivateKeyAsRaw } from './asn1';
-import { HSMSignerFactory, HSMSignerFactoryImpl } from './hsmsigner';
+import { HSMSignerFactory, HSMSignerFactoryImpl as HSMSignerFactoryImplType } from './hsmsigner';
 import { Signer } from './signer';
 
 const namedCurves: Record<string, EC> = {
@@ -66,6 +66,10 @@ export function newHSMSignerFactory(library: string): HSMSignerFactory {
     if (!library || library.trim() === '') {
         throw new Error('library must be provided');
     }
+
+    // Dynamic module load to prevent unnecessary load of optional pkcs11js dependency
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { HSMSignerFactoryImpl } = require('./hsmsigner') as { HSMSignerFactoryImpl: typeof HSMSignerFactoryImplType };
 
     return new HSMSignerFactoryImpl(library);
 }


### PR DESCRIPTION
Prevents this dependency being loaded unless an HSM signer is actually created, avoiding runtime issues on systems that do not have the optional pkcs11js dependency available.

Resolves #252 