### PR TITLE
Add Endorse, Submit and CommitStatus exceptions to Java API

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsRequest.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsRequest.java
@@ -15,7 +15,7 @@ public interface ChaincodeEventsRequest extends Signable {
      * Get events emitted by transaction functions of a specific chaincode. The Java gRPC implementation may not begin
      * reading events until the first use of the returned iterator.
      * <p>Note that the returned iterator may
-     * throw {@link io.grpc.StatusRuntimeException} during iteration if a gRPC connection error occurs.</p>
+     * throw {@link GatewayRuntimeException} during iteration if a gRPC connection error occurs.</p>
      * @param options Call options.
      * @return Ordered sequence of events.
      */

--- a/java/src/main/java/org/hyperledger/fabric/client/CloseableIterator.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/CloseableIterator.java
@@ -11,7 +11,7 @@ import java.util.Iterator;
 /**
  * An iterator that can be closed when the consumer does not want to read any more elements, freeing up resources that
  * may be held by the iterator.
- * <p>Note that iteration may throw {@code io.grpc.StatusRuntimeException} if the gRPC connection fails.</p>
+ * <p>Note that iteration may throw {@link GatewayRuntimeException} if the gRPC connection fails.</p>
  * @param <T> The type of elements returned by this iterator.
  */
 public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {

--- a/java/src/main/java/org/hyperledger/fabric/client/Commit.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Commit.java
@@ -21,7 +21,7 @@ public interface Commit extends Signable {
      * the commit occurs.
      * @param options Call options.
      * @return Transaction commit status.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws CommitStatusException if the gRPC service invocation fails.
      */
-    Status getStatus(CallOption... options);
+    Status getStatus(CallOption... options) throws CommitStatusException;
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/CommitException.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/CommitException.java
@@ -32,16 +32,6 @@ public final class CommitException extends Exception {
     }
 
     /**
-     * Constructs a new commit exception for the specified transaction.
-     * @param status Transaction commit status.
-     * @param cause the cause.
-     */
-    CommitException(final Status status, final Throwable cause) {
-        super(message(status), cause);
-        this.status = status;
-    }
-
-    /**
      * Get the ID of the transaction.
      * @return transaction ID.
      */

--- a/java/src/main/java/org/hyperledger/fabric/client/CommitImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/CommitImpl.java
@@ -41,7 +41,7 @@ class CommitImpl implements Commit {
     }
 
     @Override
-    public Status getStatus(final CallOption... options) {
+    public Status getStatus(final CallOption... options) throws CommitStatusException {
         sign();
         CommitStatusResponse response = client.commitStatus(signedRequest, options);
         return new StatusImpl(transactionId, response);

--- a/java/src/main/java/org/hyperledger/fabric/client/CommitStatusException.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/CommitStatusException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Thrown when a failure occurs obtaining the commit status of a transaction.
+ */
+public class CommitStatusException extends GatewayException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with the specified cause.
+     * @param cause the cause.
+     */
+    public CommitStatusException(final StatusRuntimeException cause) {
+        super(cause);
+    }
+}

--- a/java/src/main/java/org/hyperledger/fabric/client/Contract.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Contract.java
@@ -134,11 +134,13 @@ public interface Contract {
      * }</pre>
      * @param name Transaction function name.
      * @return Payload response from the transaction function.
-     * @throws CommitException if the transaction fails to commit successfully.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws EndorseException if the endorse invocation fails.
+     * @throws SubmitException if the submit invocation fails.
+     * @throws CommitStatusException if the commit status invocation fails.
+     * @throws CommitException if the transaction commits unsuccessfully.
      * @throws NullPointerException if the transaction name is null.
      */
-    byte[] submitTransaction(String name) throws CommitException;
+    byte[] submitTransaction(String name) throws EndorseException, CommitException, SubmitException, CommitStatusException;
 
     /**
      * Submit a transaction to the ledger and return its result only after it is committed to the ledger. The
@@ -154,11 +156,13 @@ public interface Contract {
      * @param name Transaction function name.
      * @param args Transaction function arguments.
      * @return Payload response from the transaction function.
-     * @throws CommitException if the transaction fails to commit successfully.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws EndorseException if the endorse invocation fails.
+     * @throws SubmitException if the submit invocation fails.
+     * @throws CommitStatusException if the commit status invocation fails.
+     * @throws CommitException if the transaction commits unsuccessfully.
      * @throws NullPointerException if the transaction name is null.
      */
-    byte[] submitTransaction(String name, String... args) throws CommitException;
+    byte[] submitTransaction(String name, String... args) throws EndorseException, SubmitException, CommitStatusException, CommitException;
 
     /**
      * Submit a transaction to the ledger and return its result only after it is committed to the ledger. The
@@ -175,11 +179,13 @@ public interface Contract {
      * @param name Transaction function name.
      * @param args Transaction function arguments.
      * @return Payload response from the transaction function.
-     * @throws CommitException if the transaction fails to commit successfully.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws EndorseException if the endorse invocation fails.
+     * @throws SubmitException if the submit invocation fails.
+     * @throws CommitStatusException if the commit status invocation fails.
+     * @throws CommitException if the transaction commits unsuccessfully.
      * @throws NullPointerException if the transaction name is null.
      */
-    byte[] submitTransaction(String name, byte[]... args) throws CommitException;
+    byte[] submitTransaction(String name, byte[]... args) throws EndorseException, CommitException, SubmitException, CommitStatusException;
 
     /**
      * Evaluate a transaction function and return its results. A transaction proposal will be evaluated on endorsing
@@ -194,10 +200,10 @@ public interface Contract {
      * }</pre>
      * @param name Transaction function name.
      * @return Payload response from the transaction function.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws GatewayException if the gRPC service invocation fails.
      * @throws NullPointerException if the transaction name is null.
      */
-    byte[] evaluateTransaction(String name);
+    byte[] evaluateTransaction(String name) throws GatewayException;
 
     /**
      * Evaluate a transaction function and return its results. A transaction proposal will be evaluated on endorsing
@@ -214,10 +220,10 @@ public interface Contract {
      * @param name Transaction function name.
      * @param args Transaction function arguments.
      * @return Payload response from the transaction function.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws GatewayException if the gRPC service invocation fails.
      * @throws NullPointerException if the transaction name is null.
      */
-    byte[] evaluateTransaction(String name, String... args);
+    byte[] evaluateTransaction(String name, String... args) throws GatewayException;
 
     /**
      * Evaluate a transaction function and return its results. A transaction proposal will be evaluated on endorsing
@@ -233,10 +239,10 @@ public interface Contract {
      * @param name Transaction function name.
      * @param args Transaction function arguments.
      * @return Payload response from the transaction function.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws GatewayException if the gRPC service invocation fails.
      * @throws NullPointerException if the transaction name is null.
      */
-    byte[] evaluateTransaction(String name, byte[]... args);
+    byte[] evaluateTransaction(String name, byte[]... args) throws GatewayException;
 
     /**
      * Build a new proposal that can be evaluated or sent to peers for endorsement. Supports both asynchronous submit

--- a/java/src/main/java/org/hyperledger/fabric/client/ContractImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ContractImpl.java
@@ -32,7 +32,7 @@ final class ContractImpl implements Contract {
     }
 
     @Override
-    public byte[] submitTransaction(final String name) throws CommitException {
+    public byte[] submitTransaction(final String name) throws EndorseException, CommitException, SubmitException, CommitStatusException {
         return newProposal(name)
                 .build()
                 .endorse()
@@ -40,16 +40,7 @@ final class ContractImpl implements Contract {
     }
 
     @Override
-    public byte[] submitTransaction(final String name, final String... args) throws CommitException {
-        return newProposal(name)
-                .addArguments(args)
-                .build()
-                .endorse()
-                .submit();
-    }
-
-    @Override
-    public byte[] submitTransaction(final String name, final byte[]... args) throws CommitException {
+    public byte[] submitTransaction(final String name, final String... args) throws EndorseException, CommitException, SubmitException, CommitStatusException {
         return newProposal(name)
                 .addArguments(args)
                 .build()
@@ -58,14 +49,23 @@ final class ContractImpl implements Contract {
     }
 
     @Override
-    public byte[] evaluateTransaction(final String name) {
+    public byte[] submitTransaction(final String name, final byte[]... args) throws EndorseException, CommitException, SubmitException, CommitStatusException {
+        return newProposal(name)
+                .addArguments(args)
+                .build()
+                .endorse()
+                .submit();
+    }
+
+    @Override
+    public byte[] evaluateTransaction(final String name) throws GatewayException {
         return newProposal(name)
                 .build()
                 .evaluate();
     }
 
     @Override
-    public byte[] evaluateTransaction(final String name, final String... args) {
+    public byte[] evaluateTransaction(final String name, final String... args) throws GatewayException {
         return newProposal(name)
                 .addArguments(args)
                 .build()
@@ -73,7 +73,7 @@ final class ContractImpl implements Contract {
     }
 
     @Override
-    public byte[] evaluateTransaction(final String name, final byte[]... args) {
+    public byte[] evaluateTransaction(final String name, final byte[]... args) throws GatewayException {
         return newProposal(name)
                 .addArguments(args)
                 .build()

--- a/java/src/main/java/org/hyperledger/fabric/client/EndorseException.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/EndorseException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Thrown when a failure occurs endorsing a transaction proposal.
+ */
+public class EndorseException extends GatewayException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with the specified cause.
+     * @param cause the cause.
+     */
+    public EndorseException(final StatusRuntimeException cause) {
+        super(cause);
+    }
+}

--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayException.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 IBM All Rights Reserved.
+ * Copyright 2021 IBM All Rights Reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -16,7 +16,7 @@ import org.hyperledger.fabric.protos.gateway.ErrorDetail;
  * of the processing to other nodes (endorsing peers and orderers), then the error could have originated from one or
  * more of those nodes. In that case, the details will contain errors information from those nodes.
  */
-public class GatewayRuntimeException extends RuntimeException {
+public class GatewayException extends Exception {
     private static final long serialVersionUID = 1L;
 
     private final GrpcStatus grpcStatus;
@@ -25,7 +25,7 @@ public class GatewayRuntimeException extends RuntimeException {
      * Constructs a new exception with the specified cause.
      * @param cause the cause.
      */
-    public GatewayRuntimeException(final StatusRuntimeException cause) {
+    public GatewayException(final StatusRuntimeException cause) {
         super(cause);
         grpcStatus = new GrpcStatus(cause.getStatus(), cause.getTrailers());
     }

--- a/java/src/main/java/org/hyperledger/fabric/client/GrpcStatus.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GrpcStatus.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import com.google.protobuf.InvalidProtocolBufferException;
+import io.grpc.protobuf.StatusProto;
+import org.hyperledger.fabric.protos.gateway.ErrorDetail;
+
+final class GrpcStatus {
+    private final io.grpc.Status status;
+    private final io.grpc.Metadata trailers;
+
+    GrpcStatus(final io.grpc.Status status, final io.grpc.Metadata trailers) {
+        this.status = status;
+        this.trailers = trailers;
+    }
+
+    public io.grpc.Status getStatus() {
+        return status;
+    }
+
+    public List<ErrorDetail> getDetails() {
+        return StatusProto.fromStatusAndTrailers(status, trailers)
+                .getDetailsList()
+                .stream()
+                .filter(any -> any.is(ErrorDetail.class))
+                .map(any -> {
+                    try {
+                        return any.unpack(ErrorDetail.class);
+                    } catch (InvalidProtocolBufferException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+}

--- a/java/src/main/java/org/hyperledger/fabric/client/Proposal.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Proposal.java
@@ -25,18 +25,18 @@ public interface Proposal extends Signable {
      * not committed to the ledger.
      * @param options Call options.
      * @return Transaction result.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws GatewayException if the gRPC service invocation fails.
      */
-    byte[] evaluate(CallOption... options);
+    byte[] evaluate(CallOption... options) throws GatewayException;
 
     /**
      * Send the proposal to peers to obtain endorsements. Successful endorsement results in a transaction that can be
      * submitted to the orderer to be committer to the ledger.
      * @param options Call options.
      * @return An endorsed transaction.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws EndorseException if the gRPC service invocation fails.
      */
-    Transaction endorse(CallOption... options);
+    Transaction endorse(CallOption... options) throws EndorseException;
 
     /**
      * Builder used to create a new transaction proposal.

--- a/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
@@ -45,7 +45,7 @@ final class ProposalImpl implements Proposal {
     }
 
     @Override
-    public byte[] evaluate(final CallOption... options) {
+    public byte[] evaluate(final CallOption... options) throws GatewayException {
         sign();
         final EvaluateRequest evaluateRequest = EvaluateRequest.newBuilder()
                 .setTransactionId(proposedTransaction.getTransactionId())
@@ -60,7 +60,7 @@ final class ProposalImpl implements Proposal {
     }
 
     @Override
-    public Transaction endorse(final CallOption... options) {
+    public Transaction endorse(final CallOption... options) throws EndorseException {
         sign();
         final EndorseRequest endorseRequest = EndorseRequest.newBuilder()
                 .setTransactionId(proposedTransaction.getTransactionId())

--- a/java/src/main/java/org/hyperledger/fabric/client/SigningIdentity.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/SigningIdentity.java
@@ -42,7 +42,7 @@ final class SigningIdentity {
         try {
             return signer.sign(digest);
         } catch (GeneralSecurityException e) {
-            throw new GatewayRuntimeException(e);
+            throw new RuntimeException(e);
         }
     }
 

--- a/java/src/main/java/org/hyperledger/fabric/client/SubmitException.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/SubmitException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import io.grpc.StatusRuntimeException;
+
+/**
+ * Thrown when a failure occurs submitting an endorsed transaction to the orderer.
+ */
+public class SubmitException extends GatewayException {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs a new exception with the specified cause.
+     * @param cause the cause.
+     */
+    public SubmitException(final StatusRuntimeException cause) {
+        super(cause);
+    }
+}

--- a/java/src/main/java/org/hyperledger/fabric/client/Transaction.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Transaction.java
@@ -30,10 +30,11 @@ public interface Transaction extends Signable {
      * has been successfully committed to the ledger.
      * @param options Call options.
      * @return A transaction result.
-     * @throws CommitException if the transaction fails to commit successfully.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws SubmitException if the submit invocation fails.
+     * @throws CommitStatusException if the commit status invocation fails.
+     * @throws CommitException if the transaction commits unsuccessfully.
      */
-    byte[] submit(CallOption... options) throws CommitException;
+    byte[] submit(CallOption... options) throws SubmitException, CommitStatusException, CommitException;
 
     /**
      * Submit the transaction to the orderer to be committed to the ledger. This method returns immediately after the
@@ -41,7 +42,7 @@ public interface Transaction extends Signable {
      * for the transaction to be committed to the ledger.
      * @param options Call options.
      * @return A transaction commit.
-     * @throws io.grpc.StatusRuntimeException if the gRPC service invocation fails.
+     * @throws SubmitException if the gRPC service invocation fails.
      */
-    SubmittedTransaction submitAsync(CallOption... options);
+    SubmittedTransaction submitAsync(CallOption... options) throws SubmitException;
 }

--- a/java/src/main/java/org/hyperledger/fabric/client/TransactionImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/TransactionImpl.java
@@ -51,7 +51,7 @@ final class TransactionImpl implements Transaction {
     }
 
     @Override
-    public SubmittedTransaction submitAsync(final CallOption... options) {
+    public SubmittedTransaction submitAsync(final CallOption... options) throws SubmitException {
         sign();
         SubmitRequest submitRequest = SubmitRequest.newBuilder()
                 .setTransactionId(preparedTransaction.getTransactionId())
@@ -64,7 +64,7 @@ final class TransactionImpl implements Transaction {
     }
 
     @Override
-    public byte[] submit(final CallOption... options) throws CommitException {
+    public byte[] submit(final CallOption... options) throws CommitException, SubmitException, CommitStatusException {
         Status status = submitAsync(options).getStatus(options);
         if (!status.isSuccessful()) {
             throw new CommitException(status);

--- a/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
@@ -72,7 +72,9 @@ public final class ChaincodeEventsTest {
             try (CloseableIterator<ChaincodeEvent> events = network.getChaincodeEvents("CHAINCODE_NAME")) {
                 events.forEachRemaining(event -> { });
             }
-        }).isInstanceOf(StatusRuntimeException.class);
+        }).isInstanceOf(GatewayRuntimeException.class)
+                .extracting(t -> ((GatewayRuntimeException) t).getStatus())
+                .isEqualTo(Status.UNAVAILABLE);
     }
 
     @Test
@@ -200,7 +202,9 @@ public final class ChaincodeEventsTest {
         }
 
         assertThatThrownBy(() -> eventIter.forEachRemaining(event -> { }))
-                .isInstanceOf(StatusRuntimeException.class);
+                .isInstanceOf(GatewayRuntimeException.class)
+                .extracting(t -> ((GatewayRuntimeException) t).getStatus().getCode())
+                .isEqualTo(Status.Code.CANCELLED);
     }
 
     @Test

--- a/java/src/test/java/org/hyperledger/fabric/client/OfflineSignTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/OfflineSignTest.java
@@ -6,6 +6,9 @@
 
 package org.hyperledger.fabric.client;
 
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
 import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.client.identity.X509Identity;
 import org.hyperledger.fabric.protos.gateway.EndorseRequest;
@@ -16,9 +19,6 @@ import org.hyperledger.fabric.protos.gateway.SubmitRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.nio.charset.StandardCharsets;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -68,7 +68,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void evaluate_uses_offline_signature() {
+    void evaluate_uses_offline_signature() throws GatewayException {
         byte[] expected = "MY_SIGNATURE".getBytes(StandardCharsets.UTF_8);
 
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
@@ -90,7 +90,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void endorse_uses_offline_signature() {
+    void endorse_uses_offline_signature() throws EndorseException {
         byte[] expected = "MY_SIGNATURE".getBytes(StandardCharsets.UTF_8);
 
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
@@ -104,7 +104,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void submit_throws_with_no_signer_and_no_explicit_signing() {
+    void submit_throws_with_no_signer_and_no_explicit_signing() throws EndorseException {
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
         Proposal signedProposal = gateway.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
         Transaction transaction = signedProposal.endorse();
@@ -114,7 +114,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void submit_uses_offline_signature() {
+    void submit_uses_offline_signature() throws EndorseException, SubmitException {
         byte[] expected = "MY_SIGNATURE".getBytes(StandardCharsets.UTF_8);
 
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
@@ -130,7 +130,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void commit_throws_with_no_signer_and_no_explicit_signing() {
+    void commit_throws_with_no_signer_and_no_explicit_signing() throws EndorseException, SubmitException {
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
         Proposal signedProposal = gateway.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
         Transaction transaction = signedProposal.endorse();
@@ -143,7 +143,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void commit_uses_offline_signature() {
+    void commit_uses_offline_signature() throws EndorseException, SubmitException, CommitStatusException {
         byte[] expected = "MY_SIGNATURE".getBytes(StandardCharsets.UTF_8);
 
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
@@ -184,7 +184,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void signed_proposal_keeps_same_endorsing_orgs() {
+    void signed_proposal_keeps_same_endorsing_orgs() throws GatewayException {
         Contract contract = network.getContract("CHAINCODE_NAME");
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME")
                 .setEndorsingOrganizations("Org1MSP", "Org3MSP")
@@ -200,7 +200,7 @@ public final class OfflineSignTest {
 
 
     @Test
-    void signed_transaction_keeps_same_transaction_ID() {
+    void signed_transaction_keeps_same_transaction_ID() throws EndorseException {
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
         Proposal signedProposal = gateway.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
         Transaction unsignedTransaction = signedProposal.endorse();
@@ -213,7 +213,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void signed_transaction_keeps_same_digest() {
+    void signed_transaction_keeps_same_digest() throws EndorseException {
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
         Proposal signedProposal = gateway.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
         Transaction unsignedTransaction = signedProposal.endorse();
@@ -226,7 +226,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void signed_commit_keeps_same_transaction_ID() {
+    void signed_commit_keeps_same_transaction_ID() throws EndorseException, SubmitException {
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
         Proposal signedProposal = gateway.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
         Transaction unsignedTransaction = signedProposal.endorse();
@@ -241,7 +241,7 @@ public final class OfflineSignTest {
     }
 
     @Test
-    void signed_commit_keeps_same_digest() {
+    void signed_commit_keeps_same_digest() throws EndorseException, SubmitException {
         Proposal unsignedProposal = contract.newProposal("TRANSACTION_NAME").build();
         Proposal signedProposal = gateway.newSignedProposal(unsignedProposal.getBytes(), "SIGNATURE".getBytes(StandardCharsets.UTF_8));
         Transaction unsignedTransaction = signedProposal.endorse();

--- a/java/src/test/java/scenario/TransactionInvocation.java
+++ b/java/src/test/java/scenario/TransactionInvocation.java
@@ -12,10 +12,14 @@ import java.util.concurrent.Callable;
 
 import com.google.protobuf.InvalidProtocolBufferException;
 import org.hyperledger.fabric.client.Commit;
+import org.hyperledger.fabric.client.CommitStatusException;
 import org.hyperledger.fabric.client.Contract;
+import org.hyperledger.fabric.client.EndorseException;
 import org.hyperledger.fabric.client.Gateway;
+import org.hyperledger.fabric.client.GatewayException;
 import org.hyperledger.fabric.client.Proposal;
 import org.hyperledger.fabric.client.Status;
+import org.hyperledger.fabric.client.SubmitException;
 import org.hyperledger.fabric.client.SubmittedTransaction;
 import org.hyperledger.fabric.client.Transaction;
 import org.hyperledger.fabric.client.identity.Signer;
@@ -75,7 +79,7 @@ public final class TransactionInvocation {
         }
     }
 
-    private byte[] submit() throws InvalidProtocolBufferException, GeneralSecurityException {
+    private byte[] submit() throws InvalidProtocolBufferException, GeneralSecurityException, EndorseException, SubmitException, CommitStatusException {
         Proposal unsignedProposal = proposalBuilder.build();
         Proposal signedProposal = offlineSign(unsignedProposal);
 
@@ -122,7 +126,7 @@ public final class TransactionInvocation {
         return gateway.newSignedCommit(commit.getBytes(), signature);
     }
 
-    private byte[] evaluate() throws InvalidProtocolBufferException, GeneralSecurityException {
+    private byte[] evaluate() throws InvalidProtocolBufferException, GeneralSecurityException, GatewayException {
         Proposal unsignedProposal = proposalBuilder.build();
         Proposal signedProposal = offlineSign(unsignedProposal);
 


### PR DESCRIPTION
These exceptions all have GatewayException as their superclass, which provides access to the gRPC status exception information.

GatewayRuntimeException is an unchecked equivalent of GatewayException, and is used by chaincode events to wrap any thrown gRPC StatusRuntimeException. And unchecked exception is used by this streaming call to maintain compatibility with the Iterator API, and to allow Stream APIs to be used with events.

Contributes to #302 