### PR TITLE
Allow per-call gRPC call options to be specified in Go client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ lint:
 	$(base_dir)/ci/check_gofmt.sh $(base_dir)/pkg $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 	staticcheck -f stylish -tags="pkcs11" $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
 	go vet -tags pkcs11 $(base_dir)/pkg/... $(scenario_dir)/go $(samples_dir)/go $(hsm_samples_dir)/go
-	gosec -tags pkcs11 -exclude-generated $(base_dir)/pkg/... $(samples_dir)/go $(hsm_samples_dir)/go
+	gosec -tags pkcs11 -exclude-generated $(base_dir)/pkg/... $(samples_dir)/go
 
 scan: scan-go scan-node scan-java
 

--- a/pkg/client/blockevents.go
+++ b/pkg/client/blockevents.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/common"
 	"github.com/hyperledger/fabric-protos-go/peer"
+	"google.golang.org/grpc"
 )
 
 type baseBlockEventsRequest struct {
@@ -66,12 +67,12 @@ type FilteredBlockEventsRequest struct {
 }
 
 // Events returns a channel from which filtered block events can be read.
-func (events *FilteredBlockEventsRequest) Events(ctx context.Context) (<-chan *peer.FilteredBlock, error) {
+func (events *FilteredBlockEventsRequest) Events(ctx context.Context, opts ...grpc.CallOption) (<-chan *peer.FilteredBlock, error) {
 	if err := events.sign(); err != nil {
 		return nil, err
 	}
 
-	eventsClient, err := events.client.FilteredBlockEvents(ctx, events.request)
+	eventsClient, err := events.client.FilteredBlockEvents(ctx, events.request, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -100,12 +101,12 @@ type BlockEventsRequest struct {
 }
 
 // Events returns a channel from which block events can be read.
-func (events *BlockEventsRequest) Events(ctx context.Context) (<-chan *common.Block, error) {
+func (events *BlockEventsRequest) Events(ctx context.Context, opts ...grpc.CallOption) (<-chan *common.Block, error) {
 	if err := events.sign(); err != nil {
 		return nil, err
 	}
 
-	eventsClient, err := events.client.BlockEvents(ctx, events.request)
+	eventsClient, err := events.client.BlockEvents(ctx, events.request, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -134,12 +135,12 @@ type BlockAndPrivateDataEventsRequest struct {
 }
 
 // Events returns a channel from which block and private data events can be read.
-func (events *BlockAndPrivateDataEventsRequest) Events(ctx context.Context) (<-chan *peer.BlockAndPrivateData, error) {
+func (events *BlockAndPrivateDataEventsRequest) Events(ctx context.Context, opts ...grpc.CallOption) (<-chan *peer.BlockAndPrivateData, error) {
 	if err := events.sign(); err != nil {
 		return nil, err
 	}
 
-	eventsClient, err := events.client.BlockAndPrivateEventsData(ctx, events.request)
+	eventsClient, err := events.client.BlockAndPrivateDataEvents(ctx, events.request, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/blockeventsfiltered_test.go
+++ b/pkg/client/blockeventsfiltered_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go/orderer"
 	"github.com/hyperledger/fabric-protos-go/peer"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -274,5 +275,40 @@ func TestFilteredBlockEvents(t *testing.T) {
 			actual := <-receive
 			test.AssertProtoEqual(t, event, actual)
 		}
+	})
+
+	t.Run("Uses specified gRPC call options", func(t *testing.T) {
+		var actual []grpc.CallOption
+		expected := grpc.WaitForReady(true)
+
+		controller := gomock.NewController(t)
+		mockClient := NewMockDeliverClient(controller)
+		mockEvents := NewMockDeliver_DeliverClient(controller)
+
+		mockClient.EXPECT().DeliverFiltered(gomock.Any(), gomock.Any()).
+			Do(func(_ context.Context, opts ...grpc.CallOption) {
+				actual = opts
+			}).
+			Return(mockEvents, nil).
+			Times(1)
+
+		mockEvents.EXPECT().Send(gomock.Any()).
+			Return(nil).
+			AnyTimes()
+		mockEvents.EXPECT().Recv().
+			Return(nil, errors.New("fake")).
+			AnyTimes()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := AssertNewTestNetwork(t, "NETWORK", WithDeliverClient(mockClient))
+		request, err := network.NewFilteredBlockEventsRequest()
+		require.NoError(t, err, "NewFilteredBlockEventsRequest")
+
+		_, err = request.Events(ctx, expected)
+		require.NoError(t, err, "Events")
+
+		require.Contains(t, actual, expected, "CallOptions")
 	})
 }

--- a/pkg/client/chaincodeevents.go
+++ b/pkg/client/chaincodeevents.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger/fabric-gateway/pkg/internal/util"
 	"github.com/hyperledger/fabric-protos-go/gateway"
+	"google.golang.org/grpc"
 )
 
 // ChaincodeEventsRequest delivers events emitted by transaction functions in a specific chaincode.
@@ -37,12 +38,12 @@ func (events *ChaincodeEventsRequest) Digest() []byte {
 }
 
 // Events returns a channel from which chaincode events can be read.
-func (events *ChaincodeEventsRequest) Events(ctx context.Context) (<-chan *ChaincodeEvent, error) {
+func (events *ChaincodeEventsRequest) Events(ctx context.Context, opts ...grpc.CallOption) (<-chan *ChaincodeEvent, error) {
 	if err := events.sign(); err != nil {
 		return nil, err
 	}
 
-	eventsClient, err := events.client.ChaincodeEvents(ctx, events.signedRequest)
+	eventsClient, err := events.client.ChaincodeEvents(ctx, events.signedRequest, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -120,7 +120,7 @@ func (client *gatewayClient) FilteredBlockEvents(ctx context.Context, in *common
 	return deliverClient, nil
 }
 
-func (client *gatewayClient) BlockAndPrivateEventsData(ctx context.Context, in *common.Envelope, opts ...grpc.CallOption) (peer.Deliver_DeliverWithPrivateDataClient, error) {
+func (client *gatewayClient) BlockAndPrivateDataEvents(ctx context.Context, in *common.Envelope, opts ...grpc.CallOption) (peer.Deliver_DeliverWithPrivateDataClient, error) {
 	deliverClient, err := client.grpcDeliverClient.DeliverWithPrivateData(ctx, opts...)
 	if err != nil {
 		return nil, err

--- a/pkg/client/commit.go
+++ b/pkg/client/commit.go
@@ -60,28 +60,30 @@ func (commit *Commit) TransactionID() string {
 
 // Status of the committed transaction. If the transaction has not yet committed, this call blocks until the commit
 // occurs.
-func (commit *Commit) Status() (*Status, error) {
-	return commit.status(commit.client.CommitStatus)
+func (commit *Commit) Status(opts ...grpc.CallOption) (*Status, error) {
+	return commit.status(commit.client.CommitStatus, opts...)
 }
 
 // StatusWithContext uses the supplied context to get the status of the committed transaction. If the transaction has
 // not yet committed, this call blocks until the commit occurs.
-func (commit *Commit) StatusWithContext(ctx context.Context) (*Status, error) {
+func (commit *Commit) StatusWithContext(ctx context.Context, opts ...grpc.CallOption) (*Status, error) {
 	return commit.status(
 		func(in *gateway.SignedCommitStatusRequest, opts ...grpc.CallOption) (*gateway.CommitStatusResponse, error) {
 			return commit.client.CommitStatusWithContext(ctx, in, opts...)
 		},
+		opts...,
 	)
 }
 
 func (commit *Commit) status(
 	call func(in *gateway.SignedCommitStatusRequest, opts ...grpc.CallOption) (*gateway.CommitStatusResponse, error),
+	opts ...grpc.CallOption,
 ) (*Status, error) {
 	if err := commit.sign(); err != nil {
 		return nil, err
 	}
 
-	response, err := call(commit.signedRequest)
+	response, err := call(commit.signedRequest, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Contributes to #289