### PR TITLE
Timeouts for Go API

### DIFF
--- a/hsm-samples/go/hsm-sample.go
+++ b/hsm-samples/go/hsm-sample.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/sha256"
@@ -113,7 +114,9 @@ func exampleSubmitAsync(gateway *client.Gateway) {
 	fmt.Printf("Submit result: %s\n", string(submitResult))
 	fmt.Println("Waiting for transaction commit")
 
-	status, err := commit.Status()
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancel()
+	status, err := commit.Status(ctx)
 	if err != nil {
 		panic(fmt.Errorf("failed to obtain commit status: %w", err))
 	}

--- a/node/src/gateway.ts
+++ b/node/src/gateway.ts
@@ -32,7 +32,6 @@ import { SigningIdentity } from './signingidentity';
  *     endorseOptions: defaultTimeout,
  *     submitOptions: defaultTimeout,
  *     commitStatusOptions: defaultTimeout,
- *     chaincodeEventsOptions: defaultTimeout,
  * };
  * ```
  */

--- a/pkg/client/commit.go
+++ b/pkg/client/commit.go
@@ -9,7 +9,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/gateway"
@@ -60,13 +59,10 @@ func (commit *Commit) TransactionID() string {
 
 // Status of the committed transaction. If the transaction has not yet committed, this call blocks until the commit
 // occurs.
-func (commit *Commit) Status() (*Status, error) {
+func (commit *Commit) Status(ctx context.Context) (*Status, error) {
 	if err := commit.sign(); err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
 
 	response, err := commit.client.CommitStatus(ctx, commit.signedRequest)
 	if err != nil {

--- a/pkg/client/example_contract_test.go
+++ b/pkg/client/example_contract_test.go
@@ -7,7 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package client_test
 
 import (
+	"context"
 	"fmt"
+	"time"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
@@ -66,8 +68,11 @@ func ExampleContract_SubmitAsync() {
 	// Use transaction result to update UI or return REST response after successful submit to the orderer.
 	fmt.Printf("Result: %s", result)
 
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
 	// Wait for transaction commit.
-	status, err := commit.Status()
+	status, err := commit.Status(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -102,8 +107,11 @@ func ExampleContract_offlineSign() {
 		panic(err)
 	}
 
+	endorseCtx, cancelEndorse := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancelEndorse()
+
 	// Endorse proposal to create an endorsed transaction.
-	unsignedTransaction, err := signedProposal.Endorse()
+	unsignedTransaction, err := signedProposal.Endorse(endorseCtx)
 	if err != nil {
 		panic(err)
 	}
@@ -123,8 +131,11 @@ func ExampleContract_offlineSign() {
 		panic(err)
 	}
 
+	submitCtx, cancelSubmit := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancelSubmit()
+
 	// Submit transaction to the orderer.
-	unsignedCommit, err := signedTransaction.Submit()
+	unsignedCommit, err := signedTransaction.Submit(submitCtx)
 	if err != nil {
 		panic(err)
 	}
@@ -141,8 +152,11 @@ func ExampleContract_offlineSign() {
 	}
 	signedCommit, err := network.NewSignedCommit(commitBytes, commitSignature)
 
+	statusCtx, cancelStatus := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancelStatus()
+
 	// Wait for transaction commit.
-	status, err := signedCommit.Status()
+	status, err := signedCommit.Status(statusCtx)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/example_network_test.go
+++ b/pkg/client/example_network_test.go
@@ -18,6 +18,7 @@ func ExampleNetwork_ChaincodeEvents() {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
+
 	events, err := network.ChaincodeEvents(ctx, "chaincodeName", client.WithStartBlock(101))
 	if err != nil {
 		panic(err)
@@ -25,5 +26,6 @@ func ExampleNetwork_ChaincodeEvents() {
 
 	for event := range events {
 		fmt.Printf("Event: %#v\n", event)
+		// Break when done reading.
 	}
 }

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -19,6 +19,9 @@ import (
 )
 
 func TestOfflineSign(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	evaluateResponse := gateway.EvaluateResponse{
 		Result: &peer.Response{
 			Payload: nil,
@@ -63,7 +66,7 @@ func TestOfflineSign(t *testing.T) {
 			proposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
 
-			_, err = proposal.Evaluate()
+			_, err = proposal.Evaluate(ctx)
 			require.Error(t, err)
 		})
 
@@ -89,7 +92,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedProposal.Evaluate()
+			_, err = signedProposal.Evaluate(ctx)
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -118,7 +121,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
 			require.NoError(t, err)
 
-			_, err = signedProposal.Evaluate()
+			_, err = signedProposal.Evaluate(ctx)
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -137,7 +140,7 @@ func TestOfflineSign(t *testing.T) {
 			proposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
 
-			_, err = proposal.Endorse()
+			_, err = proposal.Endorse(ctx)
 			require.Error(t, err)
 		})
 
@@ -163,7 +166,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedProposal.Endorse()
+			_, err = signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -192,7 +195,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
 			require.NoError(t, err)
 
-			_, err = signedProposal.Endorse()
+			_, err = signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -220,10 +223,10 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			transaction, err := signedProposal.Endorse()
+			transaction, err := signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
-			_, err = transaction.Submit()
+			_, err = transaction.Submit(ctx)
 			require.Error(t, err)
 		})
 
@@ -251,7 +254,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse()
+			unsignedTransaction, err := signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -260,7 +263,7 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedTransaction.Submit()
+			_, err = signedTransaction.Submit(ctx)
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -291,7 +294,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse()
+			unsignedTransaction, err := signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -300,10 +303,10 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			commit, err := signedTransaction.Submit()
+			commit, err := signedTransaction.Submit(ctx)
 			require.NoError(t, err)
 
-			_, err = commit.Status()
+			_, err = commit.Status(ctx)
 			require.Error(t, err)
 		})
 
@@ -335,7 +338,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse()
+			unsignedTransaction, err := signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -344,7 +347,7 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
 			require.NoError(t, err)
 
-			unsignedCommit, err := signedTransaction.Submit()
+			unsignedCommit, err := signedTransaction.Submit(ctx)
 			require.NoError(t, err)
 
 			commitBytes, err := unsignedCommit.Bytes()
@@ -353,7 +356,7 @@ func TestOfflineSign(t *testing.T) {
 			signedCommit, err := network.NewSignedCommit(commitBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedCommit.Status()
+			_, err = signedCommit.Status(ctx)
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -416,7 +419,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse()
+			unsignedTransaction, err := signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -452,7 +455,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse()
+			unsignedTransaction, err := signedProposal.Endorse(ctx)
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -461,7 +464,7 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedCommit, err := signedTransaction.Submit()
+			unsignedCommit, err := signedTransaction.Submit(ctx)
 			require.NoError(t, err)
 
 			commitBytes, err := unsignedCommit.Bytes()

--- a/pkg/client/proposal.go
+++ b/pkg/client/proposal.go
@@ -9,7 +9,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/gateway"
@@ -44,13 +43,10 @@ func (proposal *Proposal) TransactionID() string {
 }
 
 // Endorse the proposal to obtain an endorsed transaction for submission to the orderer.
-func (proposal *Proposal) Endorse() (*Transaction, error) {
+func (proposal *Proposal) Endorse(ctx context.Context) (*Transaction, error) {
 	if err := proposal.sign(); err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
-	defer cancel()
 
 	endorseRequest := &gateway.EndorseRequest{
 		TransactionId:          proposal.proposedTransaction.GetTransactionId(),
@@ -78,13 +74,10 @@ func (proposal *Proposal) Endorse() (*Transaction, error) {
 }
 
 // Evaluate the proposal to obtain a transaction result. This is effectively a query.
-func (proposal *Proposal) Evaluate() ([]byte, error) {
+func (proposal *Proposal) Evaluate(ctx context.Context) ([]byte, error) {
 	if err := proposal.sign(); err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
-	defer cancel()
 
 	evaluateRequest := &gateway.EvaluateRequest{
 		TransactionId:       proposal.proposedTransaction.GetTransactionId(),

--- a/pkg/client/transaction.go
+++ b/pkg/client/transaction.go
@@ -9,7 +9,6 @@ package client
 import (
 	"context"
 	"fmt"
-	"time"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-protos-go/gateway"
@@ -49,7 +48,7 @@ func (transaction *Transaction) TransactionID() string {
 }
 
 // Submit the transaction to the orderer for commit to the ledger.
-func (transaction *Transaction) Submit() (*Commit, error) {
+func (transaction *Transaction) Submit(ctx context.Context) (*Commit, error) {
 	if err := transaction.sign(); err != nil {
 		return nil, err
 	}
@@ -59,9 +58,6 @@ func (transaction *Transaction) Submit() (*Commit, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
-	defer cancel()
 
 	submitRequest := &gateway.SubmitRequest{
 		TransactionId:       transaction.TransactionID(),

--- a/samples/java/src/main/java/com/example/Sample.java
+++ b/samples/java/src/main/java/com/example/Sample.java
@@ -63,8 +63,7 @@ public class Sample {
                 .evaluateOptions(CallOption.deadlineAfter(5, TimeUnit.SECONDS))
                 .endorseOptions(CallOption.deadlineAfter(15, TimeUnit.SECONDS))
                 .submitOptions(CallOption.deadlineAfter(5, TimeUnit.SECONDS))
-                .commitStatusOptions(CallOption.deadlineAfter(1, TimeUnit.MINUTES))
-                .chaincodeEventsOptions(CallOption.deadlineAfter(1, TimeUnit.MINUTES));
+                .commitStatusOptions(CallOption.deadlineAfter(1, TimeUnit.MINUTES));
 
         try (Gateway gateway = builder.connect()) {
             System.out.println("exampleSubmit:");

--- a/samples/node/src/sample.ts
+++ b/samples/node/src/sample.ts
@@ -41,9 +41,6 @@ async function main() {
         commitStatusOptions: () => {
             return { deadline: Date.now() + 60000 }; // 1 minute
         },
-        chaincodeEventsOptions: () => {
-            return { deadline: Date.now() + 60000 }; // 1 minute
-        },
     });
 
     try {

--- a/scenario/go/connection_test.go
+++ b/scenario/go/connection_test.go
@@ -243,7 +243,7 @@ func (connection *GatewayConnection) PrepareTransaction(txnType TransactionType,
 		return nil, fmt.Errorf("no contract selected")
 	}
 
-	return NewTransaction(connection.network, connection.contract, txnType, name), nil
+	return NewTransaction(connection.ctx, connection.network, connection.contract, txnType, name), nil
 }
 
 func (connection *GatewayConnection) ListenForChaincodeEvents(listenerName string, chaincodeName string) error {


### PR DESCRIPTION
- Removed chaincode events default call options from samples since it makes little sense to set an arbitrary timeout on a streaming call.

Contributes to #198 