### PR TITLE
Go security vulnerability scan in nightly build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,10 @@ lint:
 	go vet -tags pkcs11 $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 	gosec -tags pkcs11 -exclude-generated $(base_dir)/pkg/... $(samples_dir)/go $(hsm_samples_dir)/go
 
-scan: scan-node scan-java
+scan: scan-go scan-node scan-java
+
+scan-go:
+	go list -json -deps ./pkg/... | docker run --rm --interactive sonatypecommunity/nancy:latest sleuth
 
 scan-node:
 	cd $(node_dir); npm install --package-lock-only; npm audit --production

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ build these components, the following needs to be installed and available in the
 - Java 8
 - Docker
 - Make
+- Protobuf compiler (https://grpc.io/docs/protoc-installation/)
 - Go tools:
   - `go install github.com/cucumber/godog/cmd/godog@v0.12`
   - `go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27`

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -128,7 +128,7 @@ stages:
     dependsOn: []
     timeoutInMinutes: 60
     steps:
-    - template: install_deps.yml
+    - template: install_deps_hsm.yml
     - checkout: self
     - script: make generate unit-test-go-pkcs11
       displayName: Run Go unit tests with pkcs11
@@ -173,7 +173,7 @@ stages:
     dependsOn: []
     timeoutInMinutes: 60
     steps:
-    - template: install_deps.yml
+    - template: install_deps_hsm_ca.yml
     - checkout: self
     - script: make pull-latest-peer scenario-test-go
       displayName: Run Go SDK scenario tests
@@ -187,11 +187,13 @@ stages:
     dependsOn: []
     timeoutInMinutes: 60
     steps:
-    - template: install_deps.yml
+    - template: install_deps_hsm_ca.yml
     - checkout: self
     - task: NodeTool@0
       inputs:
         versionSpec: $(NODEVER)
+    - script: go install -tags pkcs11 github.com/hyperledger/fabric-ca/cmd/fabric-ca-client@latest
+      displayName: Install Fabric-ca-client with HSM Support
     - script: make pull-latest-peer scenario-test-node
       displayName: Run Node SDK scenario tests
       env:
@@ -223,7 +225,7 @@ stages:
     dependsOn: []
     timeoutInMinutes: 60
     steps:
-      - template: install_deps.yml
+      - template: install_deps_hsm_ca.yml
       - checkout: self
       - script: |
           make sample-network
@@ -237,7 +239,7 @@ stages:
     dependsOn: []
     timeoutInMinutes: 60
     steps:
-      - template: install_deps.yml
+      - template: install_deps_hsm_ca.yml
       - checkout: self
       - task: NodeTool@0
         inputs:
@@ -266,6 +268,32 @@ stages:
   dependsOn: VerifyVersions
   condition: eq(variables['Build.Reason'], 'Schedule')
   jobs:
+  - job: ScanGo
+    pool:
+      vmImage: ubuntu-20.04
+    dependsOn: []
+    timeoutInMinutes: 60
+    steps:
+    - task: GoTool@0
+      inputs:
+        version: $(GOVER)
+        goPath:  $(GOPATH)
+      displayName: Install Go $(GOVER)
+    - checkout: self
+    - script: make scan-go
+      displayName: 'Run Go security vulnerability scan'
+  - job: ScanNode
+    pool:
+      vmImage: ubuntu-20.04
+    dependsOn: []
+    timeoutInMinutes: 60
+    steps:
+    - checkout: self
+    - task: NodeTool@0
+      inputs:
+        versionSpec: $(NODEVER)
+    - script: make scan-node
+      displayName: 'Run Node security vulnerability scan'
   - job: ScanJava
     pool:
       vmImage: ubuntu-20.04
@@ -281,19 +309,6 @@ stages:
         jdkSourceOption: 'PreInstalled'
     - script: make scan-java
       displayName: 'Run Java security vulnerability scan'
-  - job: ScanNode
-    pool:
-      vmImage: ubuntu-20.04
-    dependsOn: []
-    timeoutInMinutes: 60
-    steps:
-    - template: install_deps.yml
-    - checkout: self
-    - task: NodeTool@0
-      inputs:
-        versionSpec: $(NODEVER)
-    - script: make scan-node
-      displayName: 'Run Node security vulnerability scan'
       
 # Only publish on scheduled builds and tagged releases
 - stage: Publish

--- a/ci/install_deps.yml
+++ b/ci/install_deps.yml
@@ -6,7 +6,7 @@ steps:
   - script: |
       sudo apt-get clean
       sudo apt-get update
-      sudo apt-get install -y autoconf automake libtool curl g++ unzip gcc make protobuf-compiler libprotobuf-dev softhsm2
+      sudo apt-get install -y autoconf automake libtool curl g++ unzip gcc make protobuf-compiler libprotobuf-dev
       echo "vsts  hard  nofile  65535" | sudo tee -a /etc/security/limits.conf
       echo "vsts  soft  nofile  65535" | sudo tee -a /etc/security/limits.conf
     displayName: Install Dependencies
@@ -15,13 +15,6 @@ steps:
       version: $(GOVER)
       goPath:  $(GOPATH)
     displayName: Install Go $(GOVER)
-  - script: |
-      echo directories.tokendir = /tmp > $HOME/softhsm2.conf
-      export SOFTHSM2_CONF=$HOME/softhsm2.conf
-      softhsm2-util --init-token --slot 0 --label "ForFabric" --pin 98765432 --so-pin 1234
-    displayName: Set up SoftHSM
-  - script: go get -tags 'pkcs11' github.com/hyperledger/fabric-ca/cmd/fabric-ca-client
-    displayName: Install Fabric-ca-client with HSM Support
   - script: |
       go install github.com/cucumber/godog/cmd/godog@v0.12
       go install google.golang.org/protobuf/cmd/protoc-gen-go@v1.27

--- a/ci/install_deps_hsm.yml
+++ b/ci/install_deps_hsm.yml
@@ -1,0 +1,14 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+steps:
+  - template: install_deps.yml
+  - script: |
+      sudo apt-get install -y softhsm2
+    displayName: Install SoftHSM
+  - script: |
+      echo directories.tokendir = /tmp > $HOME/softhsm2.conf
+      export SOFTHSM2_CONF=$HOME/softhsm2.conf
+      softhsm2-util --init-token --slot 0 --label "ForFabric" --pin 98765432 --so-pin 1234
+    displayName: Set up SoftHSM

--- a/ci/install_deps_hsm_ca.yml
+++ b/ci/install_deps_hsm_ca.yml
@@ -1,0 +1,8 @@
+# Copyright the Hyperledger Fabric contributors. All rights reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+steps:
+  - template: install_deps_hsm.yml
+  - script: go install -tags pkcs11 github.com/hyperledger/fabric-ca/cmd/fabric-ca-client@latest
+    displayName: Install Fabric-ca-client with HSM Support


### PR DESCRIPTION
Install HSM dependencies only when required to improve execution time of the majority of build jobs.

Resolves #267