### PR TITLE
Remove references to developing applications section of Fabric docs

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -1,8 +1,6 @@
 # Hyperledger Fabric Gateway Client API for Java
 
-The Fabric Gateway client API allows applications to interact with a Hyperledger Fabric blockchain network. It provides a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.
-
-The Gateway client API implements the Fabric programming model as described in the [Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html) chapter of the Fabric documentation.
+The Fabric Gateway client API allows applications to interact with a Hyperledger Fabric blockchain network. It implements the Fabric programming model, providing a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.
 
 ## How to use
 

--- a/node/README.md
+++ b/node/README.md
@@ -1,9 +1,7 @@
 # Hyperledger Fabric Gateway Client API for Node
 
 
-The Fabric Gateway client API allows applications to interact with a Hyperledger Fabric blockchain network. It provides a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.
-
-The Gateway client API implements the Fabric programming model as described in the [Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html) chapter of the Fabric documentation.
+The Fabric Gateway client API allows applications to interact with a Hyperledger Fabric blockchain network. It implements the Fabric programming model, providing a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.
 
 ## How to use
 

--- a/pkg/client/README.md
+++ b/pkg/client/README.md
@@ -1,8 +1,6 @@
 # Hyperledger Fabric Gateway Client API for Go
 
-The Fabric Gateway client API allows applications to interact with a Hyperledger Fabric blockchain network. It provides a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.
-
-The Gateway client API implements the Fabric programming model as described in the [Developing Applications](https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html) chapter of the Fabric documentation.
+The Fabric Gateway client API allows applications to interact with a Hyperledger Fabric blockchain network. It implements the Fabric programming model, providing a simple API to submit transactions to a ledger or query the contents of a ledger with minimal code.
 
 ## How to use
 

--- a/pkg/client/gateway.go
+++ b/pkg/client/gateway.go
@@ -4,10 +4,7 @@ Copyright 2020 IBM All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-// Package client enables Go developers to build client applications using the Hyperledger Fabric programming model as
-// described in the Developing Applications chapter of the Fabric documentation:
-//
-// https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html
+// Package client enables Go developers to build client applications using the Hyperledger Fabric programming model.
 //
 // Client applications interact with the blockchain network using a Fabric Gateway. A client connection to a Fabric
 // Gateway is established by calling client.Connect() with a client identity, client signing implementation, and client


### PR DESCRIPTION
This content is outdated and describes the legacy SDKs. Remove references to it for now to avoid confusion.

The asset-transfer samples and associated tutorials in the Fabric documentation provide a better guide for new users. Those are already linked in both READMEs and the main documentation page for fabric-gateway.