### PR TITLE
Default gRPC call timeouts for Go API

### DIFF
--- a/hsm-samples/node/src/hsm-sample.ts
+++ b/hsm-samples/node/src/hsm-sample.ts
@@ -5,7 +5,6 @@
  */
 
 import * as grpc from '@grpc/grpc-js';
-import { ServiceClient } from '@grpc/grpc-js/build/src/make-client';
 import * as crypto from 'crypto';
 import { connect, Gateway, HSMSigner, HSMSignerFactory, HSMSignerOptions, signers } from 'fabric-gateway';
 import * as fs from 'fs';
@@ -46,9 +45,7 @@ async function main() {
     try {
         await exampleSubmit(gateway);
         console.log();
-
-        await exampleSubmitAsync(gateway)
-        console.log('\nNode HSM sample completed successfully');
+        console.log('Node HSM sample completed successfully');
     } finally {
         gateway.close();
         client.close();
@@ -72,37 +69,6 @@ async function exampleSubmit(gateway: Gateway) {
     console.log('Evaluating "get" query with arguments: time');
 
     const evaluateResult = await contract.evaluateTransaction('get', 'time');
-
-    console.log('Query result:', evaluateResult.toString());
-}
-
-async function exampleSubmitAsync(gateway: Gateway) {
-    const network = gateway.getNetwork('mychannel');
-    const contract = network.getContract('basic');
-
-    const timestamp = new Date().toISOString();
-    console.log('Submitting "put" transaction asynchronously with arguments: async,', timestamp);
-
-	// Submit transaction asynchronously, blocking until the transaction has been sent to the orderer, and allowing
-	// this thread to process the chaincode response (e.g. update a UI) without waiting for the commit notification
-    const commit = await contract.submitAsync('put', {
-        arguments: ['async', timestamp],
-    });
-    const submitResult = commit.getResult();
-
-    console.log('Submit result:', submitResult.toString());
-    console.log('Waiting for transaction commit');
-
-    const status = await commit.getStatus();
-    if (!status.successful) {
-        const status = await commit.getStatus();
-        throw new Error(`Transaction ${status.transactionId} failed to commit with status code: ${status.code}`);
-    }
-
-    console.log('Transaction committed successfully');
-    console.log('Evaluating "get" query with arguments: async');
-
-    const evaluateResult = await contract.evaluateTransaction('get', 'async');
 
     console.log('Query result:', evaluateResult.toString());
 }

--- a/pkg/client/context.go
+++ b/pkg/client/context.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import "context"
+
+type contextWithCancel func(parent context.Context) (context.Context, context.CancelFunc)
+
+type contextFactory struct {
+	ctx          context.Context
+	evaluate     contextWithCancel
+	endorse      contextWithCancel
+	submit       contextWithCancel
+	commitStatus contextWithCancel
+}
+
+func (factory *contextFactory) getOrDefault(supplier contextWithCancel) (context.Context, context.CancelFunc) {
+	if supplier != nil {
+		return supplier(factory.ctx)
+	}
+	return context.WithCancel(factory.ctx)
+}
+
+func (factory *contextFactory) Evaluate() (context.Context, context.CancelFunc) {
+	return factory.getOrDefault(factory.evaluate)
+}
+
+func (factory *contextFactory) Endorse() (context.Context, context.CancelFunc) {
+	return factory.getOrDefault(factory.endorse)
+}
+
+func (factory *contextFactory) Submit() (context.Context, context.CancelFunc) {
+	return factory.getOrDefault(factory.submit)
+}
+
+func (factory *contextFactory) CommitStatus() (context.Context, context.CancelFunc) {
+	return factory.getOrDefault(factory.commitStatus)
+}

--- a/pkg/client/network.go
+++ b/pkg/client/network.go
@@ -20,6 +20,7 @@ type Network struct {
 	client    gateway.GatewayClient
 	signingID *signingIdentity
 	name      string
+	contexts  *contextFactory
 }
 
 // Name of the Fabric channel this network represents.
@@ -40,6 +41,7 @@ func (network *Network) GetContractWithName(chaincodeName string, contractName s
 		channelName:   network.name,
 		chaincodeName: chaincodeName,
 		contractName:  contractName,
+		contexts:      network.contexts,
 	}
 }
 

--- a/samples/go/sample.go
+++ b/samples/go/sample.go
@@ -39,7 +39,16 @@ func main() {
 	sign := newSign()
 
 	// Create a Gateway connection for a specific client identity
-	gateway, err := client.Connect(id, client.WithSign(sign), client.WithClientConnection(clientConnection))
+	gateway, err := client.Connect(
+		id,
+		client.WithSign(sign),
+		client.WithClientConnection(clientConnection),
+		// Default timeouts for different gRPC calls
+		client.WithEvaluateTimeout(5*time.Second),
+		client.WithEndorseTimeout(15*time.Second),
+		client.WithSubmitTimeout(5*time.Second),
+		client.WithCommitStatusTimeout(1*time.Minute),
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -305,7 +314,6 @@ func exampleChaincodeEventReplay(gateway *client.Gateway) {
 
 	statusCtx, cancelStatus := context.WithTimeout(context.Background(), 1*time.Minute)
 	defer cancelStatus()
-
 	status, err := commit.Status(statusCtx)
 	if err != nil {
 		panic(fmt.Errorf("failed to get commit status: %w", err))


### PR DESCRIPTION
- Updated samples to demonstrate setting default timeouts.
- Removed async submit example for HSM samples since this duplicates main samples and keeping them simple makes it easier to see the HSM-specific aspects.

Contributes to #198 