### PR TITLE
Make fine-grained Go API usable without explicit context handling

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -22,9 +22,9 @@
     "author": "",
     "license": "Apache-2.0",
     "dependencies": {
-        "@grpc/grpc-js": "^1.4.1",
+        "@grpc/grpc-js": "^1.4.2",
         "asn1.js": "^5.4.1",
-        "elliptic": "^6.5.3",
+        "elliptic": "^6.5.4",
         "google-protobuf": "^3.18.0"
     },
     "optionalDependencies": {
@@ -32,21 +32,21 @@
     },
     "devDependencies": {
         "@tsconfig/node12": "^1.0.9",
-        "@types/elliptic": "^6.4.13",
+        "@types/elliptic": "^6.4.14",
         "@types/google-protobuf": "^3.15.5",
         "@types/jest": "^27.0.1",
-        "@types/node": "^12.20.33",
-        "@typescript-eslint/eslint-plugin": "^5.0.0",
-        "@typescript-eslint/parser": "^5.0.0",
-        "eslint": "^8.0.1",
-        "eslint-plugin-jest": "^25.0.6",
+        "@types/node": "^12.20.36",
+        "@typescript-eslint/eslint-plugin": "^5.3.0",
+        "@typescript-eslint/parser": "^5.3.0",
+        "eslint": "^8.1.0",
+        "eslint-plugin-jest": "^25.2.2",
         "eslint-plugin-tsdoc": "^0.2.14",
         "grpc-tools": "^1.11.2",
-        "jest": "^27.2.5",
+        "jest": "^27.3.1",
         "npm-run-all": "^4.1.5",
-        "ts-jest": "^27.0.5",
+        "ts-jest": "^27.0.7",
         "ts-protoc-gen": "^0.15.0",
-        "typedoc": "^0.22.3",
-        "typescript": "^4.4.4"
+        "typedoc": "^0.22.7",
+        "typescript": "~4.4.4"
     }
 }

--- a/node/src/identity/signers.ts
+++ b/node/src/identity/signers.ts
@@ -44,7 +44,7 @@ function newECPrivateKeySigner(key: KeyObject): Signer {
 
     return async (digest) => {
         const signature = curve.sign(digest, keyPair, { canonical: true });
-        const signatureBytes = new Uint8Array(signature.toDER() as number[]);
+        const signatureBytes = new Uint8Array(signature.toDER());
         return Promise.resolve(signatureBytes);
     }
 }

