### PR TITLE
Looser checks for required Node engines

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "engines": {
-        "node": "^14.15.0 || ^16.13.0"
+        "node": ">=14.15.0"
     },
     "repository": {
         "type": "git",

--- a/samples/node/package.json
+++ b/samples/node/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "dist/sample.js",
     "engines": {
-        "node": "^14.15.0 || ^16.13.0"
+        "node": ">=14.15.0"
     },
     "scripts": {
         "build": "npm-run-all clean compile lint",

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "description": "Scenario test for Fabric Gateway",
     "engines": {
-        "node": "^14.15.0 || ^16.13.0"
+        "node": ">=14.15.0"
     },
     "scripts": {
         "build": "npm-run-all clean compile lint",


### PR DESCRIPTION
Specify only the minimum required Node version, below which the code will not run. Allows more flexibility for consumers to pick a preferred Node runtime versions, including non-LTS versions. The documented supported versions still specify the Node versions tested and for which bugs will be addressed.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>