### PR TITLE
Remove system channel from scenario test network

### DIFF
--- a/scenario/fixtures/crypto-material/configtx.yaml
+++ b/scenario/fixtures/crypto-material/configtx.yaml
@@ -98,10 +98,17 @@ Orderer: &OrdererDefaults
 
     # Orderer Type: The orderer implementation to start
     # Available types are "solo" and "kafka"
-    OrdererType: solo
+    OrdererType: etcdraft
 
     Addresses:
         - orderer.example.com:7050
+
+    EtcdRaft:
+        Consenters:
+            - Host: orderer.example.com
+              Port: 7050
+              ClientTLSCert: crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
+              ServerTLSCert: crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
 
     # Batch Timeout: The amount of time to wait before creating a batch
     BatchTimeout: 0.5s
@@ -120,12 +127,6 @@ Orderer: &OrdererDefaults
         # the serialized messages in a batch. A message larger than the preferred
         # max bytes will result in a batch larger than preferred max bytes.
         PreferredMaxBytes: 512 KB
-
-    Kafka:
-        # Brokers: A list of Kafka brokers to which the orderer connects
-        # NOTE: Use IP:port notation
-        Brokers:
-            - 127.0.0.1:9092
 
     # Organizations is the list of orgs which are defined as participants on
     # the orderer side of the network
@@ -314,7 +315,7 @@ Organizations:
 ################################################################################
 Profiles:
 
-    ThreeOrgsOrdererGenesis:
+    ThreeOrgsApplicationGenesis:
         <<: *ChannelDefaults
         Orderer:
             <<: *OrdererDefaults
@@ -322,15 +323,6 @@ Profiles:
                 - *OrdererOrg
             Capabilities:
                 <<: *OrdererCapabilities
-        Consortiums:
-            SampleConsortium:
-                Organizations:
-                    - *Org1
-                    - *Org2
-                    - *Org3
-    ThreeOrgsChannel:
-        <<: *ChannelDefaults
-        Consortium: SampleConsortium
         Application:
             <<: *ApplicationDefaults
             Organizations:

--- a/scenario/fixtures/docker-compose/docker-compose-base.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-base.yaml
@@ -48,8 +48,6 @@ services:
     environment:
       - ORDERER_GENERAL_LOGLEVEL=${DOCKER_DEBUG}
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
-      - ORDERER_GENERAL_GENESISMETHOD=file
-      - ORDERER_GENERAL_GENESISFILE=/etc/hyperledger/configtx/genesis.block
       - ORDERER_GENERAL_LOCALMSPID=OrdererMSP
       - ORDERER_GENERAL_LOCALMSPDIR=/etc/hyperledger/orderer/msp
       - CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE=node_default
@@ -57,6 +55,7 @@ services:
     command: orderer
     ports:
       - 7050:7050
+      - 7053:7053
     volumes:
         - ../crypto-material/:/etc/hyperledger/configtx
         - ../crypto-material/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/:/etc/hyperledger/orderer

--- a/scenario/fixtures/docker-compose/docker-compose-tls.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-tls.yaml
@@ -46,6 +46,17 @@ services:
       - ORDERER_GENERAL_TLS_PRIVATEKEY=/etc/hyperledger/orderer/tls/server.key
       - ORDERER_GENERAL_TLS_CERTIFICATE=/etc/hyperledger/orderer/tls/server.crt
       - ORDERER_GENERAL_TLS_ROOTCAS=[/etc/hyperledger/orderer/tls/ca.crt, /etc/hyperledger/peerOrg1/tls/ca.crt, /etc/hyperledger/peerOrg2/tls/ca.crt]
+      - ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE=/etc/hyperledger/orderer/tls/server.crt
+      - ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY=/etc/hyperledger/orderer/tls/server.key
+      - ORDERER_GENERAL_CLUSTER_ROOTCAS=[/etc/hyperledger/orderer/tls/ca.crt]
+      - ORDERER_GENERAL_BOOTSTRAPMETHOD=none
+      - ORDERER_CHANNELPARTICIPATION_ENABLED=true
+      - ORDERER_ADMIN_TLS_ENABLED=true
+      - ORDERER_ADMIN_TLS_CERTIFICATE=/etc/hyperledger/orderer/tls/server.crt
+      - ORDERER_ADMIN_TLS_PRIVATEKEY=/etc/hyperledger/orderer/tls/server.key
+      - ORDERER_ADMIN_TLS_ROOTCAS=[/etc/hyperledger/orderer/tls/ca.crt]
+      - ORDERER_ADMIN_TLS_CLIENTROOTCAS=[/etc/hyperledger/orderer/tls/ca.crt]
+      - ORDERER_ADMIN_LISTENADDRESS=orderer.example.com:7053
 
   peer0.org1.example.com:
     extends:

