### PR TITLE
Minimise dependencies on Go protobuf versions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hyperledger/fabric-gateway
 go 1.16
 
 require (
-	github.com/cucumber/godog v0.12.3
+	github.com/cucumber/godog v0.12.4
 	github.com/cucumber/messages-go/v16 v16.0.1
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -42,8 +42,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cucumber/gherkin-go/v19 v19.0.3 h1:mMSKu1077ffLbTJULUfM5HPokgeBcIGboyeNUof1MdE=
 github.com/cucumber/gherkin-go/v19 v19.0.3/go.mod h1:jY/NP6jUtRSArQQJ5h1FXOUgk5fZK24qtE7vKi776Vw=
-github.com/cucumber/godog v0.12.3 h1:nBshklqcWho/joTFtSBfyD4KYkvftwwf0r0XpX6ajNU=
-github.com/cucumber/godog v0.12.3/go.mod h1:u6SD7IXC49dLpPN35kal0oYEjsXZWee4pW6Tm9t5pIc=
+github.com/cucumber/godog v0.12.4 h1:m+vQaDztkpwpmkBIX6jlwNFJiuCMkPjz5jkrUq4SIlM=
+github.com/cucumber/godog v0.12.4/go.mod h1:u6SD7IXC49dLpPN35kal0oYEjsXZWee4pW6Tm9t5pIc=
 github.com/cucumber/messages-go/v16 v16.0.0/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=
 github.com/cucumber/messages-go/v16 v16.0.1 h1:fvkpwsLgnIm0qugftrw2YwNlio+ABe2Iu94Ap8GMYIY=
 github.com/cucumber/messages-go/v16 v16.0.1/go.mod h1:EJcyR5Mm5ZuDsKJnT2N9KRnBK30BGjtYotDKpwQ0v6g=

--- a/pkg/client/chaincodeevents.go
+++ b/pkg/client/chaincodeevents.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 )
 
@@ -23,7 +23,7 @@ type ChaincodeEventsRequest struct {
 
 // Bytes of the serialized chaincode events request.
 func (events *ChaincodeEventsRequest) Bytes() ([]byte, error) {
-	requestBytes, err := proto.Marshal(events.signedRequest)
+	requestBytes, err := util.Marshal(events.signedRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshall SignedChaincodeEventsRequest protobuf: %w", err)
 	}

--- a/pkg/client/chaincodeevents_test.go
+++ b/pkg/client/chaincodeevents_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -70,7 +70,7 @@ func TestChaincodeEvents(t *testing.T) {
 		mockClient.EXPECT().ChaincodeEvents(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.SignedChaincodeEventsRequest, _ ...grpc.CallOption) {
 				request := &gateway.ChaincodeEventsRequest{}
-				err := proto.Unmarshal(in.GetRequest(), request)
+				err := util.Unmarshal(in.GetRequest(), request)
 				require.NoError(t, err)
 				actual = request
 			}).
@@ -101,7 +101,7 @@ func TestChaincodeEvents(t *testing.T) {
 				},
 			},
 		}
-		require.True(t, proto.Equal(expected, actual), "Expected %v, got %v", expected, actual)
+		require.True(t, util.ProtoEqual(expected, actual), "Expected %v, got %v", expected, actual)
 	})
 
 	t.Run("Sends valid request with specified start block number", func(t *testing.T) {
@@ -113,7 +113,7 @@ func TestChaincodeEvents(t *testing.T) {
 		mockClient.EXPECT().ChaincodeEvents(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.SignedChaincodeEventsRequest, _ ...grpc.CallOption) {
 				request := &gateway.ChaincodeEventsRequest{}
-				err := proto.Unmarshal(in.GetRequest(), request)
+				err := util.Unmarshal(in.GetRequest(), request)
 				require.NoError(t, err)
 				actual = request
 			}).
@@ -146,7 +146,7 @@ func TestChaincodeEvents(t *testing.T) {
 				},
 			},
 		}
