### PR TITLE
Reinstate nightly publishing

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -183,11 +183,10 @@ stages:
           make run-samples-java
         displayName: Run Java SDK samples
 
-# TODO Only publish on scheduled builds
+# Only publish on scheduled builds
 - stage: Publish
   dependsOn: Test
-  condition: and(succeeded('Test'),eq(variables['Build.Reason'], 'IndividualCI'))
-  #condition: and(succeeded('Test'), eq(variables['Build.Reason'], 'Schedule'))
+  condition: and(succeeded('Test'), eq(variables['Build.Reason'], 'Schedule'))
   jobs:
   - job: PublishDocs
     pool:
@@ -251,37 +250,6 @@ stages:
       - script: |
           npm publish --access public --tag unstable
         displayName: npm publish
-        workingDirectory: $(Pipeline.Workspace)/NodeBuild
-        env:
-          GATEWAY_VERSION: $(GATEWAY_VERSION)
-          BUILD_DATE: $(BUILD_DATE)
-          BUILD_NUMBER: $(BUILD_NUMBER)
-  # TODO Remove after deprecation!!!
-  - job: DeprecateNodeModule
-    pool:
-      vmImage: ubuntu-20.04
-    steps:
-      - download: current
-        artifact: NodeBuild
-      - task: NodeTool@0
-        inputs:
-          versionSpec: 16.13.0
-      - script: |
-          touch $(Agent.TempDirectory)/.npmrc
-          echo '##vso[task.setvariable variable=NPM_CONFIG_USERCONFIG]$(Agent.TempDirectory)/.npmrc'
-        displayName: 'create user .npmrc file'
-      - script: |
-          npm config set registry https://registry.npmjs.org/
-          npm config set git-tag-version false
-          npm config ls
-        displayName: set npm config
-      - task: npmAuthenticate@0
-        inputs:
-          workingFile: '$(Agent.TempDirectory)/.npmrc'
-          customEndpoint: 'npm'
-      - script: |
-          npm deprecate fabric-gateway "Use @hyperledger/fabric-gateway"
-        displayName: npm deprecate
         workingDirectory: $(Pipeline.Workspace)/NodeBuild
         env:
           GATEWAY_VERSION: $(GATEWAY_VERSION)


### PR DESCRIPTION
Old node module has been deprecated so can remove that step from ci and
switch back to nightly publishing

Signed-off-by: James Taylor <jamest@uk.ibm.com>

Contributes to #209 