### PR TITLE
Fix Java releases

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ build-node: build-protos
 	cd $(node_dir); npm install; npm run build; rm -f fabric-gateway-dev.tgz; mv $$(npm pack) fabric-gateway-dev.tgz
 
 build-java: build-protos
-	cd $(java_dir); mvn install -DskipTests -Dmaven.javadoc.skip=true
+	cd $(java_dir); mvn install -DskipTests
 
 unit-test: generate unit-test-go unit-test-node unit-test-java
 
@@ -99,7 +99,7 @@ run-samples-node: build-node
 	cd $(samples_dir)/node; rm -rf package-lock.json node_modules; npm install; npm run build; npm start
 
 run-samples-java: build-java
-	cd $(samples_dir)/java; mvn clean compile exec:java -Dexec.mainClass='com.example.Sample' -Dmaven.javadoc.skip=true
+	cd $(samples_dir)/java; mvn clean compile exec:java -Dexec.mainClass='com.example.Sample'
 
 generate:
 	go generate ./pkg/...
@@ -115,7 +115,7 @@ scenario-test-node: vendor-chaincode build-node
 	cd $(scenario_dir)/node; rm -rf package-lock.json node_modules; npm install; SOFTHSM2_CONF=${HOME}/softhsm2.conf npm test
 
 scenario-test-java: vendor-chaincode build-java
-	cd $(java_dir); mvn verify -Dmaven.javadoc.skip=true
+	cd $(java_dir); mvn verify
 
 scenario-test: scenario-test-go scenario-test-node scenario-test-java
 

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -142,8 +142,6 @@ stages:
     - task: NodeTool@0
       inputs:
         versionSpec: $(NODEVER)
-    - script: node --version
-      displayName: node version DELETE ME
     - script: make unit-test-node
       displayName: Run Node unit tests
     - publish: $(System.DefaultWorkingDirectory)/node
@@ -161,8 +159,6 @@ stages:
         versionSpec: $(JAVAVER)
         jdkArchitectureOption: 'x64'
         jdkSourceOption: 'PreInstalled'
-    - script: java -version
-      displayName: java version DELETE ME
     - script: make unit-test-java
       displayName: Run Java unit tests
   #   - script: bash <(curl https://codecov.io/bash) -t $CODECOV_UPLOAD_TOKEN

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -40,6 +40,7 @@
         <protobufVersion>3.17.2</protobufVersion> <!-- keep in step with the version used by io.grpc:grpc-protobuf -->
         <cucumberVersion>7.0.0</cucumberVersion>
         <junitVersion>5.8.1</junitVersion>
+        <enforceJavaVersion>1.8</enforceJavaVersion> <!-- this is overridden in the release profile -->
     </properties>
 
     <repositories>
@@ -156,84 +157,114 @@
                 <version>1.6.2</version>
             </extension>
         </extensions>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                    <configuration>
-                        <source>${javaVersion}</source>
-                        <target>${javaVersion}</target>
-                        <showDeprecation>true</showDeprecation>
-                        <showWarnings>true</showWarnings>
-                        <compilerArgs>
-                            <arg>-Xlint</arg>
-                            <!-- Disable command line warnings, seen when building against multiple releases: -->
-                            <arg>-Xlint:-options</arg>
-                            <arg>-Xlint:-processing</arg>
-                            <arg>-Werror</arg>
-                        </compilerArgs>
-                    </configuration>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M5</version>
-                    <configuration>
-                        <excludes>
-                            <exclude>**/scenario/**</exclude>
-                        </excludes>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>scenarios</id>
-                            <phase>integration-test</phase>
-                            <goals>
-                                <goal>test</goal>
-                            </goals>
-                            <configuration>
-                                <excludes>
-                                    <exclude>none</exclude>
-                                </excludes>
-                                <includes>
-                                    <include>**/RunScenarioTest</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>setup</id>
-                            <phase>pre-integration-test</phase>
-                            <goals>
-                                <goal>test</goal>
-                            </goals>
-                            <configuration>
-                                <excludes>
-                                    <exclude>none</exclude>
-                                </excludes>
-                                <includes>
-                                    <include>**/SetupScenarioTest</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>cleanup</id>
-                            <phase>post-integration-test</phase>
-                            <goals>
-                                <goal>test</goal>
-                            </goals>
-                            <configuration>
-                                <excludes>
-                                    <exclude>none</exclude>
-                                </excludes>
-                                <includes>
-                                    <include>**/CleanupScenarioTest</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>enforce-version</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>${enforceJavaVersion}</version>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-help-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>show-profiles</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>active-profiles</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${javaVersion}</source>
+                    <target>${javaVersion}</target>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                    <compilerArgs>
+                        <arg>-Xlint</arg>
+                        <!-- Disable command line warnings, seen when building against multiple releases: -->
+                        <arg>-Xlint:-options</arg>
+                        <arg>-Xlint:-processing</arg>
+                        <arg>-Werror</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M5</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/scenario/**</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>scenarios</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/RunScenarioTest</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>setup</id>
+                        <phase>pre-integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/SetupScenarioTest</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cleanup</id>
+                        <phase>post-integration-test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/CleanupScenarioTest</include>
+                            </includes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -252,7 +283,7 @@
                     <source>${javaVersion}</source>
                     <detectJavaApiLink>false</detectJavaApiLink>
                     <additionalJOptions>
-                        <additionalJOption>--no-module-directories</additionalJOption>
+                        <additionalJOption>${additionalJavadocOpts}</additionalJOption>
                     </additionalJOptions>
                 </configuration>
                 <executions>
@@ -332,6 +363,15 @@
     </distributionManagement>
     <profiles>
         <profile>
+            <id>javadoc-no-module-directories</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <additionalJavadocOpts>--no-module-directories</additionalJavadocOpts>
+            </properties>
+        </profile>
+        <profile>
             <id>owasp</id>
             <build>
                 <plugins>
@@ -358,6 +398,9 @@
         </profile>
         <profile>
             <id>release</id>
+            <properties>
+                <enforceJavaVersion>[1.8,1.9)</enforceJavaVersion> <!-- must use 1.8 JDK for release build -->
+            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -408,32 +451,6 @@
                                 <id>attach-sources</id>
                                 <goals>
                                     <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.2.0</version>
-                        <configuration>
-                            <excludePackageNames>
-                                org.hyperledger.fabric.protos.gateway.impl:org.hyperledger.fabric.protos.*
-                            </excludePackageNames>
-                            <show>public</show>
-                            <doctitle>Hyperledger Fabric Gateway SDK for Java</doctitle>
-                            <nohelp>true</nohelp>
-                            <failOnError>true</failOnError>
-                            <failOnWarnings>true</failOnWarnings>
-                            <additionalJOptions>
-                                <additionalJOption>--no-module-directories</additionalJOption>
-                            </additionalJOptions>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>


### PR DESCRIPTION
Needing to know which versions of javadoc support the --no-module-directories option is error prone and also causes confusion running builds locally

The pom.xml has been update with a javadoc-no-module-directories profile which automatically adds the option for newer JDKs

Also removes the pluginManagement section, since there are no child builds, and strictly enfoces a 1.8 JDK for release builds

Signed-off-by: James Taylor <jamest@uk.ibm.com>