### PR TITLE
Use ipv4 style for gRPC endpoint address in scenario tests

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
@@ -212,7 +212,7 @@ public interface Gateway extends AutoCloseable {
         Builder connection(Channel grpcChannel);
 
         /**
-         * Specifies the client identity used to connect to the network. All interactions will the Fabric network using
+         * Specifies the client identity used to connect to the network. All interactions with the Fabric network using
          * this Gateway will be performed by this identity.
          * @param identity An identity.
          * @return The builder instance, allowing multiple configuration options to be chained.

--- a/scenario/features/blockevents.feature
+++ b/scenario/features/blockevents.feature
@@ -9,7 +9,7 @@ Feature: Block event listening
         And I have created and joined all channels
         And I deploy golang chaincode named basic at version 1.0.0 for all organizations on channel mychannel with endorsement policy AND("Org1MSP.member","Org2MSP.member")
         And I create a gateway named mygateway for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the basic contract
 

--- a/scenario/features/chaincodeevents.feature
+++ b/scenario/features/chaincodeevents.feature
@@ -9,7 +9,7 @@ Feature: Chaincode event listening
         And I have created and joined all channels
         And I deploy golang chaincode named basic at version 1.0.0 for all organizations on channel mychannel with endorsement policy AND("Org1MSP.member","Org2MSP.member")
         And I create a gateway named mygateway for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the basic contract
 

--- a/scenario/features/discovery.feature
+++ b/scenario/features/discovery.feature
@@ -9,7 +9,7 @@ Feature: Discovery
         And I have created and joined all channels
         And I deploy golang chaincode named basic at version 1.0.0 for all organizations on channel mychannel with endorsement policy AND("Org1MSP.member", "Org2MSP.member", "Org3MSP.member")
         And I create a gateway named mygateway for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the basic contract
 

--- a/scenario/features/endorsement.feature
+++ b/scenario/features/endorsement.feature
@@ -9,7 +9,7 @@ Feature: Specify endorsing organizations
         And I have created and joined all channels
         And I deploy golang chaincode named private at version 1.0.0 for all organizations on channel mychannel with endorsement policy OR("Org1MSP.member","Org2MSP.member","Org3MSP.member")
         And I create a gateway named gateway1 for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the private contract
 

--- a/scenario/features/endorsement_hsm.feature
+++ b/scenario/features/endorsement_hsm.feature
@@ -11,7 +11,7 @@ Feature: Specify endorsing organizations using HSM managed identities
         And I deploy golang chaincode named private at version 1.0.0 for all organizations on channel mychannel with endorsement policy OR("Org1MSP.member","Org2MSP.member","Org3MSP.member")
         And I register and enroll an HSM user HSMUser1 in MSP Org1MSP
         And I create a gateway named hsmgateway1 for HSM user HSMUser1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the private contract
 

--- a/scenario/features/errors.feature
+++ b/scenario/features/errors.feature
@@ -9,7 +9,7 @@ Feature: Errors
         And I have created and joined all channels
         And I deploy node chaincode named errors at version 1.0.0 for all organizations on channel mychannel with endorsement policy AND("Org1MSP.member","Org2MSP.member","Org3MSP.member")
         And I create a gateway named mygateway for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the errors contract
 

--- a/scenario/features/offlinesign.feature
+++ b/scenario/features/offlinesign.feature
@@ -9,7 +9,7 @@ Feature: Off-line signing
         And I have created and joined all channels
         And I deploy golang chaincode named basic at version 1.0.0 for all organizations on channel mychannel with endorsement policy AND("Org1MSP.member","Org2MSP.member")
         And I create a gateway named mygateway without signer for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the basic contract
 

--- a/scenario/features/privatedata.feature
+++ b/scenario/features/privatedata.feature
@@ -9,11 +9,11 @@ Feature: Private data collections
         And I have created and joined all channels
         And I deploy golang chaincode named private at version 1.0.0 for all organizations on channel mychannel with endorsement policy OR("Org1MSP.member","Org2MSP.member","Org3MSP.member")
         And I create a gateway named gateway1 for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the private contract
         And I create a gateway named gateway2 for user User1 in MSP Org2MSP
-        And I connect the gateway to peer0.org2.example.com
+        And I connect the gateway to org2.example.com
         And I use the mychannel network
         And I use the private contract
         And I use the gateway named gateway1

--- a/scenario/features/sbe.feature
+++ b/scenario/features/sbe.feature
@@ -9,7 +9,7 @@ Feature: State-based endorsement
         And I have created and joined all channels
         And I deploy golang chaincode named private at version 1.0.0 for all organizations on channel mychannel with endorsement policy OR("Org1MSP.member","Org2MSP.member","Org3MSP.member")
         And I create a gateway named gateway1 for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the private contract
         And I prepare to submit a SetStateWithEndorser transaction

--- a/scenario/features/transactions.feature
+++ b/scenario/features/transactions.feature
@@ -9,7 +9,7 @@ Feature: Transaction invocation
         And I have created and joined all channels
         And I deploy golang chaincode named basic at version 1.0.0 for all organizations on channel mychannel with endorsement policy AND("Org1MSP.member","Org2MSP.member")
         And I create a gateway named mygateway for user User1 in MSP Org1MSP
-        And I connect the gateway to peer0.org1.example.com
+        And I connect the gateway to org1.example.com
         And I use the mychannel network
         And I use the basic contract
 

--- a/scenario/node/src/scenario_steps.ts
+++ b/scenario/node/src/scenario_steps.ts
@@ -84,8 +84,8 @@ Given('I use the gateway named {word}', function(this: CustomWorld, name: string
     this.useGateway(name);
 });
 
-Given('I connect the gateway to {word}', async function(this: CustomWorld, address: string): Promise<void> {
-    await this.connect(address);
+Given('I connect the gateway to {word}', async function(this: CustomWorld, org: string): Promise<void> {
+    await this.connect(org);
 });
 
 Given('I create a checkpointer', function(this: CustomWorld): void {


### PR DESCRIPTION
This allows the gRPC implementation to handle fail-over between Gateway peers.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>