### PR TITLE
Node security scan in nightly build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,10 @@ lint:
 	staticcheck -tags="pkcs11" $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 	go vet -tags pkcs11 $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 
-scan: scan-java
+scan: scan-node scan-java
+
+scan-node:
+	cd $(node_dir); npm install --package-lock-only; npm audit --production
 
 scan-java: build-protos
 	cd $(java_dir); mvn verify -DskipTests -P owasp

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -281,6 +281,19 @@ stages:
         jdkSourceOption: 'PreInstalled'
     - script: make scan-java
       displayName: 'Run Java security vulnerability scan'
+  - job: ScanNode
+    pool:
+      vmImage: ubuntu-20.04
+    dependsOn: []
+    timeoutInMinutes: 60
+    steps:
+    - template: install_deps.yml
+    - checkout: self
+    - task: NodeTool@0
+      inputs:
+        versionSpec: $(NODEVER)
+    - script: make scan-node
+      displayName: 'Run Node security vulnerability scan'
       
 # Only publish on scheduled builds and tagged releases
 - stage: Publish

--- a/hsm-samples/node/package.json
+++ b/hsm-samples/node/package.json
@@ -23,13 +23,13 @@
     },
     "devDependencies": {
         "@tsconfig/node14": "^1.0.1",
-        "@types/jsrsasign": "^8.0.13",
+        "@types/jsrsasign": "^9.0.3",
         "@types/node": "^14.17.32",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
         "eslint": "^8.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
-        "typescript": "~4.4.4"
+        "typescript": "~4.5.4"
     }
 }

--- a/node/package.json
+++ b/node/package.json
@@ -57,6 +57,6 @@
         "ts-jest": "^27.0.7",
         "ts-protoc-gen": "^0.15.0",
         "typedoc": "^0.22.7",
-        "typescript": "~4.4.4"
+        "typescript": "~4.5.4"
     }
 }

--- a/samples/node/package.json
+++ b/samples/node/package.json
@@ -28,6 +28,6 @@
         "eslint": "^8.1.0",
         "npm-run-all": "^4.1.5",
         "rimraf": "^3.0.2",
-        "typescript": "~4.4.4"
+        "typescript": "~4.5.4"
     }
 }

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -20,9 +20,9 @@
         "@hyperledger/fabric-gateway": "file:../../node/fabric-gateway-dev.tgz"
     },
     "devDependencies": {
-        "@cucumber/cucumber": "^7.0.0",
+        "@cucumber/cucumber": "^7.3.2",
         "@tsconfig/node14": "^1.0.1",
-        "@types/jsrsasign": "^8.0.13",
+        "@types/jsrsasign": "^9.0.3",
         "@types/node": "^14.17.32",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
@@ -32,6 +32,6 @@
         "jsrsasign": "^10.4.0",
         "npm-run-all": "^4.1.5",
         "ts-node": "^10.3.0",
-        "typescript": "~4.4.4"
+        "typescript": "~4.5.4"
     }
 }


### PR DESCRIPTION
Also fixes a build break caused by a malicious transient dependency of @cucumber/cucumber.