### PR TITLE
Don't set PreparedTransaction.result field in Java client

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ProposalImpl.java
@@ -73,7 +73,6 @@ final class ProposalImpl implements Proposal {
         PreparedTransaction preparedTransaction = PreparedTransaction.newBuilder()
                 .setTransactionId(proposedTransaction.getTransactionId())
                 .setEnvelope(endorseResponse.getPreparedTransaction())
-                .setResult(endorseResponse.getResult())
                 .build();
         return new TransactionImpl(client, signingIdentity, preparedTransaction);
     }


### PR DESCRIPTION
This field is no longer used and will be removed.

Contributes to #316 