--- a/pkg/client/chaincodeevents.go
+++ b/pkg/client/chaincodeevents.go
@@ -16,7 +16,7 @@ import (
 
 // ChaincodeEventsRequest delivers events emitted by transaction functions in a specific chaincode.
 type ChaincodeEventsRequest struct {
-	client        gateway.GatewayClient
+	client        *gatewayClient
 	signingID     *signingIdentity
 	signedRequest *gateway.SignedChaincodeEventsRequest
 }

--- a/pkg/client/chaincodeeventsbuilder.go
+++ b/pkg/client/chaincodeeventsbuilder.go
@@ -15,7 +15,7 @@ import (
 )
 
 type chaincodeEventsBuilder struct {
-	client        gateway.GatewayClient
+	client        *gatewayClient
 	signingID     *signingIdentity
 	channelName   string
 	chaincodeName string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"context"
+
+	"github.com/hyperledger/fabric-protos-go/gateway"
+	"google.golang.org/grpc"
+)
+
+type gatewayClient struct {
+	grpcClient gateway.GatewayClient
+	contexts   *contextFactory
+}
+
+func (client *gatewayClient) Endorse(in *gateway.EndorseRequest, opts ...grpc.CallOption) (*gateway.EndorseResponse, error) {
+	ctx, cancel := client.contexts.Endorse()
+	defer cancel()
+	return client.EndorseWithContext(ctx, in, opts...)
+}
+
+func (client *gatewayClient) EndorseWithContext(ctx context.Context, in *gateway.EndorseRequest, opts ...grpc.CallOption) (*gateway.EndorseResponse, error) {
+	return client.grpcClient.Endorse(ctx, in, opts...)
+}
+
+func (client *gatewayClient) Submit(in *gateway.SubmitRequest, opts ...grpc.CallOption) (*gateway.SubmitResponse, error) {
+	ctx, cancel := client.contexts.Submit()
+	defer cancel()
+	return client.SubmitWithContext(ctx, in, opts...)
+}
+
+func (client *gatewayClient) SubmitWithContext(ctx context.Context, in *gateway.SubmitRequest, opts ...grpc.CallOption) (*gateway.SubmitResponse, error) {
+	return client.grpcClient.Submit(ctx, in, opts...)
+}
+
+func (client *gatewayClient) CommitStatus(in *gateway.SignedCommitStatusRequest, opts ...grpc.CallOption) (*gateway.CommitStatusResponse, error) {
+	ctx, cancel := client.contexts.CommitStatus()
+	defer cancel()
+	return client.CommitStatusWithContext(ctx, in, opts...)
+}
+
+func (client *gatewayClient) CommitStatusWithContext(ctx context.Context, in *gateway.SignedCommitStatusRequest, opts ...grpc.CallOption) (*gateway.CommitStatusResponse, error) {
+	return client.grpcClient.CommitStatus(ctx, in, opts...)
+}
+
+func (client *gatewayClient) Evaluate(in *gateway.EvaluateRequest, opts ...grpc.CallOption) (*gateway.EvaluateResponse, error) {
+	ctx, cancel := client.contexts.Evaluate()
+	defer cancel()
+	return client.EvaluateWithContext(ctx, in, opts...)
+}
+
+func (client *gatewayClient) EvaluateWithContext(ctx context.Context, in *gateway.EvaluateRequest, opts ...grpc.CallOption) (*gateway.EvaluateResponse, error) {
+	return client.grpcClient.Evaluate(ctx, in, opts...)
+}
+
+func (client *gatewayClient) ChaincodeEvents(ctx context.Context, in *gateway.SignedChaincodeEventsRequest, opts ...grpc.CallOption) (gateway.Gateway_ChaincodeEventsClient, error) {
+	return client.grpcClient.ChaincodeEvents(ctx, in, opts...)
+}

--- a/pkg/client/evaluate_test.go
+++ b/pkg/client/evaluate_test.go
@@ -31,9 +31,6 @@ func NewStatusError(t *testing.T, code codes.Code, message string, details ...pr
 }
 
 func TestEvaluateTransaction(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	newEvaluateResponse := func(value []byte) *gateway.EvaluateResponse {
 		return &gateway.EvaluateResponse{
 			Result: &peer.Response{
@@ -200,7 +197,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		proposal, err := contract.NewProposal("transaction")
 		require.NoError(t, err, "NewProposal")
-		_, err = proposal.Evaluate(ctx)
+		_, err = proposal.Evaluate()
 		require.NoError(t, err, "Evaluate")
 
 		require.Equal(t, proposal.TransactionID(), actual)
@@ -220,7 +217,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		proposal, err := contract.NewProposal("transaction")
 		require.NoError(t, err, "NewProposal")
-		_, err = proposal.Evaluate(ctx)
+		_, err = proposal.Evaluate()
 		require.NoError(t, err, "Evaluate")
 
 		require.Equal(t, proposal.TransactionID(), actual)
@@ -299,8 +296,9 @@ func TestEvaluateTransaction(t *testing.T) {
 
 	t.Run("Uses specified context", func(t *testing.T) {
 		var actual context.Context
-		evaluateCtx, cancelCtx := context.WithCancel(ctx)
-		defer cancelCtx()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
 		mockClient := NewMockGatewayClient(gomock.NewController(t))
 		mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
@@ -314,11 +312,11 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		proposal, err := contract.NewProposal("transaction")
 		require.NoError(t, err, "NewProposal")
-		_, err = proposal.Evaluate(evaluateCtx)
+		_, err = proposal.EvaluateWithContext(ctx)
 		require.NoError(t, err, "Evaluate")
 
 		require.Nil(t, actual.Err(), "context not done before explicit cancel")
-		cancelCtx()
+		cancel()
 		require.NotNil(t, actual.Err(), "context done after explicit cancel")
 	})
 

--- a/pkg/client/example_contract_test.go
+++ b/pkg/client/example_contract_test.go
@@ -7,9 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package client_test
 
 import (
-	"context"
 	"fmt"
-	"time"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
@@ -68,11 +66,8 @@ func ExampleContract_SubmitAsync() {
 	// Use transaction result to update UI or return REST response after successful submit to the orderer.
 	fmt.Printf("Result: %s", result)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
-
 	// Wait for transaction commit.
-	status, err := commit.Status(ctx)
+	status, err := commit.Status()
 	if err != nil {
 		panic(err)
 	}
@@ -107,11 +102,8 @@ func ExampleContract_offlineSign() {
 		panic(err)
 	}
 
-	endorseCtx, cancelEndorse := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancelEndorse()
-
 	// Endorse proposal to create an endorsed transaction.
-	unsignedTransaction, err := signedProposal.Endorse(endorseCtx)
+	unsignedTransaction, err := signedProposal.Endorse()
 	if err != nil {
 		panic(err)
 	}
@@ -131,11 +123,8 @@ func ExampleContract_offlineSign() {
 		panic(err)
 	}
 
-	submitCtx, cancelSubmit := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancelSubmit()
-
 	// Submit transaction to the orderer.
-	unsignedCommit, err := signedTransaction.Submit(submitCtx)
+	unsignedCommit, err := signedTransaction.Submit()
 	if err != nil {
 		panic(err)
 	}
@@ -152,11 +141,8 @@ func ExampleContract_offlineSign() {
 	}
 	signedCommit, err := network.NewSignedCommit(commitBytes, commitSignature)
 
-	statusCtx, cancelStatus := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancelStatus()
-
 	// Wait for transaction commit.
-	status, err := signedCommit.Status(statusCtx)
+	status, err := signedCommit.Status()
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/gateway_test.go
+++ b/pkg/client/gateway_test.go
@@ -22,7 +22,7 @@ import (
 // WithClient uses the supplied client for the Gateway. Allows a stub implementation to be used for testing.
 func WithClient(client proto.GatewayClient) ConnectOption {
 	return func(gateway *Gateway) error {
-		gateway.client = client
+		gateway.client.grpcClient = client
 		return nil
 	}
 }

--- a/pkg/client/network.go
+++ b/pkg/client/network.go
@@ -17,10 +17,9 @@ import (
 // Network represents a blockchain network, or Fabric channel. The Network can be used to access deployed smart
 // contracts, and to listen for events emitted when blocks are committed to the ledger.
 type Network struct {
-	client    gateway.GatewayClient
+	client    *gatewayClient
 	signingID *signingIdentity
 	name      string
-	contexts  *contextFactory
 }
 
 // Name of the Fabric channel this network represents.
@@ -41,7 +40,6 @@ func (network *Network) GetContractWithName(chaincodeName string, contractName s
 		channelName:   network.name,
 		chaincodeName: chaincodeName,
 		contractName:  contractName,
-		contexts:      network.contexts,
 	}
 }
 

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -19,9 +19,6 @@ import (
 )
 
 func TestOfflineSign(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
 	evaluateResponse := gateway.EvaluateResponse{
 		Result: &peer.Response{
 			Payload: nil,
@@ -66,7 +63,7 @@ func TestOfflineSign(t *testing.T) {
 			proposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
 
-			_, err = proposal.Evaluate(ctx)
+			_, err = proposal.Evaluate()
 			require.Error(t, err)
 		})
 
@@ -92,7 +89,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedProposal.Evaluate(ctx)
+			_, err = signedProposal.Evaluate()
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -121,7 +118,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
 			require.NoError(t, err)
 
-			_, err = signedProposal.Evaluate(ctx)
+			_, err = signedProposal.Evaluate()
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -140,7 +137,7 @@ func TestOfflineSign(t *testing.T) {
 			proposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
 
-			_, err = proposal.Endorse(ctx)
+			_, err = proposal.Endorse()
 			require.Error(t, err)
 		})
 
@@ -166,7 +163,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedProposal.Endorse(ctx)
+			_, err = signedProposal.Endorse()
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -195,7 +192,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
 			require.NoError(t, err)
 
-			_, err = signedProposal.Endorse(ctx)
+			_, err = signedProposal.Endorse()
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -223,10 +220,10 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			transaction, err := signedProposal.Endorse(ctx)
+			transaction, err := signedProposal.Endorse()
 			require.NoError(t, err)
 
-			_, err = transaction.Submit(ctx)
+			_, err = transaction.Submit()
 			require.Error(t, err)
 		})
 
@@ -254,7 +251,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse(ctx)
+			unsignedTransaction, err := signedProposal.Endorse()
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -263,7 +260,7 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedTransaction.Submit(ctx)
+			_, err = signedTransaction.Submit()
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -294,7 +291,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse(ctx)
+			unsignedTransaction, err := signedProposal.Endorse()
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -303,10 +300,10 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			commit, err := signedTransaction.Submit(ctx)
+			commit, err := signedTransaction.Submit()
 			require.NoError(t, err)
 
-			_, err = commit.Status(ctx)
+			_, err = commit.Status()
 			require.Error(t, err)
 		})
 
@@ -338,7 +335,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse(ctx)
+			unsignedTransaction, err := signedProposal.Endorse()
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -347,7 +344,7 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
 			require.NoError(t, err)
 
-			unsignedCommit, err := signedTransaction.Submit(ctx)
+			unsignedCommit, err := signedTransaction.Submit()
 			require.NoError(t, err)
 
 			commitBytes, err := unsignedCommit.Bytes()
@@ -356,7 +353,7 @@ func TestOfflineSign(t *testing.T) {
 			signedCommit, err := network.NewSignedCommit(commitBytes, expected)
 			require.NoError(t, err)
 
-			_, err = signedCommit.Status(ctx)
+			_, err = signedCommit.Status()
 			require.NoError(t, err)
 
 			require.EqualValues(t, expected, actual)
@@ -419,7 +416,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse(ctx)
+			unsignedTransaction, err := signedProposal.Endorse()
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -455,7 +452,7 @@ func TestOfflineSign(t *testing.T) {
 			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedTransaction, err := signedProposal.Endorse(ctx)
+			unsignedTransaction, err := signedProposal.Endorse()
 			require.NoError(t, err)
 
 			transactionBytes, err := unsignedTransaction.Bytes()
@@ -464,7 +461,7 @@ func TestOfflineSign(t *testing.T) {
 			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
 			require.NoError(t, err)
 
-			unsignedCommit, err := signedTransaction.Submit(ctx)
+			unsignedCommit, err := signedTransaction.Submit()
 			require.NoError(t, err)
 
 			commitBytes, err := unsignedCommit.Bytes()

--- a/pkg/client/proposalbuilder.go
+++ b/pkg/client/proposalbuilder.go
@@ -17,7 +17,7 @@ import (
 )
 
 type proposalBuilder struct {
-	client          gateway.GatewayClient
+	client          *gatewayClient
 	signingID       *signingIdentity
 	channelName     string
 	chaincodeName   string

--- a/samples/go/sample.go
+++ b/samples/go/sample.go
@@ -128,9 +128,7 @@ func exampleSubmitAsync(gateway *client.Gateway) {
 	fmt.Printf("Submit result: %s\n", string(submitResult))
 	fmt.Println("Waiting for transaction commit")
 
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancel()
-	if status, err := commit.Status(ctx); err != nil {
+	if status, err := commit.Status(); err != nil {
 		panic(fmt.Errorf("failed to get commit status: %w", err))
 	} else if !status.Successful {
 		panic(fmt.Errorf("transaction %s, failed to commit with status: %d", status.TransactionID, int32(status.Code)))
@@ -312,9 +310,7 @@ func exampleChaincodeEventReplay(gateway *client.Gateway) {
 		panic(fmt.Errorf("failed to submit transaction: %w", err))
 	}
 
-	statusCtx, cancelStatus := context.WithTimeout(context.Background(), 1*time.Minute)
-	defer cancelStatus()
-	status, err := commit.Status(statusCtx)
+	status, err := commit.Status()
 	if err != nil {
 		panic(fmt.Errorf("failed to get commit status: %w", err))
 	}
@@ -323,9 +319,9 @@ func exampleChaincodeEventReplay(gateway *client.Gateway) {
 	}
 
 	fmt.Printf("Read chaincode events starting at block number %d\n", status.BlockNumber)
-	eventsCtx, cancelEvents := context.WithCancel(context.Background())
-	defer cancelEvents()
-	events, err := network.ChaincodeEvents(eventsCtx, "basic", client.WithStartBlock(status.BlockNumber))
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	events, err := network.ChaincodeEvents(ctx, "basic", client.WithStartBlock(status.BlockNumber))
 	if err != nil {
 		panic(fmt.Errorf("failed to read chaincode events: %w", err))
 	}

--- a/scenario/go/connection_test.go
+++ b/scenario/go/connection_test.go
@@ -243,7 +243,7 @@ func (connection *GatewayConnection) PrepareTransaction(txnType TransactionType,
 		return nil, fmt.Errorf("no contract selected")
 	}
 
-	return NewTransaction(connection.ctx, connection.network, connection.contract, txnType, name), nil
+	return NewTransaction(connection.network, connection.contract, txnType, name), nil
 }
 
 func (connection *GatewayConnection) ListenForChaincodeEvents(listenerName string, chaincodeName string) error {

--- a/scenario/go/transaction_test.go
+++ b/scenario/go/transaction_test.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package scenario
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
@@ -18,7 +17,6 @@ import (
 )
 
 type Transaction struct {
-	ctx         context.Context
 	network     *client.Network
 	contract    *client.Contract
 	txType      TransactionType
@@ -30,9 +28,8 @@ type Transaction struct {
 	blockNumber uint64
 }
 
-func NewTransaction(ctx context.Context, network *client.Network, contract *client.Contract, txType TransactionType, name string) *Transaction {
+func NewTransaction(network *client.Network, contract *client.Contract, txType TransactionType, name string) *Transaction {
 	return &Transaction{
-		ctx:      ctx,
 		network:  network,
 		contract: contract,
 		txType:   txType,
@@ -93,7 +90,7 @@ func (transaction *Transaction) evaluate() ([]byte, error) {
 		return nil, err
 	}
 
-	return proposal.Evaluate(transaction.ctx)
+	return proposal.Evaluate()
 }
 
 func (transaction *Transaction) submit() ([]byte, error) {
@@ -107,7 +104,7 @@ func (transaction *Transaction) submit() ([]byte, error) {
 		return nil, err
 	}
 
-	unsignedTransaction, err := proposal.Endorse(transaction.ctx)
+	unsignedTransaction, err := proposal.Endorse()
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +116,7 @@ func (transaction *Transaction) submit() ([]byte, error) {
 
 	result := signedTransaction.Result()
 
-	unsignedCommit, err := signedTransaction.Submit(transaction.ctx)
+	unsignedCommit, err := signedTransaction.Submit()
 	if err != nil {
 		return result, err
 	}
@@ -129,7 +126,7 @@ func (transaction *Transaction) submit() ([]byte, error) {
 		return result, err
 	}
 
-	status, err := signedCommit.Status(transaction.ctx)
+	status, err := signedCommit.Status()
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
Use default contexts throughout the Go API, except for chaincode events, which requires an explicit context for cancellation. This avoids requiring the burden of context management for the client application. Added ...WithContext() alternatives to finer-grained calls to allow a context to be specified if desired.

Also fixes a build break in Node linting when we picked up new type definitions for a dependency.

Closes #198 