### PR TITLE
Additional staticcheck and gofmt checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,8 @@ unit-test-java: build-protos
 	cd $(java_dir); mvn test
 
 lint:
-	staticcheck -tags="pkcs11" $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
+	$(base_dir)/ci/check_gofmt.sh $(base_dir)/pkg $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
+	staticcheck -f stylish -tags="pkcs11" $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 	go vet -tags pkcs11 $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 	gosec -tags pkcs11 -exclude-generated $(base_dir)/pkg/... $(samples_dir)/go $(hsm_samples_dir)/go
 

--- a/ci/check_gofmt.sh
+++ b/ci/check_gofmt.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -eu
+
+GOFMT=$(gofmt -l "$@")
+if [ ! -z "${GOFMT}" ]; then
+    echo 'Go formatting errors:'
+    echo "${GOFMT}"
+    exit 1
+fi

--- a/pkg/client/chaincodeevents_test.go
+++ b/pkg/client/chaincodeevents_test.go
@@ -353,7 +353,7 @@ func TestChaincodeEvents(t *testing.T) {
 		network := AssertNewTestNetwork(t, "NETWORK", WithGatewayClient(mockClient))
 
 		checkpointer := new(InMemoryCheckpointer)
-		checkpointer.CheckpointTransaction(uint64(500),"txn1")
+		checkpointer.CheckpointTransaction(uint64(500), "txn1")
 
 		_, err := network.ChaincodeEvents(ctx, "CHAINCODE", WithCheckpointer(checkpointer))
 		require.NoError(t, err)
@@ -399,13 +399,13 @@ func TestChaincodeEvents(t *testing.T) {
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithGatewayClient(mockClient))
 
-		checkpointer :=  new(InMemoryCheckpointer)
+		checkpointer := new(InMemoryCheckpointer)
 		event := &ChaincodeEvent{
-				BlockNumber:   1,
-				ChaincodeName: "CHAINCODE",
-				EventName:     "EVENT_1",
-				Payload:       []byte("PAYLOAD_1"),
-				TransactionID: "TRANSACTION_1",
+			BlockNumber:   1,
+			ChaincodeName: "CHAINCODE",
+			EventName:     "EVENT_1",
+			Payload:       []byte("PAYLOAD_1"),
+			TransactionID: "TRANSACTION_1",
 		}
 
 		checkpointer.CheckpointChaincodeEvent(event)

--- a/pkg/client/chaincodeeventsbuilder.go
+++ b/pkg/client/chaincodeeventsbuilder.go
@@ -56,10 +56,10 @@ func (builder *chaincodeEventsBuilder) newChaincodeEventsRequestProto() (*gatewa
 	}
 
 	request := &gateway.ChaincodeEventsRequest{
-		ChannelId:     builder.channelName,
-		Identity:      creator,
-		ChaincodeId:   builder.chaincodeName,
-		StartPosition: builder.getStartPosition(),
+		ChannelId:          builder.channelName,
+		Identity:           creator,
+		ChaincodeId:        builder.chaincodeName,
+		StartPosition:      builder.getStartPosition(),
 		AfterTransactionId: builder.afterTransactionID,
 	}
 	return request, nil

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -63,15 +63,15 @@ func (client *gatewayClient) CommitStatus(in *gateway.SignedCommitStatusRequest,
 func (client *gatewayClient) CommitStatusWithContext(ctx context.Context, in *gateway.SignedCommitStatusRequest, opts ...grpc.CallOption) (*gateway.CommitStatusResponse, error) {
 	response, err := client.grpcGatewayClient.CommitStatus(ctx, in, opts...)
 	if err != nil {
-		transactionId := getTransactionIdFromSignedCommitStatusRequest(in)
-		txErr := newTransactionError(err, transactionId)
+		transactionID := getTransactionIDFromSignedCommitStatusRequest(in)
+		txErr := newTransactionError(err, transactionID)
 		return nil, &CommitStatusError{txErr}
 	}
 
 	return response, nil
 }
 
-func getTransactionIdFromSignedCommitStatusRequest(in *gateway.SignedCommitStatusRequest) string {
+func getTransactionIDFromSignedCommitStatusRequest(in *gateway.SignedCommitStatusRequest) string {
 	request := &gateway.CommitStatusRequest{}
 	err := util.Unmarshal(in.GetRequest(), request)
 	if err != nil {

--- a/pkg/client/eventsbuilder.go
+++ b/pkg/client/eventsbuilder.go
@@ -7,15 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 import (
-
 	"github.com/hyperledger/fabric-protos-go/orderer"
 )
 
 type eventsBuilder struct {
-	client        *gatewayClient
-	signingID     *signingIdentity
-	channelName   string
-	startPosition *orderer.SeekPosition
+	client             *gatewayClient
+	signingID          *signingIdentity
+	channelName        string
+	startPosition      *orderer.SeekPosition
 	afterTransactionID string
 }
 
@@ -33,9 +32,11 @@ func (builder *eventsBuilder) getStartPosition() *orderer.SeekPosition {
 
 type eventOption = func(builder *eventsBuilder) error
 
-// Inferace used while checkpointing events
+// Checkpointer provides the current position for event processing.
 type Checkpointer interface {
+	// BlockNumber in which the next event is expected.
 	BlockNumber() uint64
+	// TransactionID of the last successfully processed event within the current block.
 	TransactionID() string
 }
 
@@ -60,7 +61,7 @@ func WithCheckpointer(checkpointer Checkpointer) eventOption {
 		blockNumber := checkpointer.BlockNumber()
 		transactionID := checkpointer.TransactionID()
 
-		if (blockNumber == 0 && transactionID == "") {
+		if blockNumber == 0 && transactionID == "" {
 			return nil
 		}
 		builder.startPosition = &orderer.SeekPosition{

--- a/pkg/client/inmemorycheckpointer.go
+++ b/pkg/client/inmemorycheckpointer.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package client
 
 type InMemoryCheckpointer struct {
-	blockNumber uint64
+	blockNumber   uint64
 	transactionID string
 }
 
@@ -16,13 +16,13 @@ func (c *InMemoryCheckpointer) CheckpointBlock(blockNumber uint64) {
 	c.transactionID = ""
 }
 
-func (c *InMemoryCheckpointer) CheckpointTransaction(blockNumber uint64 , transactionID string) {
+func (c *InMemoryCheckpointer) CheckpointTransaction(blockNumber uint64, transactionID string) {
 	c.blockNumber = blockNumber
 	c.transactionID = transactionID
 }
 
 func (c *InMemoryCheckpointer) CheckpointChaincodeEvent(event *ChaincodeEvent) {
-    c.CheckpointTransaction(event.BlockNumber, event.TransactionID)
+	c.CheckpointTransaction(event.BlockNumber, event.TransactionID)
 }
 
 func (c *InMemoryCheckpointer) BlockNumber() uint64 {

--- a/pkg/client/inmemorycheckpointer_test.go
+++ b/pkg/client/inmemorycheckpointer_test.go
@@ -14,32 +14,32 @@ import (
 
 func TestInMemoryCheckpointer(t *testing.T) {
 	t.Run("Initializes default checkpointer state when no checkpointer already exist", func(t *testing.T) {
-		checkpointer :=  new(InMemoryCheckpointer)
+		checkpointer := new(InMemoryCheckpointer)
 
 		blockNumber := checkpointer.BlockNumber()
 
 		require.Equal(t, uint64(0), blockNumber)
 		require.Equal(t, "", checkpointer.TransactionID())
-	});
+	})
 
 	t.Run("Checkpointing a block gives next block number & empty transaction Id", func(t *testing.T) {
 		blockNumber := uint64(101)
-		checkpointer :=  new(InMemoryCheckpointer)
+		checkpointer := new(InMemoryCheckpointer)
 
 		checkpointer.CheckpointBlock(blockNumber)
 
-		require.Equal(t, blockNumber + 1 , checkpointer.BlockNumber())
+		require.Equal(t, blockNumber+1, checkpointer.BlockNumber())
 		require.Equal(t, "", checkpointer.TransactionID())
-	});
+	})
 
 	t.Run("Checkpointing a transaction gives valid transaction Id and blocknumber ", func(t *testing.T) {
 		blockNumber := uint64(101)
-		checkpointer :=  new(InMemoryCheckpointer)
+		checkpointer := new(InMemoryCheckpointer)
 
-		checkpointer.CheckpointTransaction(blockNumber,"txn1")
+		checkpointer.CheckpointTransaction(blockNumber, "txn1")
 
 		require.Equal(t, blockNumber, checkpointer.BlockNumber())
 		require.Equal(t, "txn1", checkpointer.TransactionID())
-	});
+	})
 
 }

--- a/pkg/client/transactioncontext.go
+++ b/pkg/client/transactioncontext.go
@@ -30,8 +30,8 @@ func newTransactionContext(signingIdentity *signingIdentity) (*transactionContex
 	}
 
 	saltedCreator := append(nonce, creator...)
-	rawTransactionId := signingIdentity.hash(saltedCreator)
-	transactionId := hex.EncodeToString(rawTransactionId)
+	rawTransactionID := signingIdentity.hash(saltedCreator)
+	transactionID := hex.EncodeToString(rawTransactionID)
 
 	signatureHeader := &common.SignatureHeader{
 		Creator: creator,
@@ -39,7 +39,7 @@ func newTransactionContext(signingIdentity *signingIdentity) (*transactionContex
 	}
 
 	transactionCtx := &transactionContext{
-		TransactionID:   transactionId,
+		TransactionID:   transactionID,
 		SignatureHeader: signatureHeader,
 	}
 	return transactionCtx, nil

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -4,6 +4,7 @@ Copyright 2020 IBM All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+// Package hash provides hash implementations used for digital signature of messages sent to a Fabric network.
 package hash
 
 import (

--- a/pkg/identity/hsmsign_test.go
+++ b/pkg/identity/hsmsign_test.go
@@ -1,3 +1,4 @@
+//go:build pkcs11
 // +build pkcs11
 
 /*

--- a/pkg/identity/identity.go
+++ b/pkg/identity/identity.go
@@ -4,6 +4,10 @@ Copyright 2020 IBM All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
+// Package identity defines a client identity and signing implementation used to interact with a Fabric network.
+//
+// This package provides utilities to aid creation of client identities and accompanying signing implementations from
+// various types of credentials.
 package identity
 
 import (

--- a/pkg/internal/staticcheck.conf
+++ b/pkg/internal/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["inherit", "-ST1000"]

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,1 +1,1 @@
-checks = ["inherit"]
+checks = ["all"]


### PR DESCRIPTION
Removal of the deprecated golint left some gaps in checking for correct godoc comments and recommended naming. Enabling additional (non-default) staticcheck rules covers at least some of these linting gaps.

Added a check of all Go files with gofmt to ensure recommended formatting.