### PR TITLE
Update Fabric dependencies for next Fabric version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,16 @@ samples_dir := $(base_dir)/samples
 hsm_samples_dir := $(base_dir)/hsm-samples
 
 # PEER_IMAGE_PULL is where to pull peer image from, it can be set by external env variable
+# In fabric-gateway main branch it should reflect the location of the latest fabric main branch image
 PEER_IMAGE_PULL ?= hyperledger-fabric.jfrog.io/fabric-peer:amd64-latest
 
 # PEER_IMAGE_TAG is what to tag the pulled peer image as, it will also be used in docker-compose to reference the image
-PEER_IMAGE_TAG ?= 2.4
+# In fabric-gateway main branch this version tag should correspond to the version in the fabric main branch
+PEER_IMAGE_TAG ?= 2.5
 
 # TWO_DIGIT_VERSION specifies which chaincode images to pull, they will be tagged to be consistent with PEER_IMAGE_TAG
-TWO_DIGIT_VERSION ?= 2.3
+# In fabric-gateway main branch it should typically be the latest released chaincode version available in dockerhub.
+TWO_DIGIT_VERSION ?= 2.4
 
 PKGNAME = github.com/hyperledger/fabric-gateway
 ARCH=$(shell go env GOARCH)

--- a/scenario/fixtures/docker-compose/.env
+++ b/scenario/fixtures/docker-compose/.env
@@ -1,7 +1,8 @@
 # Environment variables will be overridden if set in user environment or Makefile.
-ORDER_IMAGE_TAG=2.4
+# Typically we'll want to test with the latest released orderer and tools images from dockerhub, but latest unreleased peer image that has been pulled and tagged
+ORDERER_IMAGE_TAG=2.4
 TOOLS_IMAGE_TAG=2.4
-PEER_IMAGE_TAG=2.4
+PEER_IMAGE_TAG=2.5
 FABRIC_CA_IMAGE_TAG=1.5
 COUCHDB_IMAGE_TAG=3.1.1
 DOCKER_DEBUG=info:dockercontroller,gateway=debug

--- a/scenario/fixtures/docker-compose/docker-compose-base.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-base.yaml
@@ -44,7 +44,7 @@ services:
 
   orderer:
     container_name: orderer
-    image: hyperledger/fabric-orderer:${ORDER_IMAGE_TAG}
+    image: hyperledger/fabric-orderer:${ORDERER_IMAGE_TAG}
     environment:
       - ORDERER_GENERAL_LOGLEVEL=${DOCKER_DEBUG}
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0


### PR DESCRIPTION
Update Makefile and scenario tests to align with next version specified in Fabric main branch (v2.5).

Signed-off-by: David Enyeart <enyeart@us.ibm.com>