-		require.True(t, proto.Equal(expected, actual), "Expected %v, got %v", expected, actual)
+		require.True(t, util.ProtoEqual(expected, actual), "Expected %v, got %v", expected, actual)
 	})
 
 	t.Run("Defaults to next commit as start position", func(t *testing.T) {
@@ -158,7 +158,7 @@ func TestChaincodeEvents(t *testing.T) {
 		mockClient.EXPECT().ChaincodeEvents(gomock.Any(), gomock.Any()).
 			Do(func(_ context.Context, in *gateway.SignedChaincodeEventsRequest, _ ...grpc.CallOption) {
 				request := &gateway.ChaincodeEventsRequest{}
-				err := proto.Unmarshal(in.GetRequest(), request)
+				err := util.Unmarshal(in.GetRequest(), request)
 				require.NoError(t, err)
 
 				actual = &gateway.ChaincodeEventsRequest{
@@ -184,7 +184,7 @@ func TestChaincodeEvents(t *testing.T) {
 			ChannelId:   "NETWORK",
 			ChaincodeId: "CHAINCODE",
 		}
-		require.True(t, proto.Equal(expected, actual), "Expected %v, got %v", expected, actual)
+		require.True(t, util.ProtoEqual(expected, actual), "Expected %v, got %v", expected, actual)
 	})
 
 	t.Run("Closes event channel on receive error", func(t *testing.T) {

--- a/pkg/client/chaincodeeventsbuilder.go
+++ b/pkg/client/chaincodeeventsbuilder.go
@@ -9,7 +9,7 @@ package client
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/orderer"
 )
@@ -42,7 +42,7 @@ func (builder *chaincodeEventsBuilder) newSignedChaincodeEventsRequestProto() (*
 		return nil, err
 	}
 
-	requestBytes, err := proto.Marshal(request)
+	requestBytes, err := util.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("failed to serialize chaincode events request: %w", err)
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -9,7 +9,7 @@ package client
 import (
 	"context"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"google.golang.org/grpc"
 )
@@ -84,7 +84,7 @@ func (client *gatewayClient) ChaincodeEvents(ctx context.Context, in *gateway.Si
 
 func getTransactionIdFromSignedCommitStatusRequest(in *gateway.SignedCommitStatusRequest) string {
 	request := &gateway.CommitStatusRequest{}
-	err := proto.Unmarshal(in.GetRequest(), request)
+	err := util.Unmarshal(in.GetRequest(), request)
 	if err != nil {
 		return "?"
 	}

--- a/pkg/client/commit.go
+++ b/pkg/client/commit.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"google.golang.org/grpc"
@@ -40,7 +40,7 @@ func newCommit(
 
 // Bytes of the serialized commit.
 func (commit *Commit) Bytes() ([]byte, error) {
-	requestBytes, err := proto.Marshal(commit.signedRequest)
+	requestBytes, err := util.Marshal(commit.signedRequest)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshall SignedCommitStatusRequest protobuf: %w", err)
 	}

--- a/pkg/client/evaluate_test.go
+++ b/pkg/client/evaluate_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -20,9 +19,10 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/runtime/protoiface"
 )
 
-func NewStatusError(t *testing.T, code codes.Code, message string, details ...proto.Message) error {
+func NewStatusError(t *testing.T, code codes.Code, message string, details ...protoiface.MessageV1) error {
 	s, err := status.New(code, message).WithDetails(details...)
 	require.NoError(t, err)
 

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func Example() {
 	// Create gRPC client connection, which should be shared by all gateway connections to this endpoint.
-	clientConnection, err := grpc.Dial("gateway.example.org:1337", grpc.WithInsecure())
+	clientConnection, err := grpc.Dial("gateway.example.org:1337", grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/client/gateway.go
+++ b/pkg/client/gateway.go
@@ -21,9 +21,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-gateway/pkg/hash"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -166,22 +166,22 @@ func (gw *Gateway) GetNetwork(name string) *Network {
 // NewSignedProposal creates a transaction proposal with signature, which can be sent to peers for endorsement.
 func (gw *Gateway) NewSignedProposal(bytes []byte, signature []byte) (*Proposal, error) {
 	proposedTransaction := &gateway.ProposedTransaction{}
-	if err := proto.Unmarshal(bytes, proposedTransaction); err != nil {
+	if err := util.Unmarshal(bytes, proposedTransaction); err != nil {
 		return nil, fmt.Errorf("failed to deserialize proposed transaction: %w", err)
 	}
 
 	proposal := &peer.Proposal{}
-	if err := proto.Unmarshal(proposedTransaction.GetProposal().GetProposalBytes(), proposal); err != nil {
+	if err := util.Unmarshal(proposedTransaction.GetProposal().GetProposalBytes(), proposal); err != nil {
 		return nil, fmt.Errorf("failed to deserialize proposal: %w", err)
 	}
 
 	header := &common.Header{}
-	if err := proto.Unmarshal(proposal.GetHeader(), header); err != nil {
+	if err := util.Unmarshal(proposal.GetHeader(), header); err != nil {
 		return nil, fmt.Errorf("failed to deserialize header: %w", err)
 	}
 
 	channelHeader := &common.ChannelHeader{}
-	if err := proto.Unmarshal(header.GetChannelHeader(), channelHeader); err != nil {
+	if err := util.Unmarshal(header.GetChannelHeader(), channelHeader); err != nil {
 		return nil, fmt.Errorf("failed to deserialize channel header: %w", err)
 	}
 
@@ -200,7 +200,7 @@ func (gw *Gateway) NewSignedProposal(bytes []byte, signature []byte) (*Proposal,
 // to the ledger.
 func (gw *Gateway) NewSignedTransaction(bytes []byte, signature []byte) (*Transaction, error) {
 	preparedTransaction := &gateway.PreparedTransaction{}
-	if err := proto.Unmarshal(bytes, preparedTransaction); err != nil {
+	if err := util.Unmarshal(bytes, preparedTransaction); err != nil {
 		return nil, fmt.Errorf("failed to deserialize prepared transaction: %w", err)
 	}
 
@@ -217,12 +217,12 @@ func (gw *Gateway) NewSignedTransaction(bytes []byte, signature []byte) (*Transa
 // NewSignedCommit creates an commit with signature, which can be used to access a committed transaction.
 func (gw *Gateway) NewSignedCommit(bytes []byte, signature []byte) (*Commit, error) {
 	signedRequest := &gateway.SignedCommitStatusRequest{}
-	if err := proto.Unmarshal(bytes, signedRequest); err != nil {
+	if err := util.Unmarshal(bytes, signedRequest); err != nil {
 		return nil, fmt.Errorf("failed to deserialize signed commit status request: %w", err)
 	}
 
 	request := &gateway.CommitStatusRequest{}
-	if err := proto.Unmarshal(signedRequest.Request, request); err != nil {
+	if err := util.Unmarshal(signedRequest.Request, request); err != nil {
 		return nil, fmt.Errorf("failed to deserialize commit status request: %w", err)
 	}
 
@@ -235,7 +235,7 @@ func (gw *Gateway) NewSignedCommit(bytes []byte, signature []byte) (*Commit, err
 // NewSignedChaincodeEventsRequest creates a signed request to read events emitted by a specific chaincode.
 func (gw *Gateway) NewSignedChaincodeEventsRequest(bytes []byte, signature []byte) (*ChaincodeEventsRequest, error) {
 	request := &gateway.SignedChaincodeEventsRequest{}
-	if err := proto.Unmarshal(bytes, request); err != nil {
+	if err := util.Unmarshal(bytes, request); err != nil {
 		return nil, fmt.Errorf("failed to deserialize signed chaincode events request: %w", err)
 	}
 

--- a/pkg/client/gateway_test.go
+++ b/pkg/client/gateway_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
-	proto "github.com/hyperledger/fabric-protos-go/gateway"
+	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
@@ -20,7 +20,7 @@ import (
 //go:generate mockgen -destination ./gateway_mock_test.go -package ${GOPACKAGE} github.com/hyperledger/fabric-protos-go/gateway GatewayClient
 
 // WithClient uses the supplied client for the Gateway. Allows a stub implementation to be used for testing.
-func WithClient(client proto.GatewayClient) ConnectOption {
+func WithClient(client gateway.GatewayClient) ConnectOption {
 	return func(gateway *Gateway) error {
 		gateway.client.grpcClient = client
 		return nil

--- a/pkg/client/identity_test.go
+++ b/pkg/client/identity_test.go
@@ -11,9 +11,9 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/msp"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -35,7 +35,7 @@ func TestIdentity(t *testing.T) {
 		Mspid:   id.MspID(),
 		IdBytes: id.Credentials(),
 	}
-	creator, err := proto.Marshal(serializedIdentity)
+	creator, err := util.Marshal(serializedIdentity)
 	require.NoError(t, err)
 
 	t.Run("Evaluate uses client identity for proposals", func(t *testing.T) {

--- a/pkg/client/proposal.go
+++ b/pkg/client/proposal.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"google.golang.org/grpc"
 )
@@ -25,7 +25,7 @@ type Proposal struct {
 
 // Bytes of the serialized proposal message.
 func (proposal *Proposal) Bytes() ([]byte, error) {
-	transactionBytes, err := proto.Marshal(proposal.proposedTransaction)
+	transactionBytes, err := util.Marshal(proposal.proposedTransaction)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshall Proposal protobuf: %w", err)
 	}

--- a/pkg/client/proposalbuilder.go
+++ b/pkg/client/proposalbuilder.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -85,7 +85,7 @@ func (builder *proposalBuilder) proposalBytes() ([]byte, error) {
 		Header:  headerBytes,
 		Payload: chaincodeProposalBytes,
 	}
-	return proto.Marshal(proposal)
+	return util.Marshal(proposal)
 }
 
 func (builder *proposalBuilder) headerBytes() ([]byte, error) {
@@ -94,7 +94,7 @@ func (builder *proposalBuilder) headerBytes() ([]byte, error) {
 		return nil, err
 	}
 
-	signatureHeaderBytes, err := proto.Marshal(builder.transactionCtx.SignatureHeader)
+	signatureHeaderBytes, err := util.Marshal(builder.transactionCtx.SignatureHeader)
 	if err != nil {
 		return nil, err
 	}
@@ -103,11 +103,11 @@ func (builder *proposalBuilder) headerBytes() ([]byte, error) {
 		ChannelHeader:   channelHeaderBytes,
 		SignatureHeader: signatureHeaderBytes,
 	}
-	return proto.Marshal(header)
+	return util.Marshal(header)
 }
 
 func (builder *proposalBuilder) channelHeaderBytes() ([]byte, error) {
-	extensionBytes, err := proto.Marshal(&peer.ChaincodeHeaderExtension{
+	extensionBytes, err := util.Marshal(&peer.ChaincodeHeaderExtension{
 		ChaincodeId: &peer.ChaincodeID{
 			Name: builder.chaincodeName,
 		},
@@ -124,11 +124,11 @@ func (builder *proposalBuilder) channelHeaderBytes() ([]byte, error) {
 		Epoch:     0,
 		Extension: extensionBytes,
 	}
-	return proto.Marshal(channelHeader)
+	return util.Marshal(channelHeader)
 }
 
 func (builder *proposalBuilder) chaincodeProposalPayloadBytes() ([]byte, error) {
-	invocationSpecBytes, err := proto.Marshal(&peer.ChaincodeInvocationSpec{
+	invocationSpecBytes, err := util.Marshal(&peer.ChaincodeInvocationSpec{
 		ChaincodeSpec: &peer.ChaincodeSpec{
 			ChaincodeId: &peer.ChaincodeID{
 				Name: builder.chaincodeName,
@@ -146,7 +146,7 @@ func (builder *proposalBuilder) chaincodeProposalPayloadBytes() ([]byte, error) 
 		Input:        invocationSpecBytes,
 		TransientMap: builder.transient,
 	}
-	return proto.Marshal(chaincodeProposalPayload)
+	return util.Marshal(chaincodeProposalPayload)
 }
 
 func (builder *proposalBuilder) chaincodeArgs() [][]byte {

--- a/pkg/client/signingidentity.go
+++ b/pkg/client/signingidentity.go
@@ -9,9 +9,9 @@ package client
 import (
 	"errors"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-gateway/pkg/hash"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/msp"
 )
 
@@ -48,5 +48,5 @@ func (signingID *signingIdentity) Creator() ([]byte, error) {
 		Mspid:   signingID.id.MspID(),
 		IdBytes: signingID.id.Credentials(),
 	}
-	return proto.Marshal(serializedIdentity)
+	return util.Marshal(serializedIdentity)
 }

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -12,8 +12,8 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/golang/protobuf/proto"
 	"github.com/hyperledger/fabric-gateway/pkg/internal/test"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"github.com/hyperledger/fabric-protos-go/peer"
@@ -21,10 +21,11 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/runtime/protoiface"
 )
 
-func AssertMarshal(t *testing.T, message proto.Message, msgAndArgs ...interface{}) []byte {
-	bytes, err := proto.Marshal(message)
+func AssertMarshal(t *testing.T, message protoiface.MessageV1, msgAndArgs ...interface{}) []byte {
+	bytes, err := util.Marshal(message)
 	require.NoError(t, err, msgAndArgs...)
 	return bytes
 }

--- a/pkg/client/transaction.go
+++ b/pkg/client/transaction.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
 	"google.golang.org/grpc"
 )
@@ -47,7 +47,7 @@ func (transaction *Transaction) Result() []byte {
 
 // Bytes of the serialized transaction.
 func (transaction *Transaction) Bytes() ([]byte, error) {
-	transactionBytes, err := proto.Marshal(transaction.preparedTransaction)
+	transactionBytes, err := util.Marshal(transaction.preparedTransaction)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshall PreparedTransaction protobuf: %w", err)
 	}
@@ -141,7 +141,7 @@ func (transaction *Transaction) newSignedCommitStatusRequest() (*gateway.SignedC
 		Identity:      creator,
 	}
 
-	requestBytes, err := proto.Marshal(request)
+	requestBytes, err := util.Marshal(request)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/transactionparser.go
+++ b/pkg/client/transactionparser.go
@@ -9,7 +9,7 @@ package client
 import (
 	"fmt"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 )
@@ -21,7 +21,7 @@ type transactionInfo struct {
 
 func parseTransactionEnvelope(envelope *common.Envelope) (*transactionInfo, error) {
 	payload := &common.Payload{}
-	if err := proto.Unmarshal(envelope.GetPayload(), payload); err != nil {
+	if err := util.Unmarshal(envelope.GetPayload(), payload); err != nil {
 		return nil, fmt.Errorf("failed to deserialize payload: %w", err)
 	}
 
@@ -44,7 +44,7 @@ func parseTransactionEnvelope(envelope *common.Envelope) (*transactionInfo, erro
 
 func parseChannelNameFromHeader(header *common.Header) (string, error) {
 	channelHeader := &common.ChannelHeader{}
-	if err := proto.Unmarshal(header.GetChannelHeader(), channelHeader); err != nil {
+	if err := util.Unmarshal(header.GetChannelHeader(), channelHeader); err != nil {
 		return "", fmt.Errorf("failed to deserialize channel header: %w", err)
 	}
 
@@ -53,7 +53,7 @@ func parseChannelNameFromHeader(header *common.Header) (string, error) {
 
 func parseResultFromPayload(payload *common.Payload) ([]byte, error) {
 	transaction := &peer.Transaction{}
-	if err := proto.Unmarshal(payload.GetData(), transaction); err != nil {
+	if err := util.Unmarshal(payload.GetData(), transaction); err != nil {
 		return nil, fmt.Errorf("failed to deserialize transaction: %w", err)
 	}
 
@@ -73,17 +73,17 @@ func parseResultFromPayload(payload *common.Payload) ([]byte, error) {
 
 func parseResultFromTransactionAction(transactionAction *peer.TransactionAction) ([]byte, error) {
 	actionPayload := &peer.ChaincodeActionPayload{}
-	if err := proto.Unmarshal(transactionAction.GetPayload(), actionPayload); err != nil {
+	if err := util.Unmarshal(transactionAction.GetPayload(), actionPayload); err != nil {
 		return nil, fmt.Errorf("failed to deserialize chaincode action payload: %w", err)
 	}
 
 	responsePayload := &peer.ProposalResponsePayload{}
-	if err := proto.Unmarshal(actionPayload.GetAction().GetProposalResponsePayload(), responsePayload); err != nil {
+	if err := util.Unmarshal(actionPayload.GetAction().GetProposalResponsePayload(), responsePayload); err != nil {
 		return nil, fmt.Errorf("failed to deserialize proposal response payload: %w", err)
 	}
 
 	chaincodeAction := &peer.ChaincodeAction{}
-	if err := proto.Unmarshal(responsePayload.GetExtension(), chaincodeAction); err != nil {
+	if err := util.Unmarshal(responsePayload.GetExtension(), chaincodeAction); err != nil {
 		return nil, fmt.Errorf("failed to deserialize chaincode action: %w", err)
 	}
 

--- a/pkg/internal/test/transaction.go
+++ b/pkg/internal/test/transaction.go
@@ -9,15 +9,16 @@ package test
 import (
 	"testing"
 
-	"github.com/golang/protobuf/proto"
+	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/runtime/protoiface"
 )
 
 // AssertUnmarshall ensures that a protobuf is umarshalled without error
-func AssertUnmarshall(t *testing.T, b []byte, m proto.Message) {
-	err := proto.Unmarshal(b, m)
+func AssertUnmarshall(t *testing.T, b []byte, m protoiface.MessageV1) {
+	err := util.Unmarshal(b, m)
 	require.NoError(t, err)
 }
 

--- a/pkg/internal/util/protobuf.go
+++ b/pkg/internal/util/protobuf.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2022 IBM All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package util
+
+import (
+	proto1 "github.com/golang/protobuf/proto"
+	proto2 "google.golang.org/protobuf/proto"
+)
+
+// Marshal returns the wire-format encoding of a message. The message can be either a protobuf v1 or v2 message.
+func Marshal(message proto1.GeneratedMessage) ([]byte, error) {
+	messageV2 := proto1.MessageV2(message)
+	return proto2.Marshal(messageV2)
+}
+
+// Unmarshal parses the wire-format message bytes and places the result in the provided message. The provided message
+// must be mutable (e.g., a non-nil pointer to a message). The message can be either a protobuf v1 or v2 message.
+func Unmarshal(bytes []byte, message proto1.GeneratedMessage) error {
+	messageV2 := proto1.MessageV2(message)
+	return proto2.Unmarshal(bytes, messageV2)
+}
+
+// ProtoEqual reports whether two messages are equal, as with the standard proto.Equal function. The messages can be
+// either protobuf v1 or v2 message.
+func ProtoEqual(x proto1.GeneratedMessage, y proto1.GeneratedMessage) bool {
+	return proto2.Equal(proto1.MessageV2(x), proto1.MessageV2(y))
+}

--- a/pkg/internal/util/staticcheck.conf
+++ b/pkg/internal/util/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["inherit", "-SA1019"]

--- a/scenario/go/godogs_test.go
+++ b/scenario/go/godogs_test.go
@@ -14,7 +14,7 @@ var opts = godog.Options{
 }
 
 func init() {
-	godog.BindFlags("godog.", flag.CommandLine, &opts) // godog v0.10.0 and earlier
+	godog.BindCommandLineFlags("godog.", &opts)
 }
 
 func TestMain(m *testing.M) {

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,1 +1,1 @@
-checks = ["inherit", "-SA1019"]
+checks = ["inherit"]


### PR DESCRIPTION
Extract code that depends on a specific protobuf version into a utility package so the main code is agnostic to the protobuf version. This allows the staticcheck rule for deprecated API usage to be enabled for all but that one utility package.