### PR TITLE
Add front matter to migration guide documentation page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,6 +1,6 @@
 <header class="site-header">
     <div class="wrapper">
-        <a class="site-title" rel="author" href="{{ " /" | relative_url }}">{{ site.title | escape }}</a>
+        <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
 
         <nav class="site-nav">
             <input type="checkbox" id="nav-trigger" class="nav-trigger" />

--- a/migration.md
+++ b/migration.md
@@ -1,4 +1,6 @@
-# Migration guide
+---
+title: "Migration guide"
+---
 
 This page documents key considerations when rewriting an existing application, written using legacy Hyperledger Fabric client SDKs, to the Fabric Gateway client API.
 


### PR DESCRIPTION
Define the page title in front matter, not as a markdown heading. This avoid duplication of the page title.

Also fix the home link in the page header.