--- a/scenario/fixtures/generate.sh
+++ b/scenario/fixtures/generate.sh
@@ -11,11 +11,7 @@ docker exec cli rm -rf /etc/hyperledger/config/channel.tx \
     /etc/hyperledger/config/mychannel.block \
     /etc/hyperledger/config/crypto-config
 docker exec cli cryptogen generate --config=/etc/hyperledger/config/crypto-config.yaml --output /etc/hyperledger/config/crypto-config
-docker exec cli configtxgen -profile ThreeOrgsOrdererGenesis -outputBlock /etc/hyperledger/config/genesis.block -channelID testchainid
-docker exec cli configtxgen -profile ThreeOrgsChannel -outputCreateChannelTx /etc/hyperledger/config/channel.tx -channelID mychannel
-docker exec cli configtxgen -profile ThreeOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org1MSPanchors.tx -channelID mychannel -asOrg Org1MSP
-docker exec cli configtxgen -profile ThreeOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org2MSPanchors.tx -channelID mychannel -asOrg Org2MSP
-docker exec cli configtxgen -profile ThreeOrgsChannel -outputAnchorPeersUpdate /etc/hyperledger/config/Org3MSPanchors.tx -channelID mychannel -asOrg Org3MSP
+docker exec cli configtxgen -profile ThreeOrgsApplicationGenesis -outputBlock /etc/hyperledger/config/mychannel.block -channelID mychannel
 docker exec cli cp /etc/hyperledger/fabric/core.yaml /etc/hyperledger/config
 docker exec cli sh /etc/hyperledger/config/rename_sk.sh
 docker-compose -f docker-compose-cli.yaml down --volumes

--- a/scenario/go/fabric_test.go
+++ b/scenario/go/fabric_test.go
@@ -23,26 +23,22 @@ const (
 )
 
 type orgConfig struct {
-	cli      string
-	anchortx string
-	peers    []string
+	cli   string
+	peers []string
 }
 
 var orgs = []orgConfig{
 	{
-		cli:      "org1_cli",
-		anchortx: "/etc/hyperledger/configtx/Org1MSPanchors.tx",
-		peers:    []string{"peer0.org1.example.com:7051", "peer1.org1.example.com:9051"},
+		cli:   "org1_cli",
+		peers: []string{"peer0.org1.example.com:7051", "peer1.org1.example.com:9051"},
 	},
 	{
-		cli:      "org2_cli",
-		anchortx: "/etc/hyperledger/configtx/Org2MSPanchors.tx",
-		peers:    []string{"peer0.org2.example.com:8051", "peer1.org2.example.com:10051"},
+		cli:   "org2_cli",
+		peers: []string{"peer0.org2.example.com:8051", "peer1.org2.example.com:10051"},
 	},
 	{
-		cli:      "org3_cli",
-		anchortx: "/etc/hyperledger/configtx/Org3MSPanchors.tx",
-		peers:    []string{"peer0.org3.example.com:11051"},
+		cli:   "org3_cli",
+		peers: []string{"peer0.org3.example.com:11051"},
 	},
 }
 
@@ -315,12 +311,14 @@ func createAndJoinChannels() error {
 	fmt.Println("createAndJoinChannels")
 	startAllPeers()
 	if !channelsJoined {
-		_, err := dockerCommandWithTLS(
-			"exec", "org1_cli", "peer", "channel", "create",
-			"-o", "orderer.example.com:7050",
-			"-c", "mychannel",
-			"-f", "/etc/hyperledger/configtx/channel.tx",
-			"--outputBlock", "/etc/hyperledger/configtx/mychannel.block",
+		_, err := dockerCommand(
+			"exec", "org1_cli", "osnadmin", "channel", "join",
+			"--channelID", "mychannel",
+			"--config-block", "/etc/hyperledger/configtx/mychannel.block",
+			"-o", "orderer.example.com:7053",
+			"--ca-file", "/etc/hyperledger/configtx/crypto-config/ordererOrganizations/example.com/tlsca/tlsca.example.com-cert.pem",
+			"--client-cert", "/etc/hyperledger/configtx/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt",
+			"--client-key", "/etc/hyperledger/configtx/crypto-config/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.key",
 		)
 		if err != nil {
 			return err
@@ -336,15 +334,6 @@ func createAndJoinChannels() error {
 				if err != nil {
 					return err
 				}
-			}
-			_, err = dockerCommandWithTLS(
-				"exec", org.cli, "peer", "channel", "update",
-				"-o", "orderer.example.com:7050",
-				"-c", "mychannel",
-				"-f", org.anchortx,
-			)
-			if err != nil {
-				return err
 			}
 		}
 


### PR DESCRIPTION
Update network config in scenario tests to use channel participation API and remove system channel, for compatability with future versions of Fabric.

Signed-off-by: andrew-coleman <andrew_coleman@uk.ibm.com>