### PR TITLE
Node API documentation improvements

### DIFF
--- a/hsm-samples/node/src/hsm-sample.ts
+++ b/hsm-samples/node/src/hsm-sample.ts
@@ -107,12 +107,11 @@ async function exampleSubmitAsync(gateway: Gateway) {
     console.log('Query result:', evaluateResult.toString());
 }
 
-async function newGrpcConnection(): Promise<ServiceClient> {
+async function newGrpcConnection(): Promise<grpc.Client> {
     const tlsRootCert = await fs.promises.readFile(tlsCertPath);
     const tlsCredentials = grpc.credentials.createSsl(tlsRootCert);
 
-    const GrpcClient = grpc.makeGenericClientConstructor({}, '');
-    return new GrpcClient(peerEndpoint, tlsCredentials, {
+    return new grpc.Client(peerEndpoint, tlsCredentials, {
         'grpc.ssl_target_name_override': 'peer0.org1.example.com'
     });
 }

--- a/node/src/README.md
+++ b/node/src/README.md
@@ -30,8 +30,7 @@ The following complete example shows how to connect to a Fabric network, submit 
         const privateKey = crypto.createPrivateKey(privateKeyPem);
         const signer = signers.newPrivateKeySigner(privateKey);
 
-        const GrpcClient = grpc.makeGenericClientConstructor({}, '');
-        const client = new GrpcClient('gateway.example.org:1337', grpc.credentials.createInsecure());
+        const client = new grpc.Client('gateway.example.org:1337', grpc.credentials.createInsecure());
 
         const gateway = connect({ identity, signer, client });
         try {

--- a/node/src/gateway.test.ts
+++ b/node/src/gateway.test.ts
@@ -17,8 +17,7 @@ describe('Gateway', () => {
             mspId: 'MSP_ID',
             credentials: Buffer.from('CERTIFICATE'),
         }
-        const Client = grpc.makeGenericClientConstructor({}, '');
-        client = new Client('example.org:1337', grpc.credentials.createInsecure());
+        client = new grpc.Client('example.org:1337', grpc.credentials.createInsecure());
     });
 
     describe('connect', () => {
@@ -69,8 +68,7 @@ describe('Gateway', () => {
 
     describe('close', () => {
         it('does not close supplied gRPC client', () => {
-            const Client = grpc.makeGenericClientConstructor({}, '');
-            const client = new Client('example.org:1337', grpc.credentials.createInsecure());
+            const client = new grpc.Client('example.org:1337', grpc.credentials.createInsecure());
             const closeStub = client.close = jest.fn();
             const options: ConnectOptions = {
                 identity,

--- a/node/src/gateway.ts
+++ b/node/src/gateway.ts
@@ -14,6 +14,27 @@ import { SigningIdentity } from './signingidentity';
 
 /**
  * Options used when connecting to a Fabric Gateway.
+ * @example
+ * ```
+ * function defaultTimeout(): grpc.CallOptions {
+ *     return {
+ *         deadline: Date.now() + 5000, // 5 second timeout
+ *     };
+ * };
+ * const options: ConnectOptions {
+ *     identity: {
+ *         mspId: 'myorg',
+ *         credentials,
+ *     },
+ *     signer: signers.newPrivateKeySigner(privateKey),
+ *     client: new grpc.Client('gateway.example.org:1337', grpc.credentials.createInsecure()),
+ *     evaluateOptions: defaultTimeout,
+ *     endorseOptions: defaultTimeout,
+ *     submitOptions: defaultTimeout,
+ *     commitStatusOptions: defaultTimeout,
+ *     chaincodeEventsOptions: defaultTimeout,
+ * };
+ * ```
  */
 export interface ConnectOptions {
     /**

--- a/node/src/network.test.ts
+++ b/node/src/network.test.ts
@@ -18,8 +18,7 @@ describe ('Network', () => {
             mspId: 'MSP_ID',
             credentials: Buffer.from('CERTIFICATE'),
         }
-        const Client = grpc.makeGenericClientConstructor({}, '');
-        client = new Client('example.org:1337', grpc.credentials.createInsecure());
+        client = new grpc.Client('example.org:1337', grpc.credentials.createInsecure());
         const options: ConnectOptions = {
             identity,
             client,

--- a/samples/node/src/sample.ts
+++ b/samples/node/src/sample.ts
@@ -300,8 +300,7 @@ async function newGrpcConnection(): Promise<grpc.Client> {
     const tlsRootCert = await fs.readFile(tlsCertPath);
     const tlsCredentials = grpc.credentials.createSsl(tlsRootCert);
 
-    const GrpcClient = grpc.makeGenericClientConstructor({}, '');
-    return new GrpcClient(peerEndpoint, tlsCredentials, {
+    return new grpc.Client(peerEndpoint, tlsCredentials, {
         'grpc.ssl_target_name_override': 'peer0.org1.example.com'
     });
 }

--- a/scenario/node/src/customworld.ts
+++ b/scenario/node/src/customworld.ts
@@ -164,7 +164,6 @@ export class CustomWorld {
         // address is the name of the peer, lookup the connection info
         const peer = peerConnectionInfo[address];
         const tlsRootCert = await fs.readFile(peer.tlsRootCertPath)
-        const GrpcClient = grpc.makeGenericClientConstructor({}, '');
         const credentials = grpc.credentials.createSsl(tlsRootCert);
         let grpcOptions: Record<string, unknown> = {};
         if (peer.serverNameOverride) {
@@ -172,7 +171,7 @@ export class CustomWorld {
                 'grpc.ssl_target_name_override': peer.serverNameOverride
             };
         }
-        const client = new GrpcClient(peer.url, credentials, grpcOptions);
+        const client = new grpc.Client(peer.url, credentials, grpcOptions);
         await this.getCurrentGateway().connect(client);
     }
 


### PR DESCRIPTION
- Examples of default call timeouts.
- Simplify Node gRPC client constructor examples.