### PR TITLE
Update Go version to 1.17

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ PKGNAME = github.com/hyperledger/fabric-gateway
 ARCH=$(shell go env GOARCH)
 MARCH=$(shell go env GOOS)-$(shell go env GOARCH)
 
-GO_VER = 1.16.7
+GO_VER = 1.17.8
 GO_TAGS ?=
 
 build: build-node build-java

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ See the [gateway.proto file](https://github.com/hyperledger/fabric-protos/blob/m
 
 This repository comprises three functionally equivalent client APIs, written in Go, Typescript, and Java. In order to
 build these components, the following needs to be installed and available in the PATH:
-- Go 1.16
+- Go 1.17
 - Node 14
 - Java 8
 - Docker

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -35,7 +35,7 @@ variables:
   - name: PATH
     value: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
   - name: GOVER
-    value: 1.16.7
+    value: 1.17.8
   - name: NODEVER
     value: 14.x
   - name: JAVAVER

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway
 
-go 1.16
+go 1.17
 
 require (
 	github.com/cucumber/godog v0.12.4
@@ -12,4 +12,20 @@ require (
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/grpc v1.43.0
 	google.golang.org/protobuf v1.27.1
+)
+
+require (
+	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/hashicorp/go-immutable-radix v1.3.0 // indirect
+	github.com/hashicorp/go-memdb v1.3.0 // indirect
+	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.3 // indirect
+	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/samples/README.md
+++ b/samples/README.md
@@ -7,7 +7,7 @@ Gateway in Fabric.
 
 Install the following pre-reqs to run the sample client applications:
 
-- Go v1.16 (required for sample Fabric network and Go sample)
+- Go v1.17 (required for sample Fabric network and Go sample)
 - Node 14.x or 16.x (required for Node sample)
 - Java 11 (required for Java sample)
 - Docker (required for sample Fabric network)
@@ -20,7 +20,7 @@ go install github.com/cucumber/godog/cmd/godog@v0.12.1
 ```
 
 Make sure you can run `godog --version` after installing. If the command is not found, add the Go bin directory to your
-path using: 
+path using:
 
 ```sh
 export PATH="${PATH}:$(go env GOPATH)/bin"

--- a/scenario/fixtures/chaincode/golang/basic/go.mod
+++ b/scenario/fixtures/chaincode/golang/basic/go.mod
@@ -1,8 +1,32 @@
 module github.com/hyperledger/fabric-gateway/scenario/fixtures/chaincode/go/basic
 
-go 1.16
+go 1.17
+
+require github.com/hyperledger/fabric-contract-api-go v1.1.1
 
 require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.2 // indirect
+	github.com/go-openapi/spec v0.19.4 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gobuffalo/envy v1.7.0 // indirect
+	github.com/gobuffalo/packd v0.3.0 // indirect
+	github.com/gobuffalo/packr v1.30.1 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20210718160520-38d29fabecb9 // indirect
-	github.com/hyperledger/fabric-contract-api-go v1.1.1
+	github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e // indirect
+	github.com/joho/godotenv v1.3.0 // indirect
+	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
+	github.com/rogpeppe/go-internal v1.3.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 // indirect
+	golang.org/x/sys v0.0.0-20190710143415-6ec70d6a5542 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b // indirect
+	google.golang.org/grpc v1.23.0 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )

--- a/scenario/fixtures/chaincode/golang/private/go.mod
+++ b/scenario/fixtures/chaincode/golang/private/go.mod
@@ -1,8 +1,34 @@
 module github.com/hyperledger/fabric-gateway/scenario/fixtures/chaincode/go/private
 
-go 1.16
+go 1.17
 
 require (
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20210718160520-38d29fabecb9
 	github.com/hyperledger/fabric-contract-api-go v1.1.1
+)
+
+require (
+	github.com/PuerkitoBio/purell v1.1.1 // indirect
+	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
+	github.com/go-openapi/jsonpointer v0.19.3 // indirect
+	github.com/go-openapi/jsonreference v0.19.2 // indirect
+	github.com/go-openapi/spec v0.19.4 // indirect
+	github.com/go-openapi/swag v0.19.5 // indirect
+	github.com/gobuffalo/envy v1.7.0 // indirect
+	github.com/gobuffalo/packd v0.3.0 // indirect
+	github.com/gobuffalo/packr v1.30.1 // indirect
+	github.com/golang/protobuf v1.3.2 // indirect
+	github.com/hyperledger/fabric-protos-go v0.0.0-20200424173316-dd554ba3746e // indirect
+	github.com/joho/godotenv v1.3.0 // indirect
+	github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e // indirect
+	github.com/rogpeppe/go-internal v1.3.0 // indirect
+	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
+	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297 // indirect
+	golang.org/x/sys v0.0.0-20190710143415-6ec70d6a5542 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	google.golang.org/genproto v0.0.0-20180831171423-11092d34479b // indirect
+	google.golang.org/grpc v1.23.0 // indirect
+	gopkg.in/yaml.v2 v2.2.8 // indirect
 )


### PR DESCRIPTION
- Current minimum supported Go release.
- Allows latest version of staticcheck to install/run.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>