### PR TITLE
Extract transaction response from envelope payload

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayImpl.java
@@ -6,6 +6,10 @@
 
 package org.hyperledger.fabric.client;
 
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.function.Function;
+
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.Channel;
 import org.hyperledger.fabric.client.identity.Identity;
@@ -17,10 +21,6 @@ import org.hyperledger.fabric.protos.gateway.ProposedTransaction;
 import org.hyperledger.fabric.protos.gateway.SignedChaincodeEventsRequest;
 import org.hyperledger.fabric.protos.gateway.SignedCommitStatusRequest;
 import org.hyperledger.fabric.protos.peer.ProposalPackage;
-
-import java.util.Arrays;
-import java.util.Objects;
-import java.util.function.Function;
 
 final class GatewayImpl implements Gateway {
     public static final class Builder implements Gateway.Builder {
@@ -141,10 +141,7 @@ final class GatewayImpl implements Gateway {
     public Transaction newSignedTransaction(final byte[] bytes, final byte[] signature) {
         try {
             PreparedTransaction preparedTransaction = PreparedTransaction.parseFrom(bytes);
-            Common.Payload payload = Common.Payload.parseFrom(preparedTransaction.getEnvelope().getPayload());
-            Common.ChannelHeader channelHeader = Common.ChannelHeader.parseFrom(payload.getHeader().getChannelHeader());
-
-            TransactionImpl transaction = new TransactionImpl(client, signingIdentity, channelHeader.getChannelId(), preparedTransaction);
+            TransactionImpl transaction = new TransactionImpl(client, signingIdentity, preparedTransaction);
             transaction.setSignature(signature);
             return transaction;
         } catch (InvalidProtocolBufferException e) {

--- a/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
@@ -75,7 +75,7 @@ final class ProposalImpl implements Proposal {
                 .setEnvelope(endorseResponse.getPreparedTransaction())
                 .setResult(endorseResponse.getResult())
                 .build();
-        return new TransactionImpl(client, signingIdentity, channelName, preparedTransaction);
+        return new TransactionImpl(client, signingIdentity, preparedTransaction);
     }
 
     void setSignature(final byte[] signature) {

--- a/java/src/main/java/org/hyperledger/fabric/client/TransactionEnvelopeParser.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/TransactionEnvelopeParser.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.hyperledger.fabric.client;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.InvalidProtocolBufferException;
+
+import static org.hyperledger.fabric.protos.common.Common.ChannelHeader;
+import static org.hyperledger.fabric.protos.common.Common.Envelope;
+import static org.hyperledger.fabric.protos.common.Common.Header;
+import static org.hyperledger.fabric.protos.common.Common.Payload;
+import static org.hyperledger.fabric.protos.peer.ProposalPackage.ChaincodeAction;
+import static org.hyperledger.fabric.protos.peer.ProposalResponsePackage.ProposalResponsePayload;
+import static org.hyperledger.fabric.protos.peer.TransactionPackage.ChaincodeActionPayload;
+import static org.hyperledger.fabric.protos.peer.TransactionPackage.Transaction;
+import static org.hyperledger.fabric.protos.peer.TransactionPackage.TransactionAction;
+
+final class TransactionEnvelopeParser {
+    private final String channelName;
+    private final ByteString result;
+
+    TransactionEnvelopeParser(final Envelope envelope) {
+        try {
+            Payload payload = Payload.parseFrom(envelope.getPayload());
+            channelName = parseChannelName(payload.getHeader());
+            result = parseResult(payload);
+        } catch (InvalidProtocolBufferException e) {
+            throw new IllegalArgumentException("Invalid transaction payload", e);
+        }
+    }
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public ByteString getResult() {
+        return result;
+    }
+
+    private String parseChannelName(final Header header) throws InvalidProtocolBufferException {
+        ChannelHeader channelHeader = ChannelHeader.parseFrom(header.getChannelHeader());
+        return channelHeader.getChannelId();
+    }
+
+    private ByteString parseResult(final Payload payload) throws InvalidProtocolBufferException {
+        Transaction transaction = Transaction.parseFrom(payload.getData());
+
+        List<InvalidProtocolBufferException> parseExceptions = new ArrayList<>();
+
+        for (TransactionAction transactionAction : transaction.getActionsList()) {
+            try {
+                return parseResult(transactionAction);
+            } catch (InvalidProtocolBufferException e) {
+                parseExceptions.add(e);
+            }
+        }
+
+        IllegalArgumentException e = new IllegalArgumentException("No proposal response found");
+        parseExceptions.forEach(e::addSuppressed);
+        throw e;
+    }
+
+    private ByteString parseResult(final TransactionAction transactionAction) throws InvalidProtocolBufferException {
+        ChaincodeActionPayload actionPayload = ChaincodeActionPayload.parseFrom(transactionAction.getPayload());
+        ProposalResponsePayload responsePayload = ProposalResponsePayload.parseFrom(actionPayload.getAction().getProposalResponsePayload());
+        ChaincodeAction chaincodeAction = ChaincodeAction.parseFrom(responsePayload.getExtension());
+        return chaincodeAction.getResponse().getPayload();
+    }
+}

--- a/java/src/main/java/org/hyperledger/fabric/client/TransactionImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/TransactionImpl.java
@@ -18,20 +18,21 @@ final class TransactionImpl implements Transaction {
     private final SigningIdentity signingIdentity;
     private final String channelName;
     private PreparedTransaction preparedTransaction;
+    private final ByteString result;
 
-    TransactionImpl(final GatewayClient client, final SigningIdentity signingIdentity,
-            final String channelName, final PreparedTransaction preparedTransaction) {
+    TransactionImpl(final GatewayClient client, final SigningIdentity signingIdentity, final PreparedTransaction preparedTransaction) {
         this.client = client;
         this.signingIdentity = signingIdentity;
-        this.channelName = channelName;
         this.preparedTransaction = preparedTransaction;
+
+        TransactionEnvelopeParser parser = new TransactionEnvelopeParser(preparedTransaction.getEnvelope());
+        this.channelName = parser.getChannelName();
+        this.result = parser.getResult();
     }
 
     @Override
     public byte[] getResult() {
-        return preparedTransaction.getResult()
-                .getPayload()
-                .toByteArray();
+        return result.toByteArray();
     }
 
     @Override

--- a/node/src/commit.ts
+++ b/node/src/commit.ts
@@ -5,7 +5,6 @@
  */
 
 import { CallOptions } from '@grpc/grpc-js';
-import { inspect } from 'util';
 import { GatewayClient } from './client';
 import { CommitStatusResponse, SignedCommitStatusRequest } from './protos/gateway/gateway_pb';
 import { Signable } from './signable';
@@ -57,10 +56,6 @@ export class CommitImpl implements Commit {
 
     getDigest(): Uint8Array {
         const request = this.#signedRequest.getRequest_asU8();
-        if (!request) {
-            throw new Error(`Request not defined: ${inspect(this.#signedRequest)}`);
-        }
-
         return this.#signingIdentity.hash(request);
     }
 

--- a/node/src/offlinesign.test.ts
+++ b/node/src/offlinesign.test.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { MockGatewayGrpcClient } from './client.test';
+import { MockGatewayGrpcClient, newEndorseResponse } from './client.test';
 import { Contract } from './contract';
 import { Gateway, internalConnect, InternalConnectOptions } from './gateway';
 import { Identity } from './identity/identity';
 import { Network } from './network';
-import { ChannelHeader, Envelope, Header, Payload } from './protos/common/common_pb';
-import { CommitStatusResponse, EndorseResponse, EvaluateResponse } from './protos/gateway/gateway_pb';
+import { CommitStatusResponse, EvaluateResponse } from './protos/gateway/gateway_pb';
 import { Response } from './protos/peer/proposal_response_pb';
 import { TxValidationCode } from './protos/peer/transaction_pb';
 import { undefinedSignerMessage } from './signingidentity';
@@ -35,23 +34,11 @@ describe('Offline sign', () => {
 
         client.mockEvaluateResponse(evaluateResult);
 
-        const channelHeader = new ChannelHeader();
-        channelHeader.setChannelId('CHANNEL');
-
-        const header = new Header();
-        header.setChannelHeader(channelHeader.serializeBinary());
-
-        const payload = new Payload();
-        payload.setHeader(header);
-
-        const txEnvelope = new Envelope();
-        txEnvelope.setPayload(payload.serializeBinary());
-
-        const endorseResult = new EndorseResponse();
-        endorseResult.setPreparedTransaction(txEnvelope);
-        endorseResult.setResult(txResult)
-
-        client.mockEndorseResponse(endorseResult);
+        const endorseResponse = newEndorseResponse({
+            result: Buffer.from(expectedResult),
+            channelName: 'CHANNEL',
+        });
+        client.mockEndorseResponse(endorseResponse);
 
         const commitResult = new CommitStatusResponse();
         commitResult.setResult(TxValidationCode.VALID);

--- a/node/src/proposal.test.ts
+++ b/node/src/proposal.test.ts
@@ -5,14 +5,14 @@
  */
 
 import { CallOptions, Metadata, ServiceError, status } from '@grpc/grpc-js';
-import { MockGatewayGrpcClient } from './client.test';
+import { MockGatewayGrpcClient, newEndorseResponse } from './client.test';
 import { Contract } from './contract';
 import { EndorseError } from './endorseerror';
 import { Gateway, internalConnect } from './gateway';
 import { Identity } from './identity/identity';
 import { Network } from './network';
-import { ChannelHeader, Envelope, Header, SignatureHeader } from './protos/common/common_pb';
-import { CommitStatusResponse, EndorseRequest, EndorseResponse, EvaluateRequest, EvaluateResponse } from './protos/gateway/gateway_pb';
+import { ChannelHeader, Header, SignatureHeader } from './protos/common/common_pb';
+import { CommitStatusResponse, EndorseRequest, EvaluateRequest, EvaluateResponse } from './protos/gateway/gateway_pb';
 import { SerializedIdentity } from './protos/msp/identities_pb';
 import { ChaincodeInvocationSpec, ChaincodeSpec } from './protos/peer/chaincode_pb';
 import { ChaincodeProposalPayload, Proposal as ProposalProto } from './protos/peer/proposal_pb';
@@ -341,21 +341,13 @@ describe('Proposal', () => {
 
     describe('endorse', () => {
         beforeEach(() => {
-            const txResult = new Response()
-            txResult.setPayload(Buffer.from('TX_RESULT'));
-    
-            const preparedTx = new Envelope();
-            preparedTx.setPayload(Buffer.from('PAYLOAD'));
-    
-            const endorseResult = new EndorseResponse();
-            endorseResult.setPreparedTransaction(preparedTx);
-            endorseResult.setResult(txResult)
-
+            const endorseResult = newEndorseResponse({
+                result: Buffer.from('TX_RESULT'),
+            });
             client.mockEndorseResponse(endorseResult);
 
             const commitResult = new CommitStatusResponse();
             commitResult.setResult(TxValidationCode.VALID);
-
             client.mockCommitStatusResponse(commitResult);
         });
 

--- a/node/src/transaction.test.ts
+++ b/node/src/transaction.test.ts
@@ -5,16 +5,14 @@
  */
 
 import { CallOptions, Metadata, ServiceError, status } from '@grpc/grpc-js';
-import { MockGatewayGrpcClient } from './client.test';
+import { MockGatewayGrpcClient, newEndorseResponse } from './client.test';
 import { CommitError } from './commiterror';
 import { CommitStatusError } from './commitstatuserror';
 import { Contract } from './contract';
 import { Gateway, internalConnect, InternalConnectOptions } from './gateway';
 import { Identity } from './identity/identity';
 import { Network } from './network';
-import { Envelope } from './protos/common/common_pb';
-import { CommitStatusResponse, EndorseResponse } from './protos/gateway/gateway_pb';
-import { Response } from './protos/peer/proposal_response_pb';
+import { CommitStatusResponse } from './protos/gateway/gateway_pb';
 import { TxValidationCode } from './protos/peer/transaction_pb';
 import { SubmitError } from './submiterror';
 
@@ -49,21 +47,13 @@ describe('Transaction', () => {
 
         client = new MockGatewayGrpcClient();
 
-        const txResult = new Response()
-        txResult.setPayload(Buffer.from(expectedResult));
-
-        const preparedTx = new Envelope();
-        preparedTx.setPayload(Buffer.from('PAYLOAD'));
-
-        const endorseResult = new EndorseResponse();
-        endorseResult.setPreparedTransaction(preparedTx);
-        endorseResult.setResult(txResult)
-
-        client.mockEndorseResponse(endorseResult);
+        const endorseResponse = newEndorseResponse({
+            result: Buffer.from(expectedResult),
+        });
+        client.mockEndorseResponse(endorseResponse);
 
         const commitResult = new CommitStatusResponse();
         commitResult.setResult(TxValidationCode.VALID);
-
         client.mockCommitStatusResponse(commitResult);
 
         identity = {

--- a/node/src/transactionparser.ts
+++ b/node/src/transactionparser.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 IBM All Rights Reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { inspect } from 'util';
+import { assertDefined } from './gateway';
+import { ChannelHeader, Envelope, Header, Payload } from './protos/common/common_pb';
+import { ChaincodeAction } from './protos/peer/proposal_pb';
+import { ProposalResponsePayload } from './protos/peer/proposal_response_pb';
+import { ChaincodeActionPayload, Transaction, TransactionAction } from './protos/peer/transaction_pb';
+
+export function parseTransactionEnvelope(envelope: Envelope): {
+    channelName: string,
+    result: Uint8Array,
+ } {
+    const payload = Payload.deserializeBinary(envelope.getPayload_asU8());
+    const header = assertDefined(payload.getHeader(), 'Missing header');
+
+    return {
+        channelName: parseChannelNameFromHeader(header),
+        result: parseResultFromPayload(payload),
+    };
+}
+
+function parseChannelNameFromHeader(header: Header): string {
+    const channelHeader = ChannelHeader.deserializeBinary(header.getChannelHeader_asU8());
+    return channelHeader.getChannelId();
+}
+
+function parseResultFromPayload(payload: Payload): Uint8Array {
+    const transaction = Transaction.deserializeBinary(payload.getData_asU8());
+
+    const errors: unknown[] = [];
+
+    for (const transactionAction of transaction.getActionsList()) {
+        try {
+            return parseResultFromTransactionAction(transactionAction)
+        } catch (err) {
+            errors.push(err);
+        }
+    }
+
+    throw Object.assign(new Error(`No proposal response found: ${inspect(errors)}`), {
+        suppressed: errors,
+    });
+}
+
+function parseResultFromTransactionAction(transactionAction: TransactionAction): Uint8Array {
+    const actionPayload = ChaincodeActionPayload.deserializeBinary(transactionAction.getPayload_asU8());
+    const endorsedAction = assertDefined(actionPayload.getAction(), 'Missing endorsed action');
+    const responsePayload = ProposalResponsePayload.deserializeBinary(endorsedAction.getProposalResponsePayload_asU8());
+    const chaincodeAction = ChaincodeAction.deserializeBinary(responsePayload.getExtension_asU8());
+    const chaincodeResponse = assertDefined(chaincodeAction.getResponse(), 'Missing chaincode response');
+    return chaincodeResponse.getPayload_asU8();
+}

--- a/pkg/client/gateway.go
+++ b/pkg/client/gateway.go
@@ -204,22 +204,11 @@ func (gw *Gateway) NewSignedTransaction(bytes []byte, signature []byte) (*Transa
 		return nil, fmt.Errorf("failed to deserialize prepared transaction: %w", err)
 	}
 
-	payload := &common.Payload{}
-	if err := proto.Unmarshal(preparedTransaction.GetEnvelope().GetPayload(), payload); err != nil {
-		return nil, fmt.Errorf("failed to deserialize payload: %w", err)
+	transaction, err := newTransaction(gw.client, gw.signingID, preparedTransaction)
+	if err != nil {
+		return nil, err
 	}
 
-	channelHeader := &common.ChannelHeader{}
-	if err := proto.Unmarshal(payload.GetHeader().GetChannelHeader(), channelHeader); err != nil {
-		return nil, fmt.Errorf("failed to deserialize channel header: %w", err)
-	}
-
-	transaction := &Transaction{
-		client:              gw.client,
-		signingID:           gw.signingID,
-		channelID:           channelHeader.GetChannelId(),
-		preparedTransaction: preparedTransaction,
-	}
 	transaction.setSignature(signature)
 
 	return transaction, nil

--- a/pkg/client/identity_test.go
+++ b/pkg/client/identity_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
-	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -42,7 +41,7 @@ func TestIdentity(t *testing.T) {
 	t.Run("Evaluate uses client identity for proposals", func(t *testing.T) {
 		var actual []byte
 		mockClient := NewMockGatewayClient(gomock.NewController(t))
-		evaluateResponse := gateway.EvaluateResponse{
+		evaluateResponse := &gateway.EvaluateResponse{
 			Result: &peer.Response{
 				Payload: nil,
 			},
@@ -51,7 +50,7 @@ func TestIdentity(t *testing.T) {
 			Do(func(_ context.Context, in *gateway.EvaluateRequest, _ ...grpc.CallOption) {
 				actual = test.AssertUnmarshallSignatureHeader(t, in.ProposedTransaction).Creator
 			}).
-			Return(&evaluateResponse, nil).
+			Return(evaluateResponse, nil).
 			Times(1)
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithIdentity(id))
@@ -65,25 +64,20 @@ func TestIdentity(t *testing.T) {
 	t.Run("Submit uses client identity for proposals", func(t *testing.T) {
 		var actual []byte
 		mockClient := NewMockGatewayClient(gomock.NewController(t))
-		endorseResponse := gateway.EndorseResponse{
-			PreparedTransaction: &common.Envelope{},
-			Result: &peer.Response{
-				Payload: nil,
-			},
-		}
-		statusResponse := gateway.CommitStatusResponse{
+		endorseResponse := AssertNewEndorseResponse(t, "result", "channel")
+		statusResponse := &gateway.CommitStatusResponse{
 			Result: peer.TxValidationCode_VALID,
 		}
 		mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.EndorseRequest, _ ...grpc.CallOption) {
 				actual = test.AssertUnmarshallSignatureHeader(t, in.ProposedTransaction).Creator
 			}).
-			Return(&endorseResponse, nil).
+			Return(endorseResponse, nil).
 			Times(1)
 		mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 			Return(nil, nil)
 		mockClient.EXPECT().CommitStatus(gomock.Any(), gomock.Any()).
-			Return(&statusResponse, nil)
+			Return(statusResponse, nil)
 
 		contract := AssertNewTestContract(t, "contract", WithClient(mockClient), WithIdentity(id))
 

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/stretchr/testify/require"
@@ -32,15 +31,6 @@ func TestOfflineSign(t *testing.T) {
 		contract := gateway.GetNetwork("network").GetContract("contract")
 
 		return gateway, contract
-	}
-
-	newEndorseResponse := func(value string) *gateway.EndorseResponse {
-		return &gateway.EndorseResponse{
-			PreparedTransaction: &common.Envelope{},
-			Result: &peer.Response{
-				Payload: []byte(value),
-			},
-		}
 	}
 
 	newCommitStatusResponse := func(value peer.TxValidationCode) *gateway.CommitStatusResponse {
@@ -127,7 +117,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
-				Return(newEndorseResponse("result"), nil).
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil).
 				AnyTimes()
 
 			_, contract := newContractWithNoSign(t, WithClient(mockClient))
@@ -147,7 +137,7 @@ func TestOfflineSign(t *testing.T) {
 				Do(func(_ context.Context, in *gateway.EndorseRequest, _ ...grpc.CallOption) {
 					actual = in.ProposedTransaction.Signature
 				}).
-				Return(newEndorseResponse("result"), nil).
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil).
 				Times(1)
 
 			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
@@ -176,7 +166,7 @@ func TestOfflineSign(t *testing.T) {
 				Do(func(_ context.Context, in *gateway.EndorseRequest, _ ...grpc.CallOption) {
 					actual = in.EndorsingOrganizations
 				}).
-				Return(newEndorseResponse("result"), nil).
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil).
 				Times(1)
 
 			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
@@ -201,7 +191,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
-				Return(newEndorseResponse("result"), nil).
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil).
 				AnyTimes()
 			mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 				Return(nil, nil).
@@ -230,7 +220,7 @@ func TestOfflineSign(t *testing.T) {
 			var actual []byte
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
-				Return(newEndorseResponse("result"), nil)
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil)
 			mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 				Do(func(_ context.Context, in *gateway.SubmitRequest, _ ...grpc.CallOption) {
 					actual = in.PreparedTransaction.Signature
@@ -269,7 +259,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
-				Return(newEndorseResponse("result"), nil).
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil).
 				AnyTimes()
 			mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 				Return(nil, nil).
@@ -310,7 +300,7 @@ func TestOfflineSign(t *testing.T) {
 			var actual []byte
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
-				Return(newEndorseResponse("result"), nil)
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil)
 			mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 				Return(nil, nil).
 				AnyTimes()
@@ -399,7 +389,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Transaction keeps same digest", func(t *testing.T) {
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
-				Return(newEndorseResponse("result"), nil).
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil).
 				Times(1)
 
 			gateway, contract := newContractWithNoSign(t, WithClient(mockClient))
@@ -431,7 +421,7 @@ func TestOfflineSign(t *testing.T) {
 		t.Run("Commit keeps same digest", func(t *testing.T) {
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
-				Return(newEndorseResponse("result"), nil).
+				Return(AssertNewEndorseResponse(t, "result", "network"), nil).
 				Times(1)
 			mockClient.EXPECT().Submit(gomock.Any(), gomock.Any()).
 				Return(nil, nil).

--- a/pkg/client/proposal.go
+++ b/pkg/client/proposal.go
@@ -79,15 +79,8 @@ func (proposal *Proposal) endorse(
 	preparedTransaction := &gateway.PreparedTransaction{
 		TransactionId: proposal.proposedTransaction.GetTransactionId(),
 		Envelope:      response.GetPreparedTransaction(),
-		Result:        response.GetResult(),
 	}
-	result := &Transaction{
-		client:              proposal.client,
-		signingID:           proposal.signingID,
-		channelID:           proposal.channelID,
-		preparedTransaction: preparedTransaction,
-	}
-	return result, nil
+	return newTransaction(proposal.client, proposal.signingID, preparedTransaction)
 }
 
 // Evaluate the proposal and obtain a transaction result. This is effectively a query.

--- a/pkg/client/transaction.go
+++ b/pkg/client/transaction.go
@@ -15,17 +15,34 @@ import (
 	"google.golang.org/grpc"
 )
 
+func newTransaction(client *gatewayClient, signingID *signingIdentity, preparedTransaction *gateway.PreparedTransaction) (*Transaction, error) {
+	txInfo, err := parseTransactionEnvelope(preparedTransaction.GetEnvelope())
+	if err != nil {
+		return nil, err
+	}
+
+	transaction := &Transaction{
+		client:              client,
+		signingID:           signingID,
+		channelID:           txInfo.ChannelName,
+		preparedTransaction: preparedTransaction,
+		result:              txInfo.Result,
+	}
+	return transaction, nil
+}
+
 // Transaction represents an endorsed transaction that can be submitted to the orderer for commit to the ledger.
 type Transaction struct {
 	client              *gatewayClient
 	signingID           *signingIdentity
 	channelID           string
 	preparedTransaction *gateway.PreparedTransaction
+	result              []byte
 }
 
 // Result of the proposed transaction invocation.
 func (transaction *Transaction) Result() []byte {
-	return transaction.preparedTransaction.GetResult().GetPayload()
+	return transaction.result
 }
 
 // Bytes of the serialized transaction.

--- a/pkg/client/transactionparser.go
+++ b/pkg/client/transactionparser.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package client
+
+import (
+	"fmt"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-protos-go/common"
+	"github.com/hyperledger/fabric-protos-go/peer"
+)
+
+type transactionInfo struct {
+	ChannelName string
+	Result      []byte
+}
+
+func parseTransactionEnvelope(envelope *common.Envelope) (*transactionInfo, error) {
+	payload := &common.Payload{}
+	if err := proto.Unmarshal(envelope.GetPayload(), payload); err != nil {
+		return nil, fmt.Errorf("failed to deserialize payload: %w", err)
+	}
+
+	channelName, err := parseChannelNameFromHeader(payload.GetHeader())
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := parseResultFromPayload(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	txInfo := &transactionInfo{
+		ChannelName: channelName,
+		Result:      result,
+	}
+	return txInfo, nil
+}
+
+func parseChannelNameFromHeader(header *common.Header) (string, error) {
+	channelHeader := &common.ChannelHeader{}
+	if err := proto.Unmarshal(header.GetChannelHeader(), channelHeader); err != nil {
+		return "", fmt.Errorf("failed to deserialize channel header: %w", err)
+	}
+
+	return channelHeader.GetChannelId(), nil
+}
+
+func parseResultFromPayload(payload *common.Payload) ([]byte, error) {
+	transaction := &peer.Transaction{}
+	if err := proto.Unmarshal(payload.GetData(), transaction); err != nil {
+		return nil, fmt.Errorf("failed to deserialize transaction: %w", err)
+	}
+
+	errors := make([]error, 0)
+
+	for _, transactionAction := range transaction.GetActions() {
+		result, err := parseResultFromTransactionAction(transactionAction)
+		if err == nil {
+			return result, nil
+		}
+
+		errors = append(errors, err)
+	}
+
+	return nil, fmt.Errorf("no proposal response found: %v", errors)
+}
+
+func parseResultFromTransactionAction(transactionAction *peer.TransactionAction) ([]byte, error) {
+	actionPayload := &peer.ChaincodeActionPayload{}
+	if err := proto.Unmarshal(transactionAction.GetPayload(), actionPayload); err != nil {
+		return nil, fmt.Errorf("failed to deserialize chaincode action payload: %w", err)
+	}
+
+	responsePayload := &peer.ProposalResponsePayload{}
+	if err := proto.Unmarshal(actionPayload.GetAction().GetProposalResponsePayload(), responsePayload); err != nil {
+		return nil, fmt.Errorf("failed to deserialize proposal response payload: %w", err)
+	}
+
+	chaincodeAction := &peer.ChaincodeAction{}
+	if err := proto.Unmarshal(responsePayload.GetExtension(), chaincodeAction); err != nil {
+		return nil, fmt.Errorf("failed to deserialize chaincode action: %w", err)
+	}
+
+	return chaincodeAction.GetResponse().GetPayload(), nil
+}


### PR DESCRIPTION
Don't use the top-level Result from the EndorseResponse since this duplicates the values within the envelope payload, and this duplication may cause message size limit failures.

Contributes to #316 