### PR TITLE
Migration guide

### DIFF
--- a/index.md
+++ b/index.md
@@ -10,6 +10,8 @@ The Fabric Gateway client API implements the Fabric programming model as describ
 
 There are [samples for Go, Node, and Java](https://github.com/hyperledger/fabric-gateway/blob/main/samples/README.md) which are a great place to start if you want to try out the new Fabric Gateway!
 
+If migrating an existing application from one of the legacy Fabric client SDKs, consult the [migration guide](migration).
+
 ## Client API
 
 The Fabric Gateway client API is available for several programming languages to support the development of client applications that interact with a Fabric network using the Gateway.  

--- a/migration.md
+++ b/migration.md
@@ -1,0 +1,97 @@
+# Migration guide
+
+This page documents key considerations when rewriting an existing application, written using legacy Hyperledger Fabric client SDKs, to the Fabric Gateway client API.
+
+## Fabric programming model
+
+The Fabric Gateway client API is an evolution of the legacy SDKs and the Fabric programming model. The API structure and capability remain broadly the same as the legacy SDKs. Similarities include:
+
+- **Gateway**: connection to Fabric peer(s) providing access to blockchain networks.
+- **Network**: blockchain network of nodes hosting a shared ledger (analogous to a channel).
+- **Contract**: smart contract deployed to a blockchain network.
+- **Submit transaction**: invoke a smart contract transaction function to update ledger state.
+- **Evaluate transaction**: invoke a smart contract transaction function to query ledger state.
+- **Chaincode events**: receive events emitted by committed transactions to trigger business processes.
+
+The high level API to connect a Gateway instance, and submit or evaluate a transaction remains almost identical.
+
+For more advanced transaction invocations, such as those involving transient data, the legacy SDKs provide a `createTransaction()` method on the Contract object, which allows the client application to specify additional invocation parameters (see [Go](https://pkg.go.dev/github.com/hyperledger/fabric-sdk-go/pkg/gateway?utm_source=godoc#Contract.CreateTransaction), [Node](https://hyperledger.github.io/fabric-sdk-node/release-2.2/module-fabric-network.Contract.html#createTransaction), and [Java](https://hyperledger.github.io/fabric-gateway-java/release-2.2/org/hyperledger/fabric/gateway/Contract.html#createTransaction(java.lang.String)) documentation). The Fabric Gateway client API provides a `newProposal()` method on the Contract object to perform the same function (see [Go](https://pkg.go.dev/github.com/hyperledger/fabric-gateway/pkg/client#Contract.NewProposal), [Node](https://hyperledger.github.io/fabric-gateway/main/api/node/interfaces/Contract.html#newProposal), and [Java](https://hyperledger.github.io/fabric-gateway/main/api/java/org/hyperledger/fabric/client/Contract.html#newProposal(java.lang.String)) documentation).
+
+## Key differences
+
+The key API and behavioral differences that need to be considered when switching from legacy SDKs to the Fabric Gateway client API are:
+
+- **[gRPC connections](#grpc-connections)** are managed by the application, and can be shared by Gateway instances.
+- **[Connection profiles](#connection-profiles)** are not needed.
+- **[Wallets](#wallets)** are not needed, with the application choosing how to manage credential storage.
+- **[Endorsement requirements](#endorsement-requirements)** generally no longer need to be specified.
+- **[Block event listening](#block-event-listening)** is not available (yet).
+- **[Event reconnect](#event-reconnect)** is controlled by the client application.
+- **[Event checkpointing](#event-checkpointing)** is not available (yet).
+
+More detail and recommendations for each of these items is provided below.
+
+### gRPC connections
+
+In the legacy SDKs, each Gateway instance maintains internal gRPC connections to network nodes used to evaluate and submit transactions, and to obtain events. Many gRPC connections may be created for each Gateway instance, and these connections are not shared with other Gateway instances. Since there is significant overhead associated with creating gRPC connections, this can cause resource issues.
+
+In the Fabric Gateway client API, each Gateway instance uses a single gRPC connection to the Fabric Gateway service for all operations. The Gateway instance's gRPC connection is provided by the client application, and it can be shared by multiple Gateway instances. This allows the client application complete control of gRPC connection configuration and resource allocation.
+
+The API documentation contains examples of creating a gRPC connection and using this to connect a Gateway instance for [Go](https://pkg.go.dev/github.com/hyperledger/fabric-gateway/pkg/client#example-package), [Node](https://hyperledger.github.io/fabric-gateway/main/api/node/#example) and [Java](https://hyperledger.github.io/fabric-gateway/main/api/java/).
+
+### Connection profiles
+
+The Fabric Gateway client API does not use common connection profiles. Instead, only the endpoint address of the Fabric Gateway service is required to establish a gRPC connection that will be used when connecting a Gateway instance. Since the Fabric Gateway service is provided by Fabric peers, the endpoint address may be one of the peer addresses that would be defined in a connection profile. It could also be the address of a load balancer or ingress controller that forwards connections to network peers, providing high availability.
+
+### Wallets
+
+The legacy SDKs provide wallets for credential management. Wallets perform two functions:
+
+1. Persistent credential storage.
+1. Configuration of the Gateway client based on the type of credentials (for example, identities managed by a Hardware Security Module).
+
+Using the Fabric Gateway client API, the mechanism for storing credentials is a choice for the client application. The application may continue using the legacy SDKs to access credentials stored in a wallet, or may use a different mechanism for storing and accessing credentials.
+
+To connect a Gateway instance, the application simply provides an Identity object and a signing implementation. Helper functions are provided to create an Identity object from an X.509 certificate, and also to create a signing implementation from either a private key or an HSM-managed identity. To make use of alternative signing mechanisms, the application may provide its own signing implementation.
+
+### Endorsement requirements
+
+When using the legacy SDKs in more complex scenarios, such as those involving private data collections, chaincode-to-chaincode calls, or key-based endorsement policies, it is often necessary for the client application to explicitly specify endorsement requirements for a transaction invocation. This may be in the form of specifying chaincode interests, endorsing organizations, or endorsing peers.
+
+Using the Fabric Gateway client API, it is generally not necessary for the client application to specify endorsement requirements. The Fabric Gateway service dynamically determines the endorsement requirements for a given transaction invocation and uses the most appropriate peers to obtain endorsement.
+
+For transaction proposals that contain transient data, there are two notable scenarios that do require the application to explicitly specify the organizations that may be used for endorsement:
+
+1. The Fabric Gateway service's organization is unable to endorse the transaction proposal.
+1. Transactions that perform blind writes to private data collections from which they do not have read permission.
+
+These restrictions are in place to ensure that private data is not distributed to organizations that should not have access to it.
+
+It is recommended to only specify endorsing organizations in cases where it is specifically required.
+
+### Block event listening
+
+The Fabric Gateway client API does not currently provide block event listening.
+
+A use case where block event listening is used with the legacy SDKs is to perform asynchronous submit of transactions, where the transaction submit returns immediately after successfully submitting to the orderer, allowing the client application to perform operations using the transaction result (such as updating a UI or returning a REST response) before later listening for events to confirm the transaction commit status. The Fabric Gateway client API provides a direct mechanism for asynchronous submit of transactions, making event listening unnecessary. See the API documentation for examples in [Go](https://pkg.go.dev/github.com/hyperledger/fabric-gateway/pkg/client#Contract.SubmitAsync), [Node](https://hyperledger.github.io/fabric-gateway/main/api/node/interfaces/Contract.html), and [Java](https://hyperledger.github.io/fabric-gateway/main/api/java/org/hyperledger/fabric/client/Contract.html).
+
+For specific use cases that do require blocks to be read, such as creating an off-chain data store of ledger data, it is recommended to either:
+
+- Continue to use the legacy SDKs to retrieve blocks.
+- Use [gRPC client APIs](https://grpc.io/) to access the peer [Deliver service](https://github.com/hyperledger/fabric-protos/blob/c6ece3f9b7f977fd83b243af9dc8e5dd7c926f52/peer/events.proto#L65-L81) directly.
+
+Note that the Fabric Gateway client API does provide chaincode event listening. This uses a more efficient mechanism to retrieve chaincode events directly, without the overhead of retrieving full block events, so the Fabric Gateway client API should be preferred for receiving chaincode events.
+
+### Event reconnect
+
+In the event of a peer or network failure during event listening, the legacy SDKs transparently attempt to reestablish connection and continue delivering events once successful reconnection is achieved. The Fabric Gateway client API surfaces eventing errors to the client application at the point it requests the next event. To reestablish eventing, the application must initiate a new event listening session with an appropriate start position.
+
+The [event checkpointing](#event-checkpointing) section describes how to avoid duplicate event processing.
+
+### Event checkpointing
+
+The checkpointing capability in legacy SDKs allows client applications to easily resume event listening without duplicating or missing events. This behavior can still be achieved using the Fabric Gateway client API but requires more work on the part of the client application. The client application needs to:
+
+1. Store the current block number from which events are being received.
+1. Track the events successfully processed within the current block.
+1. When resuming eventing, replay from the current block and discard any previously processed events.


### PR DESCRIPTION
Documentation describing key considerations when migrating application using the legacy client SDKs to use the Fabric Gateway client API.

Resolves hyperledger/fabric#3151