### PR TITLE
Use OptionalLong for Java checkpoint block number

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsBuilder.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/ChaincodeEventsBuilder.java
@@ -10,7 +10,6 @@ import com.google.protobuf.ByteString;
 import org.hyperledger.fabric.protos.gateway.SignedChaincodeEventsRequest;
 
 import java.util.Objects;
-import java.util.Optional;
 
 final class ChaincodeEventsBuilder implements ChaincodeEventsRequest.Builder {
     private final GatewayClient client;
@@ -39,13 +38,8 @@ final class ChaincodeEventsBuilder implements ChaincodeEventsRequest.Builder {
 
     @Override
     public ChaincodeEventsRequest.Builder checkpoint(final Checkpoint checkpoint) {
-        long blockNumber = checkpoint.getBlockNumber();
-        Optional<String> transactionId = checkpoint.getTransactionId();
-        if (blockNumber == 0 && !transactionId.isPresent()) {
-            return this;
-        }
-        startPositionBuilder.startBlock(blockNumber);
-        this.afterTransactionId = transactionId.orElse(null);
+        checkpoint.getBlockNumber().ifPresent(startPositionBuilder::startBlock);
+        this.afterTransactionId = checkpoint.getTransactionId().orElse(null);
         return this;
     }
 

--- a/java/src/main/java/org/hyperledger/fabric/client/Checkpoint.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Checkpoint.java
@@ -7,6 +7,7 @@
 package org.hyperledger.fabric.client;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * Checkpoint provides the current position for event processing.
@@ -16,7 +17,7 @@ public interface Checkpoint {
      * The block number in which the next event is expected.
      * @return  A ledger block number.
      */
-    long getBlockNumber();
+    OptionalLong getBlockNumber();
 
     /**
      * Transaction Id of the last successfully processed event within the current block.

--- a/java/src/main/java/org/hyperledger/fabric/client/InMemoryCheckpointer.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/InMemoryCheckpointer.java
@@ -7,6 +7,7 @@
 package org.hyperledger.fabric.client;
 
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /**
  * A non-persistent Checkpointer implementation.
@@ -14,7 +15,7 @@ import java.util.Optional;
  */
 public final class InMemoryCheckpointer implements Checkpointer {
 
-    private long blockNumber;
+    private OptionalLong blockNumber = OptionalLong.empty();
     private String transactionId;
 
     @Override
@@ -24,7 +25,7 @@ public final class InMemoryCheckpointer implements Checkpointer {
 
     @Override
     public void checkpointTransaction(final long blockNumber, final String transactionId) {
-        this.blockNumber = blockNumber;
+        this.blockNumber = OptionalLong.of(blockNumber);
         this.transactionId = transactionId;
     }
 
@@ -34,7 +35,7 @@ public final class InMemoryCheckpointer implements Checkpointer {
     }
 
     @Override
-    public long getBlockNumber() {
+    public OptionalLong getBlockNumber() {
         return blockNumber;
     }
 

--- a/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
@@ -6,12 +6,6 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
-import java.util.stream.Stream;
-
 import com.google.protobuf.ByteString;
 import io.grpc.CallOptions;
 import io.grpc.Deadline;
@@ -25,6 +19,12 @@ import org.hyperledger.fabric.protos.peer.ChaincodeEventPackage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -63,7 +63,9 @@ public final class ChaincodeEventsTest {
     }
 
     void assertStartPosition(final org.hyperledger.fabric.protos.gateway.ChaincodeEventsRequest actual, final Checkpoint checkpoint) {
-        assertStartPosition(actual, checkpoint.getBlockNumber(), checkpoint.getTransactionId().orElse(""));
+        long blockNumber = checkpoint.getBlockNumber().orElseThrow(() -> new IllegalArgumentException("No checkoint block number set"));
+        String transactionId = checkpoint.getTransactionId().orElse("");
+        assertStartPosition(actual, blockNumber, transactionId);
     }
 
     void assertStartPosition(final org.hyperledger.fabric.protos.gateway.ChaincodeEventsRequest actual, final long blockNumber, final String transactionId) {

--- a/java/src/test/java/org/hyperledger/fabric/client/CommonCheckpointerTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/CommonCheckpointerTest.java
@@ -1,29 +1,32 @@
 package org.hyperledger.fabric.client;
 
-import java.io.IOException;
-
 import com.google.protobuf.ByteString;
 import org.hyperledger.fabric.protos.peer.ChaincodeEventPackage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
+
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 
 public abstract  class CommonCheckpointerTest {
 
     private Checkpointer checkpointerInstance;
 
+    protected void assertCheckpoint(final Checkpoint checkpoint) {
+        assertThat(checkpoint.getBlockNumber()).isNotPresent();
+        assertThat(checkpoint.getTransactionId()).isNotPresent();
+    }
+
     protected void assertCheckpoint(final Checkpoint checkpoint, final long blockNumber) {
-        assertThat(checkpoint.getBlockNumber()).isEqualTo(blockNumber);
+        assertThat(checkpoint.getBlockNumber()).hasValue(blockNumber);
         assertThat(checkpoint.getTransactionId()).isNotPresent();
     }
     protected void assertCheckpoint(final Checkpoint checkpoint, final long blockNumber, final String transactionId) {
-        assertThat(checkpoint.getBlockNumber()).isEqualTo(blockNumber);
-        assertTrue(checkpoint.getTransactionId().isPresent());
-        assertThat(checkpoint.getTransactionId().get()).isEqualTo(transactionId);
+        assertThat(checkpoint.getBlockNumber()).hasValue(blockNumber);
+        assertThat(checkpoint.getTransactionId()).hasValue(transactionId);
     }
 
     @BeforeEach
@@ -41,7 +44,7 @@ public abstract  class CommonCheckpointerTest {
 
     @Test
     void initial_checkpointer_state() {
-        assertCheckpoint(checkpointerInstance , 0);
+        assertCheckpoint(checkpointerInstance);
     }
 
     @Test
@@ -69,5 +72,4 @@ public abstract  class CommonCheckpointerTest {
         checkpointerInstance.checkpointChaincodeEvent(eventImp);
         assertCheckpoint(checkpointerInstance ,blockNumber, eventImp.getTransactionId());
     }
-
 }

--- a/java/src/test/java/org/hyperledger/fabric/client/FileCheckpointerTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/FileCheckpointerTest.java
@@ -1,11 +1,11 @@
 package org.hyperledger.fabric.client;
 
 
+import org.junit.jupiter.api.Test;
+
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-
-import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -33,6 +33,16 @@ public class FileCheckpointerTest extends CommonCheckpointerTest {
         }
         checkpointer = new FileCheckpointer(file);
         assertCheckpoint(checkpointer, 1, "TRANSACTION_ID");
+    }
+
+    @Test
+    void partial_state_is_persisted() throws IOException {
+        Path file = testUtils.createTempFile(".json");
+        try (FileCheckpointer checkpointer = new FileCheckpointer(file)) {
+            checkpointer.checkpointBlock(1);
+        }
+        checkpointer = new FileCheckpointer(file);
+        assertCheckpoint(checkpointer, 2);
     }
 
     @Test


### PR DESCRIPTION
Block number will not be set in the initial checkpointer state, and
previously logic to detect this required that the block number be set to
zero and the transaction ID (which already uses an Optional) unset. This
can be simplified by using an Optional to indicate whether the block
number has a value.

Signed-off-by: Mark S. Lewis <Mark.S.Lewis@outlook.com>