### PR TITLE
Use ECMAScript private methods instead of TypeScript private modifiers

### DIFF
--- a/node/src/chaincodeeventsbuilder.ts
+++ b/node/src/chaincodeeventsbuilder.ts
@@ -20,17 +20,17 @@ export interface ChaincodeEventsOptions {
     startBlock?: bigint;
 }
 
-export interface ChaincodeEventsBuilderOptions extends Readonly<ChaincodeEventsOptions> {
-    readonly client: GatewayClient;
-    readonly signingIdentity: SigningIdentity;
-    readonly channelName: string;
-    readonly chaincodeName: string;
+export interface ChaincodeEventsBuilderOptions extends ChaincodeEventsOptions {
+    client: GatewayClient;
+    signingIdentity: SigningIdentity;
+    channelName: string;
+    chaincodeName: string;
 }
 
 export class ChaincodeEventsBuilder {
-    readonly #options: ChaincodeEventsBuilderOptions;
+    readonly #options: Readonly<ChaincodeEventsBuilderOptions>;
 
-    constructor(options: ChaincodeEventsBuilderOptions) {
+    constructor(options: Readonly<ChaincodeEventsBuilderOptions>) {
         this.#options = options;
     }
 
@@ -38,21 +38,21 @@ export class ChaincodeEventsBuilder {
         return new ChaincodeEventsRequestImpl({
             client: this.#options.client,
             signingIdentity: this.#options.signingIdentity,
-            request: this.newChaincodeEventsRequestProto(),
+            request: this.#newChaincodeEventsRequestProto(),
         });
     }
 
-    private newChaincodeEventsRequestProto(): ChaincodeEventsRequestProto {
+    #newChaincodeEventsRequestProto(): ChaincodeEventsRequestProto {
         const result = new ChaincodeEventsRequestProto();
         result.setChannelId(this.#options.channelName);
         result.setChaincodeId(this.#options.chaincodeName);
         result.setIdentity(this.#options.signingIdentity.getCreator());
-        result.setStartPosition(this.getStartPosition());
+        result.setStartPosition(this.#getStartPosition());
 
         return result;
     }
 
-    private getStartPosition(): SeekPosition {
+    #getStartPosition(): SeekPosition {
         const result = new SeekPosition();
 
         const startBlock = this.#options.startBlock;

--- a/node/src/chaincodeeventsrequest.ts
+++ b/node/src/chaincodeeventsrequest.ts
@@ -35,9 +35,9 @@ export interface ChaincodeEventsRequest extends Signable {
 }
 
 export interface ChaincodeEventsRequestOptions {
-    readonly client: GatewayClient;
-    readonly signingIdentity: SigningIdentity;
-    readonly request: ChaincodeEventsRequestProto;
+    client: GatewayClient;
+    signingIdentity: SigningIdentity;
+    request: ChaincodeEventsRequestProto;
 }
 
 export class ChaincodeEventsRequestImpl implements ChaincodeEventsRequest {
@@ -45,7 +45,7 @@ export class ChaincodeEventsRequestImpl implements ChaincodeEventsRequest {
     readonly #signingIdentity: SigningIdentity;
     readonly #signedRequest: SignedChaincodeEventsRequestProto;
 
-    constructor(options: ChaincodeEventsRequestOptions) {
+    constructor(options: Readonly<ChaincodeEventsRequestOptions>) {
         this.#client = options.client;
         this.#signingIdentity = options.signingIdentity;
         this.#signedRequest = new SignedChaincodeEventsRequestProto();
@@ -53,7 +53,7 @@ export class ChaincodeEventsRequestImpl implements ChaincodeEventsRequest {
     }
 
     async getEvents(options?: CallOptions): Promise<CloseableAsyncIterable<ChaincodeEvent>> {
-        await this.sign();
+        await this.#sign();
         const responses = this.#client.chaincodeEvents(this.#signedRequest, options);
         return newChaincodeEvents(responses);
     }
@@ -70,8 +70,8 @@ export class ChaincodeEventsRequestImpl implements ChaincodeEventsRequest {
         this.#signedRequest.setSignature(signature);
     }
 
-    private async sign(): Promise<void> {
-        if (this.isSigned()) {
+    async #sign(): Promise<void> {
+        if (this.#isSigned()) {
             return;
         }
 
@@ -79,7 +79,7 @@ export class ChaincodeEventsRequestImpl implements ChaincodeEventsRequest {
         this.setSignature(signature);
     }
 
-    private isSigned(): boolean {
+    #isSigned(): boolean {
         const signatureLength = this.#signedRequest.getSignature()?.length || 0;
         return signatureLength > 0;
     }

--- a/node/src/client.test.ts
+++ b/node/src/client.test.ts
@@ -16,25 +16,25 @@ type MockUnaryRequest<RequestType, ResponseType> = jest.Mock<grpc.ClientUnaryCal
 type MockServerStreamRequest<RequestType, ResponseType> = jest.Mock<ServerStreamResponse<ResponseType>, [RequestType, grpc.CallOptions]>;
 
 export class MockGatewayGrpcClient implements GatewayGrpcClient {
-    readonly chaincodeEventsMock = jest.fn() as MockServerStreamRequest<SignedChaincodeEventsRequest, ChaincodeEventsResponse>;
-    readonly commitStatusMock = jest.fn() as MockUnaryRequest<SignedCommitStatusRequest, CommitStatusResponse>;
-    readonly endorseMock = jest.fn() as MockUnaryRequest<EndorseRequest, EndorseResponse>;
-    readonly evaluateMock = jest.fn() as MockUnaryRequest<EvaluateRequest, EvaluateResponse>;
-    readonly submitMock = jest.fn() as MockUnaryRequest<SubmitRequest, SubmitResponse>;
+    readonly #chaincodeEventsMock = jest.fn() as MockServerStreamRequest<SignedChaincodeEventsRequest, ChaincodeEventsResponse>;
+    readonly #commitStatusMock = jest.fn() as MockUnaryRequest<SignedCommitStatusRequest, CommitStatusResponse>;
+    readonly #endorseMock = jest.fn() as MockUnaryRequest<EndorseRequest, EndorseResponse>;
+    readonly #evaluateMock = jest.fn() as MockUnaryRequest<EvaluateRequest, EvaluateResponse>;
+    readonly #submitMock = jest.fn() as MockUnaryRequest<SubmitRequest, SubmitResponse>;
 
     #unaryMocks = {
-        [commitStatusMethod]: this.commitStatusMock,
-        [endorseMethod]: this.endorseMock,
-        [evaluateMethod]: this.evaluateMock,
-        [submitMethod]: this.submitMock,
+        [commitStatusMethod]: this.#commitStatusMock,
+        [endorseMethod]: this.#endorseMock,
+        [evaluateMethod]: this.#evaluateMock,
+        [submitMethod]: this.#submitMock,
     };
     #serverStreamMocks = {
-        [chaincodeEventsMethod]: this.chaincodeEventsMock,
+        [chaincodeEventsMethod]: this.#chaincodeEventsMock,
     };
 
     constructor() {
         // Default empty responses
-        this.chaincodeEventsMock.mockReturnValue({
+        this.#chaincodeEventsMock.mockReturnValue({
             async* [Symbol.asyncIterator]() {
                 // Nothing
             },
@@ -80,79 +80,79 @@ export class MockGatewayGrpcClient implements GatewayGrpcClient {
     }
 
     getChaincodeEventsRequests(): SignedChaincodeEventsRequest[] {
-        return this.chaincodeEventsMock.mock.calls.map(call => call[0]);
+        return this.#chaincodeEventsMock.mock.calls.map(call => call[0]);
     }
 
     getCommitStatusRequests(): SignedCommitStatusRequest[] {
-        return this.commitStatusMock.mock.calls.map(call => call[0]);
+        return this.#commitStatusMock.mock.calls.map(call => call[0]);
     }
 
     getEndorseRequests(): EndorseRequest[] {
-        return this.endorseMock.mock.calls.map(call => call[0]);
+        return this.#endorseMock.mock.calls.map(call => call[0]);
     }
 
     getEvaluateRequests(): EvaluateRequest[] {
-        return this.evaluateMock.mock.calls.map(call => call[0]);
+        return this.#evaluateMock.mock.calls.map(call => call[0]);
     }
 
     getSubmitRequests(): SubmitRequest[] {
-        return this.submitMock.mock.calls.map(call => call[0]);
+        return this.#submitMock.mock.calls.map(call => call[0]);
     }
 
     getChaincodeEventsOptions(): grpc.CallOptions[] {
-        return this.chaincodeEventsMock.mock.calls.map(call => call[1]);
+        return this.#chaincodeEventsMock.mock.calls.map(call => call[1]);
     }
 
     getCommitStatusOptions(): grpc.CallOptions[] {
-        return this.commitStatusMock.mock.calls.map(call => call[1]);
+        return this.#commitStatusMock.mock.calls.map(call => call[1]);
     }
 
     getEndorseOptions(): grpc.CallOptions[] {
-        return this.endorseMock.mock.calls.map(call => call[1]);
+        return this.#endorseMock.mock.calls.map(call => call[1]);
     }
 
     getEvaluateOptions(): grpc.CallOptions[] {
-        return this.evaluateMock.mock.calls.map(call => call[1]);
+        return this.#evaluateMock.mock.calls.map(call => call[1]);
     }
 
     getSubmitOptions(): grpc.CallOptions[] {
-        return this.submitMock.mock.calls.map(call => call[1]);
+        return this.#submitMock.mock.calls.map(call => call[1]);
     }
 
     mockCommitStatusResponse(response: CommitStatusResponse): void {
-        this.commitStatusMock.mockImplementation(fakeUnaryCall(undefined, response));
+        this.#commitStatusMock.mockImplementation(fakeUnaryCall(undefined, response));
     }
 
     mockCommitStatusError(err: grpc.ServiceError): void {
-        this.commitStatusMock.mockImplementation(fakeUnaryCall(err, undefined));
+        this.#commitStatusMock.mockImplementation(fakeUnaryCall(err, undefined));
     }
 
     mockEndorseResponse(response: EndorseResponse): void {
-        this.endorseMock.mockImplementation(fakeUnaryCall(undefined, response));
+        this.#endorseMock.mockImplementation(fakeUnaryCall(undefined, response));
     }
 
     mockEndorseError(err: grpc.ServiceError): void {
-        this.endorseMock.mockImplementation(fakeUnaryCall(err, undefined));
+        this.#endorseMock.mockImplementation(fakeUnaryCall(err, undefined));
     }
 
     mockEvaluateResponse(response: EvaluateResponse): void {
-        this.evaluateMock.mockImplementation(fakeUnaryCall(undefined, response));
+        this.#evaluateMock.mockImplementation(fakeUnaryCall(undefined, response));
     }
 
     mockEvaluateError(err: grpc.ServiceError): void {
-        this.evaluateMock.mockImplementation(fakeUnaryCall(err, undefined));
+        this.#evaluateMock.mockImplementation(fakeUnaryCall(err, undefined));
     }
 
     mockSubmitResponse(response: SubmitResponse): void {
-        this.submitMock.mockImplementation(fakeUnaryCall(undefined, response));
+        this.#submitMock.mockImplementation(fakeUnaryCall(undefined, response));
     }
 
     mockSubmitError(err: grpc.ServiceError): void {
-        this.submitMock.mockImplementation(fakeUnaryCall(err, undefined));
+        this.#submitMock.mockImplementation(fakeUnaryCall(err, undefined));
     }
 
     mockChaincodeEventsResponse(stream: ServerStreamResponse<ChaincodeEventsResponse>): void {
-        this.chaincodeEventsMock.mockReturnValue(stream);
+        this.#chaincodeEventsMock.mockReturnValue(stream);
     }
 }
 

--- a/node/src/client.ts
+++ b/node/src/client.ts
@@ -57,7 +57,7 @@ class GatewayClientImpl implements GatewayClient {
     readonly #client: GatewayGrpcClient;
     readonly #defaultOptions: Readonly<DefaultCallOptions>;
 
-    constructor(client: GatewayGrpcClient, defaultOptions: DefaultCallOptions) {
+    constructor(client: GatewayGrpcClient, defaultOptions: Readonly<DefaultCallOptions>) {
         this.#client = client;
         this.#defaultOptions = Object.assign({}, defaultOptions);
     }

--- a/node/src/commit.ts
+++ b/node/src/commit.ts
@@ -32,10 +32,10 @@ export interface Commit extends Signable {
 }
 
 export interface CommitImplOptions {
-    readonly client: GatewayClient;
-    readonly signingIdentity: SigningIdentity;
-    readonly transactionId: string;
-    readonly signedRequest: SignedCommitStatusRequest;
+    client: GatewayClient;
+    signingIdentity: SigningIdentity;
+    transactionId: string;
+    signedRequest: SignedCommitStatusRequest;
 }
 
 export class CommitImpl implements Commit {
@@ -44,7 +44,7 @@ export class CommitImpl implements Commit {
     readonly #transactionId: string;
     readonly #signedRequest: SignedCommitStatusRequest;
 
-    constructor(options: CommitImplOptions) {
+    constructor(options: Readonly<CommitImplOptions>) {
         this.#client = options.client;
         this.#signingIdentity = options.signingIdentity;
         this.#transactionId = options.transactionId;
@@ -65,9 +65,9 @@ export class CommitImpl implements Commit {
     }
 
     async getStatus(options?: CallOptions): Promise<Status> {
-        await this.sign();
+        await this.#sign();
         const response = await this.#client.commitStatus(this.#signedRequest, options);
-        return this.newStatus(response);
+        return this.#newStatus(response);
     }
 
     getTransactionId(): string {
@@ -78,8 +78,8 @@ export class CommitImpl implements Commit {
         this.#signedRequest.setSignature(signature);
     }
 
-    private async sign(): Promise<void> {
-        if (this.isSigned()) {
+    async #sign(): Promise<void> {
+        if (this.#isSigned()) {
             return;
         }
 
@@ -87,13 +87,13 @@ export class CommitImpl implements Commit {
         this.setSignature(signature);
     }
 
-    private isSigned(): boolean {
+    #isSigned(): boolean {
         const signatureLength = this.#signedRequest.getSignature()?.length || 0;
         return signatureLength > 0;
     }
 
 
-    private newStatus(response: CommitStatusResponse): Status {
+    #newStatus(response: CommitStatusResponse): Status {
         const code = response.getResult() ?? StatusCode.INVALID_OTHER_REASON;
         return {
             blockNumber: BigInt(response.getBlockNumber()),

--- a/node/src/commiterror.ts
+++ b/node/src/commiterror.ts
@@ -21,7 +21,7 @@ export class CommitError extends Error {
      */
     transactionId: string;
 
-    constructor(properties: Omit<CommitError, keyof Error> & Partial<Pick<Error, 'message'>>) {
+    constructor(properties: Readonly<Omit<CommitError, keyof Error> & Partial<Pick<Error, 'message'>>>) {
         super(properties.message);
 
         this.name = CommitError.name;

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -199,11 +199,11 @@ export interface Contract {
 }
 
 export interface ContractOptions {
-    readonly client: GatewayClient;
-    readonly signingIdentity: SigningIdentity;
-    readonly channelName: string;
-    readonly chaincodeName: string;
-    readonly contractName?: string;
+    client: GatewayClient;
+    signingIdentity: SigningIdentity;
+    channelName: string;
+    chaincodeName: string;
+    contractName?: string;
 }
 
 export class ContractImpl implements Contract {
@@ -213,7 +213,7 @@ export class ContractImpl implements Contract {
     readonly #chaincodeName: string;
     readonly #contractName?: string;
 
-    constructor(options: ContractOptions) {
+    constructor(options: Readonly<ContractOptions>) {
         this.#client = options.client;
         this.#signingIdentity = options.signingIdentity;
         this.#channelName = options.channelName;
@@ -252,21 +252,22 @@ export class ContractImpl implements Contract {
         return submitted.getResult();
     }
 
-    async submitAsync(transactionName: string, options?: ProposalOptions): Promise<SubmittedTransaction> {
+    async submitAsync(transactionName: string, options?: Readonly<ProposalOptions>): Promise<SubmittedTransaction> {
         const transaction = await this.newProposal(transactionName, options).endorse();
         return await transaction.submit();
     }
 
-    newProposal(transactionName: string, options: ProposalOptions = {}): Proposal {
+    newProposal(transactionName: string, options: Readonly<ProposalOptions> = {}): Proposal {
         return new ProposalBuilder(Object.assign(
+            {},
+            options,
             {
                 client: this.#client,
                 signingIdentity: this.#signingIdentity,
                 channelName: this.#channelName,
                 chaincodeName: this.#chaincodeName,
-                transactionName: this.getQualifiedTransactionName(transactionName),
+                transactionName: this.#getQualifiedTransactionName(transactionName),
             },
-            options,
         )).build();
     }
 
@@ -298,7 +299,7 @@ export class ContractImpl implements Contract {
         return result;
     }
 
-    private getQualifiedTransactionName(transactionName: string) {
+    #getQualifiedTransactionName(transactionName: string) {
         return this.#contractName ? `${this.#contractName}:${transactionName}` : transactionName;
     }
 }

--- a/node/src/gateway.ts
+++ b/node/src/gateway.ts
@@ -88,7 +88,7 @@ export interface ConnectOptions {
  * @param options - Connection options.
  * @returns A connected gateway.
  */
-export function connect(options: ConnectOptions): Gateway {
+export function connect(options: Readonly<ConnectOptions>): Gateway {
     return internalConnect(options);
 }
 
@@ -96,7 +96,7 @@ export interface InternalConnectOptions extends Omit<ConnectOptions, 'client'> {
     client: GatewayGrpcClient;
 }
 
-export function internalConnect(options: InternalConnectOptions): Gateway {
+export function internalConnect(options: Readonly<InternalConnectOptions>): Gateway {
     if (!options.client) {
         throw new Error('No client connection supplied');
     }

--- a/node/src/gatewayerror.ts
+++ b/node/src/gatewayerror.ts
@@ -44,7 +44,7 @@ export class GatewayError extends Error {
      */
     details: ErrorDetail[];
 
-    constructor(properties: Omit<GatewayError, keyof Error> & Partial<Pick<Error, 'message'>>) {
+    constructor(properties: Readonly<Omit<GatewayError, keyof Error> & Partial<Pick<Error, 'message'>>>) {
         super(properties.message);
 
         this.name = GatewayError.name;

--- a/node/src/network.ts
+++ b/node/src/network.ts
@@ -77,9 +77,9 @@ export interface Network {
 }
 
 export interface NetworkOptions {
-    readonly client: GatewayClient;
-    readonly signingIdentity: SigningIdentity;
-    readonly channelName: string;
+    client: GatewayClient;
+    signingIdentity: SigningIdentity;
+    channelName: string;
 }
 
 export class NetworkImpl implements Network {
@@ -87,7 +87,7 @@ export class NetworkImpl implements Network {
     readonly #signingIdentity: SigningIdentity;
     readonly #channelName: string;
 
-    constructor(options: NetworkOptions) {
+    constructor(options: Readonly<NetworkOptions>) {
         this.#client = options.client;
         this.#signingIdentity = options.signingIdentity;
         this.#channelName = options.channelName;
@@ -122,19 +122,20 @@ export class NetworkImpl implements Network {
         return result;
     }
 
-    async getChaincodeEvents(chaincodeName: string, options?: ChaincodeEventsOptions): Promise<CloseableAsyncIterable<ChaincodeEvent>> {
+    async getChaincodeEvents(chaincodeName: string, options?: Readonly<ChaincodeEventsOptions>): Promise<CloseableAsyncIterable<ChaincodeEvent>> {
         return this.newChaincodeEventsRequest(chaincodeName, options).getEvents();
     }
 
-    newChaincodeEventsRequest(chaincodeName: string, options: ChaincodeEventsOptions = {}): ChaincodeEventsRequest {
+    newChaincodeEventsRequest(chaincodeName: string, options: Readonly<ChaincodeEventsOptions> = {}): ChaincodeEventsRequest {
         return new ChaincodeEventsBuilder(Object.assign(
+            {},
+            options,
             {
                 chaincodeName: chaincodeName,
                 channelName: this.#channelName,
                 client: this.#client,
                 signingIdentity: this.#signingIdentity,
             },
-            options,
         )).build();
     }
 

--- a/node/src/proposalbuilder.ts
+++ b/node/src/proposalbuilder.ts
@@ -36,19 +36,19 @@ export interface ProposalOptions {
     endorsingOrganizations?: string[];
 }
 
-export interface ProposalBuilderOptions extends Readonly<ProposalOptions> {
-    readonly client: GatewayClient;
-    readonly signingIdentity: SigningIdentity;
-    readonly channelName: string;
-    readonly chaincodeName: string;
-    readonly transactionName: string;
+export interface ProposalBuilderOptions extends ProposalOptions {
+    client: GatewayClient;
+    signingIdentity: SigningIdentity;
+    channelName: string;
+    chaincodeName: string;
+    transactionName: string;
 }
 
 export class ProposalBuilder {
-    readonly #options: ProposalBuilderOptions;
+    readonly #options: Readonly<ProposalBuilderOptions>;
     readonly #transactionContext: TransactionContext;
 
-    constructor(options: ProposalBuilderOptions) {
+    constructor(options: Readonly<ProposalBuilderOptions>) {
         this.#options = options;
         this.#transactionContext = new TransactionContext(options.signingIdentity);
     }
@@ -58,13 +58,13 @@ export class ProposalBuilder {
             client: this.#options.client,
             signingIdentity: this.#options.signingIdentity,
             channelName: this.#options.channelName,
-            proposedTransaction: this.newProposedTransaction(),
+            proposedTransaction: this.#newProposedTransaction(),
         });
     }
 
-    private newProposedTransaction(): ProposedTransaction {
+    #newProposedTransaction(): ProposedTransaction {
         const result = new ProposedTransaction();
-        result.setProposal(this.newSignedProposal());
+        result.setProposal(this.#newSignedProposal());
         result.setTransactionId(this.#transactionContext.getTransactionId());
         if (this.#options.endorsingOrganizations) {
             result.setEndorsingOrganizationsList(this.#options.endorsingOrganizations);
@@ -72,85 +72,85 @@ export class ProposalBuilder {
         return result;
     }
 
-    private newSignedProposal(): SignedProposal {
+    #newSignedProposal(): SignedProposal {
         const result = new SignedProposal();
-        result.setProposalBytes(this.newProposal().serializeBinary());
+        result.setProposalBytes(this.#newProposal().serializeBinary());
         return result;
     }
 
-    private newProposal(): ProposalProto {
+    #newProposal(): ProposalProto {
         const result = new ProposalProto();
-        result.setHeader(this.newHeader().serializeBinary());
-        result.setPayload(this.newChaincodeProposalPayload().serializeBinary());
+        result.setHeader(this.#newHeader().serializeBinary());
+        result.setPayload(this.#newChaincodeProposalPayload().serializeBinary());
         return result;
     }
 
-    private newHeader(): Header {
+    #newHeader(): Header {
         const result = new Header();
-        result.setChannelHeader(this.newChannelHeader().serializeBinary());
+        result.setChannelHeader(this.#newChannelHeader().serializeBinary());
         result.setSignatureHeader(this.#transactionContext.getSignatureHeader().serializeBinary());
         return result;
     }
 
-    private newChannelHeader(): ChannelHeader {
+    #newChannelHeader(): ChannelHeader {
         const result = new ChannelHeader();
         result.setType(HeaderType.ENDORSER_TRANSACTION);
         result.setTxId(this.#transactionContext.getTransactionId());
         result.setTimestamp(Timestamp.fromDate(new Date()));
         result.setChannelId(this.#options.channelName);
-        result.setExtension$(this.newChaincodeHeaderExtension().serializeBinary());
+        result.setExtension$(this.#newChaincodeHeaderExtension().serializeBinary());
         result.setEpoch(0);
         return result;
     }
 
-    private newChaincodeHeaderExtension(): ChaincodeHeaderExtension {
+    #newChaincodeHeaderExtension(): ChaincodeHeaderExtension {
         const result = new ChaincodeHeaderExtension();
-        result.setChaincodeId(this.newChaincodeID());
+        result.setChaincodeId(this.#newChaincodeID());
         return result;
     }
 
-    private newChaincodeID(): ChaincodeID {
+    #newChaincodeID(): ChaincodeID {
         const result = new ChaincodeID();
         result.setName(this.#options.chaincodeName);
         return result;
     }
 
-    private newChaincodeProposalPayload(): ChaincodeProposalPayload {
+    #newChaincodeProposalPayload(): ChaincodeProposalPayload {
         const result = new ChaincodeProposalPayload();
-        result.setInput(this.newChaincodeInvocationSpec().serializeBinary());
+        result.setInput(this.#newChaincodeInvocationSpec().serializeBinary());
         const transientMap = result.getTransientmapMap();
-        for (const [key, value] of Object.entries(this.getTransientData())) {
+        for (const [key, value] of Object.entries(this.#getTransientData())) {
             transientMap.set(key, value);
         }
         return result;
     }
 
-    private newChaincodeInvocationSpec(): ChaincodeInvocationSpec {
+    #newChaincodeInvocationSpec(): ChaincodeInvocationSpec {
         const result = new ChaincodeInvocationSpec();
-        result.setChaincodeSpec(this.newChaincodeSpec());
+        result.setChaincodeSpec(this.#newChaincodeSpec());
         return result;
     }
 
-    private newChaincodeSpec(): ChaincodeSpec {
+    #newChaincodeSpec(): ChaincodeSpec {
         const result = new ChaincodeSpec();
         result.setType(ChaincodeSpec.Type.NODE);
-        result.setChaincodeId(this.newChaincodeID());
-        result.setInput(this.newChaincodeInput());
+        result.setChaincodeId(this.#newChaincodeID());
+        result.setInput(this.#newChaincodeInput());
         return result;
     }
 
-    private newChaincodeInput(): ChaincodeInput {
+    #newChaincodeInput(): ChaincodeInput {
         const result = new ChaincodeInput();
-        result.setArgsList(this.getArgsAsBytes());
+        result.setArgsList(this.#getArgsAsBytes());
         return result;
     }
 
-    private getArgsAsBytes(): Uint8Array[] {
+    #getArgsAsBytes(): Uint8Array[] {
         return Array.of(this.#options.transactionName, ...(this.#options.arguments ?? []))
             .map(asBytes);
     }
 
-    private getTransientData(): Record<string, Uint8Array> {
+    #getTransientData(): Record<string, Uint8Array> {
         const result: Record<string, Uint8Array> = {};
 
         for (const [key, value] of Object.entries(this.#options.transientData || {})) {

--- a/node/src/signingidentity.ts
+++ b/node/src/signingidentity.ts
@@ -25,7 +25,7 @@ export class SigningIdentity {
     readonly #hash: Hash;
     readonly #sign: Signer;
 
-    constructor(options: SigningIdentityOptions) {
+    constructor(options: Readonly<SigningIdentityOptions>) {
         this.#identity = {
             mspId: options.identity.mspId,
             credentials: Uint8Array.from(options.identity.credentials)

--- a/node/src/submittedtransaction.ts
+++ b/node/src/submittedtransaction.ts
@@ -19,13 +19,13 @@ export interface SubmittedTransaction extends Commit {
 }
 
 export interface SubmittedTransactionImplOptions extends CommitImplOptions {
-    readonly result: Uint8Array;
+    result: Uint8Array;
 }
 
 export class SubmittedTransactionImpl extends CommitImpl {
     #result: Uint8Array;
 
-    constructor(options: SubmittedTransactionImplOptions) {
+    constructor(options: Readonly<SubmittedTransactionImplOptions>) {
         super(options);
         this.#result = options.result;
     }


### PR DESCRIPTION
We already use ECMAScript private fields for properties so this just extends it for methods too. This provides hard privacy and prevents plain JavaScript applications from accidentally using internal methods that may change and break them in the future.

Closes #254 