### PR TITLE
Wrap gRPC ServiceError thrown by chaincode events as GatewayError

### DIFF
--- a/node/src/chaincodeeventsrequest.ts
+++ b/node/src/chaincodeeventsrequest.ts
@@ -19,6 +19,8 @@ export interface ChaincodeEventsRequest extends Signable {
      * Get chaincode events emitted by transaction functions of a specific chaincode.
      * @param options - gRPC call options.
      * @returns Chaincode events.
+     * @throws {@link GatewayError}
+     * Thrown by the iterator if the gRPC service invocation fails.
      * @example
      * ```
      * const events = await request.getEvents();

--- a/node/src/client.test.ts
+++ b/node/src/client.test.ts
@@ -154,6 +154,12 @@ export class MockGatewayGrpcClient implements GatewayGrpcClient {
     mockChaincodeEventsResponse(stream: ServerStreamResponse<ChaincodeEventsResponse>): void {
         this.#chaincodeEventsMock.mockReturnValue(stream);
     }
+
+    mockChaincodeEventsError(err: grpc.ServiceError): void {
+        this.#chaincodeEventsMock.mockImplementation(() => {
+            throw err;
+        });
+    }
 }
 
 function fakeUnaryCall<ResponseType>(err: grpc.ServiceError | undefined, response: ResponseType | undefined) {

--- a/node/src/network.ts
+++ b/node/src/network.ts
@@ -33,6 +33,8 @@ export interface Network {
      * Get chaincode events emitted by transaction functions of a specific chaincode.
      * @param chaincodeName - A chaincode name.
      * @returns Chaincode events.
+     * @throws {@link GatewayError}
+     * Thrown by the iterator if the gRPC service invocation fails.
      * @example
      * ```
      * const events = await network.getChaincodeEvents(chaincodeName, { startBlock: BigInt(101) });

--- a/node/src/proposal.test.ts
+++ b/node/src/proposal.test.ts
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CallOptions, Metadata, ServiceError } from '@grpc/grpc-js';
+import { CallOptions, Metadata, ServiceError, status } from '@grpc/grpc-js';
 import { MockGatewayGrpcClient } from './client.test';
 import { Contract } from './contract';
 import { EndorseError } from './endorseerror';
 import { Gateway, internalConnect } from './gateway';
 import { Identity } from './identity/identity';
 import { Network } from './network';
-import { ChannelHeader, Envelope, Header, SignatureHeader, Status } from './protos/common/common_pb';
+import { ChannelHeader, Envelope, Header, SignatureHeader } from './protos/common/common_pb';
 import { CommitStatusResponse, EndorseRequest, EndorseResponse, EvaluateRequest, EvaluateResponse } from './protos/gateway/gateway_pb';
 import { SerializedIdentity } from './protos/msp/identities_pb';
 import { ChaincodeInvocationSpec, ChaincodeSpec } from './protos/peer/chaincode_pb';
@@ -64,7 +64,7 @@ function assertDecodeChannelHeader(proposal: ProposalProto): ChannelHeader {
 
 describe('Proposal', () => {
     const serviceError: ServiceError = Object.assign(new Error('ERROR_MESSAGE'), {
-        code: Status.SERVICE_UNAVAILABLE,
+        code: status.UNAVAILABLE,
         details: 'DETAILS',
         metadata: new Metadata(),
     });
@@ -371,6 +371,7 @@ describe('Proposal', () => {
             await expect(t).rejects.toMatchObject({
                 name: EndorseError.name,
                 transactionId,
+                code: serviceError.code,
                 cause: serviceError,
             });
         });

--- a/node/src/transaction.test.ts
+++ b/node/src/transaction.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CallOptions, Metadata, ServiceError } from '@grpc/grpc-js';
+import { CallOptions, Metadata, ServiceError, status } from '@grpc/grpc-js';
 import { MockGatewayGrpcClient } from './client.test';
 import { CommitError } from './commiterror';
 import { CommitStatusError } from './commitstatuserror';
@@ -12,7 +12,7 @@ import { Contract } from './contract';
 import { Gateway, internalConnect, InternalConnectOptions } from './gateway';
 import { Identity } from './identity/identity';
 import { Network } from './network';
-import { Envelope, Status } from './protos/common/common_pb';
+import { Envelope } from './protos/common/common_pb';
 import { CommitStatusResponse, EndorseResponse } from './protos/gateway/gateway_pb';
 import { Response } from './protos/peer/proposal_response_pb';
 import { TxValidationCode } from './protos/peer/transaction_pb';
@@ -21,7 +21,7 @@ import { SubmitError } from './submiterror';
 describe('Transaction', () => {
     const expectedResult = 'TX_RESULT';
     const serviceError: ServiceError = Object.assign(new Error('ERROR_MESSAGE'), {
-        code: Status.SERVICE_UNAVAILABLE,
+        code: status.UNAVAILABLE,
         details: 'DETAILS',
         metadata: new Metadata(),
     });
@@ -100,6 +100,7 @@ describe('Transaction', () => {
         await expect(t).rejects.toMatchObject({
             name: SubmitError.name,
             transactionId,
+            code: serviceError.code,
             cause: serviceError,
         });
     });
@@ -117,6 +118,7 @@ describe('Transaction', () => {
         await expect(t).rejects.toMatchObject({
             name: CommitStatusError.name,
             transactionId,
+            code: serviceError.code,
             cause: serviceError,
         });
     });


### PR DESCRIPTION
Also corrected the gRPC status code import for some unit tests.