### PR TITLE
Scan Go code with gosec

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,7 @@ unit-test-java: build-protos
 lint:
 	staticcheck -tags="pkcs11" $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 	go vet -tags pkcs11 $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
+	gosec -tags pkcs11 -exclude-generated $(base_dir)/pkg/... $(samples_dir)/go $(hsm_samples_dir)/go
 
 scan: scan-node scan-java
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ build these components, the following needs to be installed and available in the
 - Java 8
 - Docker
 - Make
-- Protobuf compiler (https://developers.google.com/protocol-buffers/docs/downloads)
-- Some Go tools:
-  - `go install github.com/cucumber/godog/cmd/godog@v0.12.2`
-  - `go get google.golang.org/grpc google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc`
-  - `go get honnef.co/go/tools/cmd/staticcheck`
-  - `go get github.com/golang/mock/mockgen`
+- Go tools:
+  - `go install github.com/cucumber/godog/cmd/godog@v0.12`
+  - `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27`
+  - `go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2`
+  - `go install honnef.co/go/tools/cmd/staticcheck@latest`
+  - `go install github.com/golang/mock/mockgen@v1.6`
+  - `go install github.com/securego/gosec/v2/cmd/gosec@latest`
 - pkcs11 enabled fabric-ca-client
   - `go get -tags 'pkcs11' github.com/hyperledger/fabric-ca/cmd/fabric-ca-client`
 - SoftHSM, which can either be:

--- a/ci/install_deps.yml
+++ b/ci/install_deps.yml
@@ -23,8 +23,10 @@ steps:
   - script: go get -tags 'pkcs11' github.com/hyperledger/fabric-ca/cmd/fabric-ca-client
     displayName: Install Fabric-ca-client with HSM Support
   - script: |
-      go install github.com/cucumber/godog/cmd/godog@v0.12.2
-      go get google.golang.org/grpc google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
-      go get honnef.co/go/tools/cmd/staticcheck
-      go get github.com/golang/mock/mockgen
+      go install github.com/cucumber/godog/cmd/godog@v0.12
+      go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27
+      go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@v1.2
+      go install honnef.co/go/tools/cmd/staticcheck@latest
+      go install github.com/golang/mock/mockgen@v1.6
+      go install github.com/securego/gosec/v2/cmd/gosec@latest
     displayName: Install Go tools

--- a/go.mod
+++ b/go.mod
@@ -4,18 +4,18 @@ go 1.16
 
 require (
 	github.com/Knetic/govaluate v3.0.0+incompatible // indirect
-	github.com/Shopify/sarama v1.30.0 // indirect
-	github.com/cucumber/godog v0.12.2
+	github.com/Shopify/sarama v1.30.1 // indirect
+	github.com/cucumber/godog v0.12.3
 	github.com/cucumber/messages-go/v16 v16.0.1
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
-	github.com/hashicorp/go-version v1.3.0 // indirect
+	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/hyperledger/fabric v2.1.1+incompatible
 	github.com/hyperledger/fabric-amcl v0.0.0-20210603140002-2670f91851c8 // indirect
 	github.com/hyperledger/fabric-protos-go v0.0.0-20211118165945-23d738fc3553
-	github.com/miekg/pkcs11 v1.0.3
+	github.com/miekg/pkcs11 v1.1.1
 	github.com/stretchr/testify v1.7.0
 	github.com/sykesm/zap-logfmt v0.0.4 // indirect
-	google.golang.org/grpc v1.42.0
-	google.golang.org/protobuf v1.26.0
+	google.golang.org/grpc v1.43.0
+	google.golang.org/protobuf v1.27.1
 )

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/Knetic/govaluate v3.0.0+incompatible h1:7o6+MAPhYTCF0+fdvoz1xDedhRb4f6s9Tn1Tt7/WTEg=
 github.com/Knetic/govaluate v3.0.0+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/Shopify/sarama v1.30.0 h1:TOZL6r37xJBDEMLx4yjB77jxbZYXPaDow08TSK6vIL0=
-github.com/Shopify/sarama v1.30.0/go.mod h1:zujlQQx1kzHsh4jfV1USnptCQrHAEZ2Hk8fTKCulPVs=
+github.com/Shopify/sarama v1.30.1 h1:z47lP/5PBw2UVKf1lvfS5uWXaJws6ggk9PLnKEHtZiQ=
+github.com/Shopify/sarama v1.30.1/go.mod h1:hGgx05L/DiW8XYBXeJdKIN6V2QUy2H6JqME5VT1NLRw=
 github.com/Shopify/toxiproxy/v2 v2.1.6-0.20210914104332-15ea381dcdae/go.mod h1:/cvHQkZ1fst0EmZnA5dFtiQdWCNCFYzb+uE2vqVgvx0=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -50,8 +50,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cucumber/gherkin-go/v19 v19.0.3 h1:mMSKu1077ffLbTJULUfM5HPokgeBcIGboyeNUof1MdE=
 github.com/cucumber/gherkin-go/v19 v19.0.3/go.mod h1:jY/NP6jUtRSArQQJ5h1FXOUgk5fZK24qtE7vKi776Vw=
-github.com/cucumber/godog v0.12.2 h1:7rxwPS907cCeJvgVCJGRjgz/zTyClBwwx5DJAa8zfeM=
-github.com/cucumber/godog v0.12.2/go.mod h1:u6SD7IXC49dLpPN35kal0oYEjsXZWee4pW6Tm9t5pIc=
+github.com/cucumber/godog v0.12.3 h1:nBshklqcWho/joTFtSBfyD4KYkvftwwf0r0XpX6ajNU=
+github.com/cucumber/godog v0.12.3/go.mod h1:u6SD7IXC49dLpPN35kal0oYEjsXZWee4pW6Tm9t5pIc=
 github.com/cucumber/messages-go/v16 v16.0.0/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
 github.com/cucumber/messages-go/v16 v16.0.1 h1:fvkpwsLgnIm0qugftrw2YwNlio+ABe2Iu94Ap8GMYIY=
 github.com/cucumber/messages-go/v16 v16.0.1/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
@@ -156,8 +156,8 @@ github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2IGE=
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
-github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
+github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go.net v0.0.1/go.mod h1:hjKkEWcCURg++eb33jQU7oqQcI9XDCnUzHA0oac0k90=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
@@ -212,8 +212,8 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
-github.com/miekg/pkcs11 v1.0.3 h1:iMwmD7I5225wv84WxIG/bmxz9AXjWvTWIbM/TYHvWtw=
-github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
+github.com/miekg/pkcs11 v1.1.1 h1:Ugu9pdy6vAYku5DEpVWVFPYnzV+bxB+iRdbuFSu7TvU=
+github.com/miekg/pkcs11 v1.1.1/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -462,8 +462,8 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
-google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
-google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -474,8 +474,9 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
+google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
+google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/hsm-samples/go/hsm-sample.go
+++ b/hsm-samples/go/hsm-sample.go
@@ -1,3 +1,6 @@
+//go:build pkcs11
+// +build pkcs11
+
 /*
 Copyright IBM Corp. All Rights Reserved.
 
@@ -143,7 +146,7 @@ func newHSMSign(h *identity.HSMSignerFactory, certPEM []byte) (identity.Sign, id
 }
 
 func loadCertificate(filename string) (*x509.Certificate, error) {
-	certificatePEM, err := ioutil.ReadFile(filename)
+	certificatePEM, err := ioutil.ReadFile(filename) //#nosec G304
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -60,9 +60,8 @@ func (client *gatewayClient) CommitStatus(in *gateway.SignedCommitStatusRequest,
 func (client *gatewayClient) CommitStatusWithContext(ctx context.Context, in *gateway.SignedCommitStatusRequest, opts ...grpc.CallOption) (*gateway.CommitStatusResponse, error) {
 	response, err := client.grpcClient.CommitStatus(ctx, in, opts...)
 	if err != nil {
-		request := &gateway.CommitStatusRequest{}
-		proto.Unmarshal(in.Request, request)
-		txErr := newTransactionError(err, request.GetTransactionId())
+		transactionId := getTransactionIdFromSignedCommitStatusRequest(in)
+		txErr := newTransactionError(err, transactionId)
 		return nil, &CommitStatusError{txErr}
 	}
 
@@ -81,4 +80,13 @@ func (client *gatewayClient) EvaluateWithContext(ctx context.Context, in *gatewa
 
 func (client *gatewayClient) ChaincodeEvents(ctx context.Context, in *gateway.SignedChaincodeEventsRequest, opts ...grpc.CallOption) (gateway.Gateway_ChaincodeEventsClient, error) {
 	return client.grpcClient.ChaincodeEvents(ctx, in, opts...)
+}
+
+func getTransactionIdFromSignedCommitStatusRequest(in *gateway.SignedCommitStatusRequest) string {
+	request := &gateway.CommitStatusRequest{}
+	err := proto.Unmarshal(in.GetRequest(), request)
+	if err != nil {
+		return "?"
+	}
+	return request.GetTransactionId()
 }

--- a/pkg/identity/hsmsign.go
+++ b/pkg/identity/hsmsign.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*
@@ -82,7 +83,7 @@ func (factory *HSMSignerFactory) NewHSMSigner(options HSMSignerOptions) (Sign, H
 
 	privateKeyHandle, err := factory.findObjectInHSM(session, pkcs11.CKO_PRIVATE_KEY, options.Identifier)
 	if err != nil {
-		factory.ctx.CloseSession(session)
+		factory.ctx.CloseSession(session) //#nosec G104 -- A close error doesn't matter as already failed
 		return nil, nil, err
 	}
 
@@ -96,7 +97,7 @@ func (factory *HSMSignerFactory) NewHSMSigner(options HSMSignerOptions) (Sign, H
 
 // Dispose of resources held by the factory when it is no longer needed.
 func (factory *HSMSignerFactory) Dispose() {
-	factory.ctx.Finalize()
+	factory.ctx.Finalize() //#nosec G104 -- Caller can't do anything useful with any error
 }
 
 func (factory *HSMSignerFactory) findSlotForLabel(label string) (uint, error) {
@@ -145,7 +146,7 @@ func (factory *HSMSignerFactory) createSession(slot uint, pin string) (pkcs11.Se
 	}
 
 	if err := factory.ctx.Login(session, pkcs11.CKU_USER, pin); err != nil && err != pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
-		factory.ctx.CloseSession(session)
+		factory.ctx.CloseSession(session) //#nosec G104 -- A close error doesn't matter as already failed
 		return 0, fmt.Errorf("login failed: %w", err)
 	}
 

--- a/samples/go/sample.go
+++ b/samples/go/sample.go
@@ -424,7 +424,7 @@ func newSign() identity.Sign {
 }
 
 func loadCertificate(filename string) (*x509.Certificate, error) {
-	certificatePEM, err := ioutil.ReadFile(filename)
+	certificatePEM, err := ioutil.ReadFile(filename) //#nosec G304
 	if err != nil {
 		return nil, fmt.Errorf("failed to read certificate file: %w", err)
 	}


### PR DESCRIPTION
Add gosec to the linters used for Go code to detect potential security vulnerabilities in the implementation code as early as possible.

Updated Go build tool versions and install process to make set up of a development environment easier.

Contributes to #267