### PR TITLE
Simplify off-line signing flow

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsRequest.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsRequest.java
@@ -8,7 +8,7 @@ package org.hyperledger.fabric.client;
 
 /**
  * A Fabric Gateway call to obtain chaincode events. Supports off-line signing flow using
- * {@link Network#newSignedChaincodeEventsRequest(byte[], byte[])}.
+ * {@link Gateway#newSignedChaincodeEventsRequest(byte[], byte[])}.
  */
 public interface ChaincodeEventsRequest extends Signable {
     /**

--- a/java/src/main/java/org/hyperledger/fabric/client/Contract.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Contract.java
@@ -8,8 +8,6 @@ package org.hyperledger.fabric.client;
 
 import java.util.Optional;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
 /**
  * Represents a smart contract instance in a network.
  * Applications should get a Contract instance from a Network using the
@@ -72,10 +70,10 @@ import com.google.protobuf.InvalidProtocolBufferException;
  * <ol>
  *     <li>Returning the serialized proposal, transaction or commit status message along with its digest to the client
  *     for them to generate a signature.</li>
- *     <li>On receipt of the serialized message and signature from the client, creating a signed proposal or transaction
- *     using the Contract's {@link #newSignedProposal(byte[], byte[])} or {@link #newSignedTransaction(byte[], byte[])}
- *     methods respectively,  or creating a signed commit using the Network's
- *     {@link Network#newSignedCommit(byte[], byte[])} method.</li>
+ *     <li>On receipt of the serialized message and signature from the client, creating a signed proposal, transaction
+ *     or commit using the Gateway's {@link Gateway#newSignedProposal(byte[], byte[])},
+ *     {@link Gateway#newSignedTransaction(byte[], byte[])} or {@link Gateway#newSignedCommit(byte[], byte[])} methods
+ *     respectively.</li>
  * </ol>
  *
  * <h3>Off-line signing examples</h3>
@@ -85,7 +83,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
  *     byte[] proposalBytes = unsignedProposal.getBytes();
  *     byte[] proposalDigest = unsignedProposal.getDigest();
  *     // Generate signature from digest
- *     Proposal signedProposal = contract.newSignedProposal(proposalBytes, proposalSignature);
+ *     Proposal signedProposal = gateway.newSignedProposal(proposalBytes, proposalSignature);
  * }</pre>
  *
  * <p>Signing of an endorsed transaction that can then be submitted to the orderer:</p>
@@ -94,7 +92,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
  *     byte[] transactionBytes = unsignedTransaction.getBytes();
  *     byte[] transactionDigest = unsignedTransaction.getDigest();
  *     // Generate signature from digest
- *     Transaction signedTransaction = contract.newSignedTransaction(transactionBytes, transactionSignature);
+ *     Transaction signedTransaction = gateway.newSignedTransaction(transactionBytes, transactionSignature);
  * }</pre>
  *
  * <p>Signing of a commit that can be used to obtain the status of a submitted transaction:</p>
@@ -103,7 +101,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
  *     byte[] commitBytes = unsignedCommit.getBytes();
  *     byte[] commitDigest = unsignedCommit.getDigest();
  *     // Generate signature from digest
- *     Commit signedCommit = network.newSignedCommit(commitBytes, commitDigest);
+ *     Commit signedCommit = gateway.newSignedCommit(commitBytes, commitDigest);
  *
  *     byte[] result = signedTransaction.getResult();
  *     Status status = signedCommit.getStatus();
@@ -248,22 +246,4 @@ public interface Contract {
      * @throws NullPointerException if the transaction name is null.
      */
     Proposal.Builder newProposal(String transactionName);
-
-    /**
-     * Create a proposal with the specified digital signature. Supports off-line signing flow.
-     * @param proposalBytes The proposal.
-     * @param signature A digital signature.
-     * @return A signed proposal.
-     * @throws InvalidProtocolBufferException if the supplied proposal bytes are not a valid proposal.
-     */
-    Proposal newSignedProposal(byte[] proposalBytes, byte[] signature) throws InvalidProtocolBufferException;
-
-    /**
-     * Create a transaction with the specified digital signature. Supports off-line signing flow.
-     * @param transactionBytes The transaction.
-     * @param signature A digital signature.
-     * @return A signed transaction.
-     * @throws InvalidProtocolBufferException if the supplied transaction bytes are not a valid transaction.
-     */
-    Transaction newSignedTransaction(byte[] transactionBytes, byte[] signature) throws InvalidProtocolBufferException;
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/ContractImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ContractImpl.java
@@ -9,10 +9,6 @@ package org.hyperledger.fabric.client;
 import java.util.Objects;
 import java.util.Optional;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import org.hyperledger.fabric.protos.gateway.PreparedTransaction;
-import org.hyperledger.fabric.protos.gateway.ProposedTransaction;
-
 final class ContractImpl implements Contract {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
@@ -88,24 +84,6 @@ final class ContractImpl implements Contract {
     public Proposal.Builder newProposal(final String transactionName) {
         String qualifiedTxName = qualifiedTransactionName(transactionName);
         return new ProposalBuilder(client, signingIdentity, channelName, chaincodeName, qualifiedTxName);
-    }
-
-    @Override
-    public Proposal newSignedProposal(final byte[] proposalBytes, final byte[] signature) throws InvalidProtocolBufferException {
-        ProposedTransaction proposedTransaction = ProposedTransaction.parseFrom(proposalBytes);
-
-        ProposalImpl proposal = new ProposalImpl(client, signingIdentity, channelName, proposedTransaction);
-        proposal.setSignature(signature);
-        return proposal;
-    }
-
-    @Override
-    public Transaction newSignedTransaction(final byte[] transactionBytes, final byte[] signature) throws InvalidProtocolBufferException {
-        PreparedTransaction preparedTransaction = PreparedTransaction.parseFrom(transactionBytes);
-
-        TransactionImpl transaction = new TransactionImpl(client, signingIdentity, channelName, preparedTransaction);
-        transaction.setSignature(signature);
-        return transaction;
     }
 
     @Override

--- a/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
@@ -6,11 +6,11 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.function.Function;
-
 import io.grpc.Channel;
 import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.client.identity.Signer;
+
+import java.util.function.Function;
 
 /**
  * The Gateway provides the connection point for an application to access the Fabric network as a specific user. It is
@@ -64,6 +64,44 @@ public interface Gateway extends AutoCloseable {
      * @throws NullPointerException if the network name is null.
      */
     Network getNetwork(String networkName);
+
+    /**
+     * Create a proposal with the specified digital signature. Supports off-line signing flow.
+     * @param proposalBytes The proposal.
+     * @param signature A digital signature.
+     * @return A signed proposal.
+     * @throws IllegalArgumentException if the supplied proposal bytes are not a valid proposal.
+     */
+    Proposal newSignedProposal(byte[] proposalBytes, byte[] signature);
+
+    /**
+     * Create a transaction with the specified digital signature. Supports off-line signing flow.
+     * @param transactionBytes The transaction.
+     * @param signature A digital signature.
+     * @return A signed transaction.
+     * @throws IllegalArgumentException if the supplied transaction bytes are not a valid transaction.
+     */
+    Transaction newSignedTransaction(byte[] transactionBytes, byte[] signature);
+
+    /**
+     * Create a commit with the specified digital signature, which can be used to access information about a
+     * transaction that is committed to the ledger. Supports off-line signing flow.
+     * @param bytes Serialized commit status request.
+     * @param signature Digital signature.
+     * @return A signed commit status request.
+     * @throws IllegalArgumentException if the supplied commit bytes are not a valid commit.
+     */
+    Commit newSignedCommit(byte[] bytes, byte[] signature);
+
+    /**
+     * Create a chaincode events request with the specified digital signature, which can be used to obtain events
+     * emitted by transaction functions of a specific chaincode. Supports off-line signing flow.
+     * @param bytes Serialized chaincode events request.
+     * @param signature Digital signature.
+     * @return A signed chaincode events request.
+     * @throws IllegalArgumentException if the supplied chaincode events request bytes are not valid.
+     */
+    ChaincodeEventsRequest newSignedChaincodeEventsRequest(byte[] bytes, byte[] signature);
 
     /**
      * Close the gateway connection and all associated resources, including removing listeners attached to networks and

--- a/java/src/main/java/org/hyperledger/fabric/client/Network.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Network.java
@@ -6,8 +6,6 @@
 
 package org.hyperledger.fabric.client;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-
 /**
  * The Network represents a Fabric network (channel). Network instances are obtained from a Gateway using the
  * {@link Gateway#getNetwork(String)} method.
@@ -68,16 +66,6 @@ public interface Network {
     String getName();
 
     /**
-     * Create a commit with the specified digital signature, which can be used to access information about a
-     * transaction that is committed to the ledger. Supports off-line signing flow.
-     * @param bytes Serialized commit status request.
-     * @param signature Digital signature.
-     * @return A signed commit status request.
-     * @throws InvalidProtocolBufferException if the supplied commit bytes are not a valid commit.
-     */
-    Commit newSignedCommit(byte[] bytes, byte[] signature) throws InvalidProtocolBufferException;
-
-    /**
      * Get events emitted by transaction functions of a specific chaincode from the next committed block. The Java gRPC
      * implementation may not begin reading events until the first use of the returned iterator.
      * <p>Note that the returned iterator may throw {@link io.grpc.StatusRuntimeException} during iteration if a gRPC connection error
@@ -98,14 +86,4 @@ public interface Network {
      * @throws NullPointerException if the chaincode name is null.
      */
     ChaincodeEventsRequest.Builder newChaincodeEventsRequest(String chaincodeName);
-
-    /**
-     * Create a chaincode events request with the specified digital signature, which can be used to obtain events
-     * emitted by transaction functions of a specific chaincode. Supports off-line signing flow.
-     * @param bytes Serialized chaincode events request.
-     * @param signature Digital signature.
-     * @return A signed chaincode events request.
-     * @throws InvalidProtocolBufferException if the supplied chaincode events request bytes are not valid.
-     */
-    ChaincodeEventsRequest newSignedChaincodeEventsRequest(byte[] bytes, byte[] signature) throws InvalidProtocolBufferException;
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
@@ -8,11 +8,6 @@ package org.hyperledger.fabric.client;
 
 import java.util.Objects;
 
-import com.google.protobuf.InvalidProtocolBufferException;
-import org.hyperledger.fabric.protos.gateway.CommitStatusRequest;
-import org.hyperledger.fabric.protos.gateway.SignedChaincodeEventsRequest;
-import org.hyperledger.fabric.protos.gateway.SignedCommitStatusRequest;
-
 final class NetworkImpl implements Network {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
@@ -42,16 +37,6 @@ final class NetworkImpl implements Network {
     }
 
     @Override
-    public Commit newSignedCommit(final byte[] bytes, final byte[] signature) throws InvalidProtocolBufferException {
-        SignedCommitStatusRequest signedRequest = SignedCommitStatusRequest.parseFrom(bytes);
-        CommitStatusRequest request = CommitStatusRequest.parseFrom(signedRequest.getRequest());
-
-        CommitImpl commit = new CommitImpl(client, signingIdentity, request.getTransactionId(), signedRequest);
-        commit.setSignature(signature);
-        return commit;
-    }
-
-    @Override
     public CloseableIterator<ChaincodeEvent> getChaincodeEvents(final String chaincodeName, final CallOption... options) {
         return newChaincodeEventsRequest(chaincodeName).build().getEvents(options);
     }
@@ -59,15 +44,5 @@ final class NetworkImpl implements Network {
     @Override
     public ChaincodeEventsRequest.Builder newChaincodeEventsRequest(final String chaincodeName) {
         return new ChaincodeEventsBuilder(client, signingIdentity, channelName, chaincodeName);
-    }
-
-    @Override
-    public ChaincodeEventsRequest newSignedChaincodeEventsRequest(final byte[] bytes, final byte[] signature) throws InvalidProtocolBufferException {
-        SignedChaincodeEventsRequest signedRequest = SignedChaincodeEventsRequest.parseFrom(bytes);
-
-        ChaincodeEventsRequestImpl result = new ChaincodeEventsRequestImpl(client, signingIdentity, signedRequest);
-        result.setSignature(signature);
-
-        return result;
     }
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/Proposal.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Proposal.java
@@ -11,7 +11,7 @@ import java.util.Map;
 /**
  * A Fabric Gateway transaction proposal, which can be used to evaluate a transaction to query ledger state, or obtain
  * endorsements so that the transaction can be submitted to update ledger state. Supports off-line signing flow using
- * {@link Network#newSignedChaincodeEventsRequest(byte[], byte[])}.
+ * {@link Gateway#newSignedChaincodeEventsRequest(byte[], byte[])}.
  */
 public interface Proposal extends Signable {
     /**

--- a/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
@@ -301,20 +301,6 @@ public final class EvaluateTransactionTest {
     }
 
     @Test
-    void sets_endorsing_orgs_offline_signing() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_NAME");
-        Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME")
-                .setEndorsingOrganizations("Org1MSP", "Org3MSP")
-                .build();
-        Proposal signedProposal = contract.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
-        signedProposal.evaluate();
-
-        EvaluateRequest request = mocker.captureEvaluate();
-        List<String> endorsingOrgs = request.getTargetOrganizationsList();
-        assertThat(endorsingOrgs).containsExactlyInAnyOrder("Org1MSP", "Org3MSP");
-    }
-
-    @Test
     void uses_specified_call_options() {
         Deadline expected = Deadline.after(1, TimeUnit.MINUTES);
         CallOption option = CallOption.deadline(expected);

--- a/java/src/test/java/org/hyperledger/fabric/client/GatewayServiceStub.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/GatewayServiceStub.java
@@ -31,7 +31,7 @@ public class GatewayServiceStub {
     private static final TestUtils utils = TestUtils.getInstance();
 
     public EndorseResponse endorse(final EndorseRequest request) {
-        return utils.newEndorseResponse("PAYLOAD");
+        return utils.newEndorseResponse("PAYLOAD", request.getChannelId());
     }
 
     public SubmitResponse submit(final SubmitRequest request) {

--- a/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
@@ -81,7 +81,7 @@ public final class SubmitTransactionTest {
 
     @Test
     void returns_gateway_response() throws Exception {
-        doReturn(utils.newEndorseResponse("MY_RESULT"))
+        doReturn(utils.newEndorseResponse("MY_RESULT", "CHANNEL_NAME"))
                 .when(stub).endorse(any());
 
         Contract contract = network.getContract("CHAINCODE_NAME");
@@ -183,20 +183,6 @@ public final class SubmitTransactionTest {
                 .build()
                 .endorse()
                 .submit();
-
-        EndorseRequest request = mocker.captureEndorse();
-        List<String> endorsingOrgs = request.getEndorsingOrganizationsList();
-        assertThat(endorsingOrgs).containsExactlyInAnyOrder("Org1MSP", "Org3MSP");
-    }
-
-    @Test
-    void sets_endorsing_orgs_offline_signing() throws Exception {
-        Contract contract = network.getContract("CHAINCODE_NAME");
-        Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME")
-                .setEndorsingOrganizations("Org1MSP", "Org3MSP")
-                .build();
-        Proposal signedProposal = contract.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
-        signedProposal.endorse().submit();
 
         EndorseRequest request = mocker.captureEndorse();
         List<String> endorsingOrgs = request.getEndorsingOrganizationsList();

--- a/java/src/test/java/org/hyperledger/fabric/client/TestUtils.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/TestUtils.java
@@ -77,8 +77,8 @@ public final class TestUtils {
                 .signer(signer);
     }
     
-    public EndorseResponse newEndorseResponse(String value) {
-        PreparedTransaction preparedTransaction = newPreparedTransaction(value);
+    public EndorseResponse newEndorseResponse(String value, String channelName) {
+        PreparedTransaction preparedTransaction = newPreparedTransaction(value, channelName);
         return EndorseResponse.newBuilder()
                 .setPreparedTransaction(preparedTransaction.getEnvelope())
                 .setResult(preparedTransaction.getResult())
@@ -102,14 +102,23 @@ public final class TestUtils {
                 .build();
     }
 
-    public PreparedTransaction newPreparedTransaction(String payload) {
+    public PreparedTransaction newPreparedTransaction(String responsePayload, String channelName) {
+        Common.ChannelHeader channelHeader = Common.ChannelHeader.newBuilder()
+                .setChannelId(channelName)
+                .build();
+        Common.Header header = Common.Header.newBuilder()
+                .setChannelHeader(channelHeader.toByteString())
+                .build();
+        Common.Payload payload = Common.Payload.newBuilder()
+                .setHeader(header)
+                .build();
         Common.Envelope envelope = Common.Envelope.newBuilder()
-                .setPayload(ByteString.copyFromUtf8(payload))
+                .setPayload(payload.toByteString())
                 .build();
         return PreparedTransaction.newBuilder()
                 .setTransactionId(newFakeTransactionId())
                 .setEnvelope(envelope)
-                .setResult(newResponse(payload))
+                .setResult(newResponse(responsePayload))
                 .build();
     }
 

--- a/java/src/test/java/scenario/GatewayContext.java
+++ b/java/src/test/java/scenario/GatewayContext.java
@@ -53,9 +53,9 @@ public class GatewayContext {
 
     public TransactionInvocation newTransaction(String action, String transactionName) {
         if (action.equals("submit")) {
-            return TransactionInvocation.prepareToSubmit(network, contract, transactionName);
+            return TransactionInvocation.prepareToSubmit(gateway, contract, transactionName);
         } else {
-            return TransactionInvocation.prepareToEvaluate(network, contract, transactionName);
+            return TransactionInvocation.prepareToEvaluate(gateway, contract, transactionName);
         }
     }
 

--- a/node/src/chaincodeeventsrequest.ts
+++ b/node/src/chaincodeeventsrequest.ts
@@ -52,7 +52,7 @@ export class ChaincodeEventsRequestImpl implements ChaincodeEventsRequest {
         this.#signedRequest.setRequest(options.request.serializeBinary())
     }
 
-    async getEvents(options?: CallOptions): Promise<CloseableAsyncIterable<ChaincodeEvent>> {
+    async getEvents(options?: Readonly<CallOptions>): Promise<CloseableAsyncIterable<ChaincodeEvent>> {
         await this.#sign();
         const responses = this.#client.chaincodeEvents(this.#signedRequest, options);
         return newChaincodeEvents(responses);

--- a/node/src/contract.ts
+++ b/node/src/contract.ts
@@ -6,30 +6,28 @@
 
 import { GatewayClient } from './client';
 import { newCommitError } from './commiterror';
-import { Proposal, ProposalImpl } from './proposal';
+import { Proposal } from './proposal';
 import { ProposalBuilder, ProposalOptions } from './proposalbuilder';
-import { PreparedTransaction, ProposedTransaction } from './protos/gateway/gateway_pb';
 import { SigningIdentity } from './signingidentity';
 import { SubmittedTransaction } from './submittedtransaction';
-import { Transaction, TransactionImpl } from './transaction';
 
 /**
  * Represents a smart contract, and allows applications to:
  * - Evaluate transactions that query state from the ledger using {@link evaluateTransaction}.
  * - Submit transactions that store state to the ledger using {@link submitTransaction}.
- * 
+ *
  * For more complex transaction invocations, such as including private data, transactions can be evaluated or
  * submitted using {@link evaluate} or {@link submit} respectively. The result of a submitted transaction can be
  * accessed prior to its commit to the ledger using {@link submitAsync}.
- * 
+ *
  * By default, proposal, transaction and commit status messages will be signed using the signing implementation
  * specified when connecting the Gateway. In cases where an external client holds the signing credentials, a default
  * signing implementation can be omitted and off-line signing can be carried out by:
  * 1. Returning the serialized proposal, transaction or commit status message along with its digest to the client for
  * them to generate a signature.
- * 1. With the serialized message and signature received from the client to create a signed proposal or transaction
- * using the Contract's {@link newSignedProposal} or {@link newSignedTransaction} methods respectively, or create a
- * signed commit using the Network's {@link Network.newSignedCommit} method.
+ * 1. With the serialized message and signature received from the client to create a signed proposal, transaction or
+ * commit using the Gateway's {@link Gateway.newSignedProposal}, {@link Gateway.newSignedTransaction} or
+ * {@link Gateway.newSignedCommit} methods respectively.
  * 
  * @example Evaluate transaction
  * ```
@@ -68,19 +66,19 @@ import { Transaction, TransactionImpl } from './transaction';
  * const proposalBytes = unsignedProposal.getBytes();
  * const proposalDigest = unsignedProposal.getDigest();
  * // Generate signature from digest
- * const signedProposal = contract.newSignedProposal(proposalBytes, proposalSignature);
+ * const signedProposal = gateway.newSignedProposal(proposalBytes, proposalSignature);
  * 
  * const unsignedTransaction = await signedProposal.endorse();
  * const transactionBytes = unsignedTransaction.getBytes();
  * const transactionDigest = unsignedTransaction.getDigest();
  * // Generate signature from digest
- * const signedTransaction = contract.newSignedTransaction(transactionBytes, transactionDigest);
+ * const signedTransaction = gateway.newSignedTransaction(transactionBytes, transactionDigest);
  * 
  * const unsignedCommit = signedTransaction.submit();
  * const commitBytes = unsignedCommit.getBytes();
  * const commitDigest = unsignedCommit.getDigest();
  * // Generate signature from digest
- * const signedCommit = network.newSignedCommit(commitBytes, commitDigest);
+ * const signedCommit = gateway.newSignedCommit(commitBytes, commitDigest);
  * 
  * const result = signedTransaction.getResult();
  * const status = await signedCommit.getStatus();
@@ -180,22 +178,6 @@ export interface Contract {
      * @param options - Transaction invocation options.
      */
     newProposal(transactionName: string, options?: ProposalOptions): Proposal;
-
-    /**
-     * Create a proposal with the specified digital signature. Supports off-line signing flow.
-     * @param bytes - Serialized proposal.
-     * @param signature - Digital signature.
-     * @returns A signed proposal.
-     */
-    newSignedProposal(bytes: Uint8Array, signature: Uint8Array): Proposal;
-
-    /**
-     * Create a transaction with the specified digital signature. Supports off-line signing flow.
-     * @param bytes - Serialized proposal.
-     * @param signature - Digital signature.
-     * @returns A signed transaction.
-     */
-    newSignedTransaction(bytes: Uint8Array, signature: Uint8Array): Transaction;
 }
 
 export interface ContractOptions {
@@ -269,34 +251,6 @@ export class ContractImpl implements Contract {
                 transactionName: this.#getQualifiedTransactionName(transactionName),
             },
         )).build();
-    }
-
-    newSignedProposal(bytes: Uint8Array, signature: Uint8Array): Proposal {
-        const proposedTransaction = ProposedTransaction.deserializeBinary(bytes);
-
-        const result = new ProposalImpl({
-            client: this.#client,
-            signingIdentity: this.#signingIdentity,
-            channelName: this.#channelName,
-            proposedTransaction,
-        });
-        result.setSignature(signature);
-
-        return result;
-    }
-
-    newSignedTransaction(bytes: Uint8Array, signature: Uint8Array): Transaction {
-        const preparedTransaction = PreparedTransaction.deserializeBinary(bytes);
-
-        const result = new TransactionImpl({
-            client: this.#client,
-            signingIdentity: this.#signingIdentity,
-            channelName: this.#channelName,
-            preparedTransaction,
-        });
-        result.setSignature(signature);
-
-        return result;
     }
 
     #getQualifiedTransactionName(transactionName: string) {

--- a/node/src/proposal.ts
+++ b/node/src/proposal.ts
@@ -97,9 +97,9 @@ export class ProposalImpl implements Proposal {
         await this.#sign();
         const endorseResponse = await this.#client.endorse(this.#newEndorseRequest(), options);
 
-        const preparedTx = endorseResponse.getPreparedTransaction();
+        const txEnvelope = endorseResponse.getPreparedTransaction();
         const response = endorseResponse.getResult();
-        if (!preparedTx || !response) {
+        if (!txEnvelope || !response) {
             throw new Error(`Invalid endorsement response: ${inspect(endorseResponse)}`)
         }
 
@@ -107,7 +107,7 @@ export class ProposalImpl implements Proposal {
             client: this.#client,
             signingIdentity: this.#signingIdentity,
             channelName: this.#channelName,
-            preparedTransaction: this.#newPreparedTransaction(preparedTx, response)
+            preparedTransaction: this.#newPreparedTransaction(txEnvelope, response)
         });
     }
 

--- a/pkg/client/contract.go
+++ b/pkg/client/contract.go
@@ -9,8 +9,6 @@ package client
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 )
 
@@ -31,9 +29,8 @@ import (
 // 1. Returning the serialized proposal, transaction or commit status message along with its digest to the client for
 // them to generate a signature.
 //
-// 2. With the serialized message and signature received from the client to create a signed proposal or transaction
-// using the Contract's NewSignedProposal() or NewSignedTransaction() methods respectively, or creating a signed
-// commit using the Network's NewSignedCommit() method.
+// 2. With the serialized message and signature received from the client to create a signed proposal, transaction or
+// commit using the Gateway's NewSignedProposal(), NewSignedTransaction() or NewSignedCommit() methods respectively.
 type Contract struct {
 	client        *gatewayClient
 	signingID     *signingIdentity
@@ -148,43 +145,6 @@ func (contract *Contract) NewProposal(transactionName string, options ...Proposa
 	}
 
 	return builder.build()
-}
-
-// NewSignedProposal creates a transaction proposal with signature, which can be sent to peers for endorsement.
-func (contract *Contract) NewSignedProposal(bytes []byte, signature []byte) (*Proposal, error) {
-	proposedTransaction := &gateway.ProposedTransaction{}
-	if err := proto.Unmarshal(bytes, proposedTransaction); err != nil {
-		return nil, fmt.Errorf("failed to deserialize proposal: %w", err)
-	}
-
-	proposal := &Proposal{
-		client:              contract.client,
-		signingID:           contract.signingID,
-		channelID:           contract.channelName,
-		proposedTransaction: proposedTransaction,
-	}
-	proposal.setSignature(signature)
-
-	return proposal, nil
-}
-
-// NewSignedTransaction creates an endorsed transaction with signature, which can be submitted to the orderer for commit
-// to the ledger.
-func (contract *Contract) NewSignedTransaction(bytes []byte, signature []byte) (*Transaction, error) {
-	preparedTransaction := &gateway.PreparedTransaction{}
-	if err := proto.Unmarshal(bytes, preparedTransaction); err != nil {
-		return nil, fmt.Errorf("failed to deserialize transaction: %w", err)
-	}
-
-	transaction := &Transaction{
-		client:              contract.client,
-		signingID:           contract.signingID,
-		channelID:           contract.channelName,
-		preparedTransaction: preparedTransaction,
-	}
-	transaction.setSignature(signature)
-
-	return transaction, nil
 }
 
 func (contract *Contract) qualifiedTransactionName(name string) string {

--- a/pkg/client/example_contract_test.go
+++ b/pkg/client/example_contract_test.go
@@ -77,7 +77,7 @@ func ExampleContract_SubmitAsync() {
 }
 
 func ExampleContract_offlineSign() {
-	var network *client.Network   // Obtained from Gateway.
+	var gateway *client.Gateway
 	var contract *client.Contract // Obtained from Network.
 	var sign identity.Sign        // Signing function.
 
@@ -97,7 +97,7 @@ func ExampleContract_offlineSign() {
 	if err != nil {
 		panic(err)
 	}
-	signedProposal, err := contract.NewSignedProposal(proposalBytes, proposalSignature)
+	signedProposal, err := gateway.NewSignedProposal(proposalBytes, proposalSignature)
 	if err != nil {
 		panic(err)
 	}
@@ -118,7 +118,7 @@ func ExampleContract_offlineSign() {
 	if err != nil {
 		panic(err)
 	}
-	signedTransaction, err := contract.NewSignedTransaction(transactionBytes, transactionSignature)
+	signedTransaction, err := gateway.NewSignedTransaction(transactionBytes, transactionSignature)
 	if err != nil {
 		panic(err)
 	}
@@ -139,7 +139,7 @@ func ExampleContract_offlineSign() {
 	if err != nil {
 		panic(err)
 	}
-	signedCommit, err := network.NewSignedCommit(commitBytes, commitSignature)
+	signedCommit, err := gateway.NewSignedCommit(commitBytes, commitSignature)
 
 	// Wait for transaction commit.
 	status, err := signedCommit.Status()

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -25,15 +25,13 @@ func TestOfflineSign(t *testing.T) {
 		},
 	}
 
-	newNetworkWithNoSign := func(t *testing.T, options ...ConnectOption) *Network {
+	newContractWithNoSign := func(t *testing.T, options ...ConnectOption) (*Gateway, *Contract) {
 		gateway, err := Connect(TestCredentials.identity, options...)
 		require.NoError(t, err)
 
-		return gateway.GetNetwork("network")
-	}
+		contract := gateway.GetNetwork("network").GetContract("contract")
 
-	newContractWithNoSign := func(t *testing.T, options ...ConnectOption) *Contract {
-		return newNetworkWithNoSign(t, options...).GetContract("chaincode")
+		return gateway, contract
 	}
 
 	newEndorseResponse := func(value string) *gateway.EndorseResponse {
@@ -58,7 +56,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(&evaluateResponse, nil).
 				AnyTimes()
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			_, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			proposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -78,7 +76,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(&evaluateResponse, nil).
 				Times(1)
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -86,7 +84,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
 			_, err = signedProposal.Evaluate()
@@ -107,7 +105,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(&evaluateResponse, nil).
 				Times(1)
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction", WithEndorsingOrganizations("MY_ORG"))
 			require.NoError(t, err)
@@ -115,7 +113,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
 			require.NoError(t, err)
 
 			_, err = signedProposal.Evaluate()
@@ -132,7 +130,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(newEndorseResponse("result"), nil).
 				AnyTimes()
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			_, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			proposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -152,7 +150,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(newEndorseResponse("result"), nil).
 				Times(1)
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -160,7 +158,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
 			_, err = signedProposal.Endorse()
@@ -181,7 +179,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(newEndorseResponse("result"), nil).
 				Times(1)
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction", WithEndorsingOrganizations("MY_ORG"))
 			require.NoError(t, err)
@@ -189,7 +187,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("SIGNATURE"))
 			require.NoError(t, err)
 
 			_, err = signedProposal.Endorse()
@@ -209,7 +207,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(nil, nil).
 				AnyTimes()
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -217,7 +215,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			transaction, err := signedProposal.Endorse()
@@ -240,7 +238,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(nil, nil).
 				Times(1)
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -248,7 +246,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
@@ -257,7 +255,7 @@ func TestOfflineSign(t *testing.T) {
 			transactionBytes, err := unsignedTransaction.Bytes()
 			require.NoError(t, err)
 
-			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
+			signedTransaction, err := gateway.NewSignedTransaction(transactionBytes, expected)
 			require.NoError(t, err)
 
 			_, err = signedTransaction.Submit()
@@ -280,7 +278,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(nil, nil).
 				AnyTimes()
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -288,7 +286,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
@@ -297,7 +295,7 @@ func TestOfflineSign(t *testing.T) {
 			transactionBytes, err := unsignedTransaction.Bytes()
 			require.NoError(t, err)
 
-			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
+			signedTransaction, err := gateway.NewSignedTransaction(transactionBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			commit, err := signedTransaction.Submit()
@@ -323,8 +321,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(newCommitStatusResponse(peer.TxValidationCode_VALID), nil).
 				Times(1)
 
-			network := newNetworkWithNoSign(t, WithClient(mockClient))
-			contract := network.GetContract("chaincode")
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -332,7 +329,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, expected)
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, expected)
 			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
@@ -341,7 +338,7 @@ func TestOfflineSign(t *testing.T) {
 			transactionBytes, err := unsignedTransaction.Bytes()
 			require.NoError(t, err)
 
-			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, expected)
+			signedTransaction, err := gateway.NewSignedTransaction(transactionBytes, expected)
 			require.NoError(t, err)
 
 			unsignedCommit, err := signedTransaction.Submit()
@@ -350,7 +347,7 @@ func TestOfflineSign(t *testing.T) {
 			commitBytes, err := unsignedCommit.Bytes()
 			require.NoError(t, err)
 
-			signedCommit, err := network.NewSignedCommit(commitBytes, expected)
+			signedCommit, err := gateway.NewSignedCommit(commitBytes, expected)
 			require.NoError(t, err)
 
 			_, err = signedCommit.Status()
@@ -363,7 +360,7 @@ func TestOfflineSign(t *testing.T) {
 	t.Run("Serialization", func(t *testing.T) {
 		t.Run("Proposal keeps same digest", func(t *testing.T) {
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -371,7 +368,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			expected := unsignedProposal.Digest()
@@ -382,7 +379,7 @@ func TestOfflineSign(t *testing.T) {
 
 		t.Run("Proposal keeps same transaction ID", func(t *testing.T) {
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -390,7 +387,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			expected := unsignedProposal.TransactionID()
@@ -405,7 +402,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(newEndorseResponse("result"), nil).
 				Times(1)
 
-			contract := newContractWithNoSign(t, WithClient(mockClient))
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -413,7 +410,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
@@ -422,7 +419,7 @@ func TestOfflineSign(t *testing.T) {
 			transactionBytes, err := unsignedTransaction.Bytes()
 			require.NoError(t, err)
 
-			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
+			signedTransaction, err := gateway.NewSignedTransaction(transactionBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			expected := unsignedTransaction.Digest()
@@ -440,8 +437,7 @@ func TestOfflineSign(t *testing.T) {
 				Return(nil, nil).
 				Times(1)
 
-			network := newNetworkWithNoSign(t, WithClient(mockClient))
-			contract := network.GetContract("chaincode")
+			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
 
 			unsignedProposal, err := contract.NewProposal("transaction")
 			require.NoError(t, err)
@@ -449,7 +445,7 @@ func TestOfflineSign(t *testing.T) {
 			proposalBytes, err := unsignedProposal.Bytes()
 			require.NoError(t, err)
 
-			signedProposal, err := contract.NewSignedProposal(proposalBytes, []byte("signature"))
+			signedProposal, err := gateway.NewSignedProposal(proposalBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			unsignedTransaction, err := signedProposal.Endorse()
@@ -458,7 +454,7 @@ func TestOfflineSign(t *testing.T) {
 			transactionBytes, err := unsignedTransaction.Bytes()
 			require.NoError(t, err)
 
-			signedTransaction, err := contract.NewSignedTransaction(transactionBytes, []byte("signature"))
+			signedTransaction, err := gateway.NewSignedTransaction(transactionBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			unsignedCommit, err := signedTransaction.Submit()
@@ -467,7 +463,7 @@ func TestOfflineSign(t *testing.T) {
 			commitBytes, err := unsignedCommit.Bytes()
 			require.NoError(t, err)
 
-			signedCommit, err := network.NewSignedCommit(commitBytes, []byte("signature"))
+			signedCommit, err := gateway.NewSignedCommit(commitBytes, []byte("signature"))
 			require.NoError(t, err)
 
 			expected := unsignedCommit.Digest()

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"

--- a/scenario/go/connection_test.go
+++ b/scenario/go/connection_test.go
@@ -243,7 +243,7 @@ func (connection *GatewayConnection) PrepareTransaction(txnType TransactionType,
 		return nil, fmt.Errorf("no contract selected")
 	}
 
-	return NewTransaction(connection.network, connection.contract, txnType, name), nil
+	return NewTransaction(connection.gateway, connection.contract, txnType, name), nil
 }
 
 func (connection *GatewayConnection) ListenForChaincodeEvents(listenerName string, chaincodeName string) error {

--- a/scenario/go/transaction_test.go
+++ b/scenario/go/transaction_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Transaction struct {
-	network     *client.Network
+	gateway     *client.Gateway
 	contract    *client.Contract
 	txType      TransactionType
 	name        string
@@ -28,9 +28,9 @@ type Transaction struct {
 	blockNumber uint64
 }
 
-func NewTransaction(network *client.Network, contract *client.Contract, txType TransactionType, name string) *Transaction {
+func NewTransaction(gateway *client.Gateway, contract *client.Contract, txType TransactionType, name string) *Transaction {
 	return &Transaction{
-		network:  network,
+		gateway:  gateway,
 		contract: contract,
 		txType:   txType,
 		name:     name,
@@ -150,7 +150,7 @@ func (transaction *Transaction) offlineSignProposal(proposal *client.Proposal) (
 		return nil, err
 	}
 
-	proposal, err = transaction.contract.NewSignedProposal(bytes, signature)
+	proposal, err = transaction.gateway.NewSignedProposal(bytes, signature)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +168,7 @@ func (transaction *Transaction) offlineSignTransaction(clientTransaction *client
 		return nil, err
 	}
 
-	clientTransaction, err = transaction.contract.NewSignedTransaction(bytes, signature)
+	clientTransaction, err = transaction.gateway.NewSignedTransaction(bytes, signature)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +186,7 @@ func (transaction *Transaction) offlineSignCommit(commit *client.Commit) (*clien
 		return nil, err
 	}
 
-	commit, err = transaction.network.NewSignedCommit(bytes, signature)
+	commit, err = transaction.gateway.NewSignedCommit(bytes, signature)
 	if err != nil {
 		return nil, err
 	}

--- a/scenario/node/src/gatewaycontext.ts
+++ b/scenario/node/src/gatewaycontext.ts
@@ -46,7 +46,7 @@ export class GatewayContext {
     }
 
     newTransaction(action: string, transactionName: string): TransactionInvocation {
-        return new TransactionInvocation(action, this.getNetwork(), this.getContract(), transactionName);
+        return new TransactionInvocation(action, this.getGateway(), this.getContract(), transactionName);
     }
 
     async listenForChaincodeEvents(listenerName: string, chaincodeName: string, options?: ChaincodeEventsOptions): Promise<void> {


### PR DESCRIPTION
Locate all methods for creating signed objects on the Gateway object, removing the need for client code to remember the network or contract used to create the unsigned objects.

Closes #301 