### PR TITLE
Fix CodeQL scan of Java client

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,11 +12,13 @@
 name: "CodeQL"
 
 on:
-#   push:
-#     branches: [ main, * ]
-#   pull_request:
-#     # The branches below must be a subset of the branches above
-#     branches: [ main ]
+  # push:
+  #   branches:
+  #     - main
+  # pull_request:
+  #   # The branches below must be a subset of the branches above
+  #   branches:
+  #     - main
   schedule:
     - cron: '15 23 * * *'
 
@@ -53,6 +55,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
+      if: matrix.language != 'java'
       uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
@@ -62,9 +65,9 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - name: Build Java
+      if: matrix.language == 'java'
+      run: make build-java
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Autobuild was insufficient for Java as the compiled protos are required.

Signed-off-by: Mark S. Lewis <Mark.S.Lewis@outlook.com>