### PR TITLE
Explicit typing of StatusCode in Node API

### DIFF
--- a/node/src/status.ts
+++ b/node/src/status.ts
@@ -9,7 +9,7 @@ import { TxValidationCode, TxValidationCodeMap } from './protos/peer/transaction
 /**
  * Enumeration of transaction status codes.
  */
-export const StatusCode = Object.freeze(TxValidationCode);
+export const StatusCode = Object.freeze(TxValidationCode) as { [P in keyof typeof TxValidationCode]: typeof TxValidationCode[P] };
 
 export const StatusNames = Object.freeze(
     Object.fromEntries(

--- a/node/typedoc.json
+++ b/node/typedoc.json
@@ -1,9 +1,9 @@
 {
+    "cleanOutputDir": true,
     "entryPoints": [
         "src/index.ts"
     ],
     "intentionallyNotExported": [
-        "TxValidationCodeMap",
         "Block",
         "BlockAndPrivateData",
         "FilteredBlock"


### PR DESCRIPTION
The typing implicitly referenced a protobuf stub and produced no detail on the type members in the tsdoc output. Add explicit type definition so the tsdoc includes all the field names and corresponding values.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>