### PR TITLE
Use engine-strict to ensure compatibility with tested Node versions

### DIFF
--- a/node/.npmrc
+++ b/node/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
Add an .npmrc so that `npm install` will fail during testing if any dependencies do not support the Node version used to run tests.

Also modify the Makefile so that targets executed in sub-directories correctly fail-fast rather than continuing to execute subsequent commands.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>