### PR TITLE
Add make target to install required Go tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,13 @@ MARCH=$(shell go env GOOS)-$(shell go env GOARCH)
 GO_VER = 1.17.8
 GO_TAGS ?=
 
+.PHONEY: setup
+setup:
+	go install github.com/cucumber/godog/cmd/godog@v0.12
+	go install honnef.co/go/tools/cmd/staticcheck@latest
+	go install github.com/golang/mock/mockgen@v1.6
+	go install github.com/securego/gosec/v2/cmd/gosec@latest
+
 build: build-node build-java
 
 fabric_protos_commit = 9f95521bb870cca7b765217c80aeb600e0bd5abf

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ build these components, the following needs to be installed and available in the
 - Java 8
 - Docker
 - Make
-- Go tools:
-  - `go install github.com/cucumber/godog/cmd/godog@v0.12`
-  - `go install honnef.co/go/tools/cmd/staticcheck@latest`
-  - `go install github.com/golang/mock/mockgen@v1.6`
-  - `go install github.com/securego/gosec/v2/cmd/gosec@latest`
+
+Additional required tools are installed using the following Makefile target:
+
+- `make setup`
+
+In order to run any of the Hardware Security Module (HSM) tests, the following must also be installed:
+
 - pkcs11 enabled fabric-ca-client
   - `go get -tags 'pkcs11' github.com/hyperledger/fabric-ca/cmd/fabric-ca-client`
 - SoftHSM, which can either be:
@@ -46,7 +48,9 @@ build these components, the following needs to be installed and available in the
 
 ### Build using make
 
-The following Makefile targets are available
+> **Note:** When the repository is first cloned, some mock implementations used for testing will not be present and the Go code will show compile errors. These will be generated when the `unit-test` target is run, or can be generated explicitly by running `make generate`.
+
+The following Makefile targets are available:
 - `make generate` - generate mock implementations used by unit tests
 - `make unit-test-go` - run unit tests for the Go client API
 - `make unit-test-node` - run unit tests for the Node client API
@@ -59,10 +63,6 @@ The following Makefile targets are available
 - `make scenario-test` - run the scenario tests for all client language implementations
 - `make test` - run all unit and scenario tests
 
-Note that immediately after creating a fresh copy of this repository, auto-generated test mocks will not be preset so
-Go code will show errors. Running the `unit-test` make target will generate the required mock implementations, and they
-can also be generated explicitly by running `make generate`.
-
 ### Scenario tests
 
 The scenario tests create a Fabric network comprising two orgs (one peer in each org) and a single gateway within a set
@@ -73,4 +73,4 @@ is used across all three client language implementations to ensure consistency o
 
 ### Run Samples
 
-Refer [Fabric-Samples](https://github.com/hyperledger/fabric-samples) for sample applications developed using fabic-gateway.
+Refer to [Fabric-Samples](https://github.com/hyperledger/fabric-samples) for sample applications developed using fabic-gateway.

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -102,7 +102,6 @@ stages:
     timeoutInMinutes: 60
     steps:
     - template: install_deps.yml
-    - checkout: self
     - script: make generate-docs-node
       displayName: Generate Node docs
     - publish: $(System.DefaultWorkingDirectory)/node/apidocs
@@ -114,7 +113,6 @@ stages:
     timeoutInMinutes: 60
     steps:
     - template: install_deps.yml
-    - checkout: self
     - task: JavaToolInstaller@0
       inputs:
         versionSpec: 17
@@ -134,7 +132,6 @@ stages:
     timeoutInMinutes: 60
     steps:
     - template: install_deps_hsm.yml
-    - checkout: self
     - script: make generate unit-test-go-pkcs11
       displayName: Run Go unit tests with pkcs11
   - job: UnitTestNode
@@ -144,7 +141,6 @@ stages:
     timeoutInMinutes: 60
     steps:
     - template: install_deps.yml
-    - checkout: self
     - task: NodeTool@0
       inputs:
         versionSpec: $(NODEVER)
@@ -159,7 +155,6 @@ stages:
     timeoutInMinutes: 60
     steps:
     - template: install_deps.yml
-    - checkout: self
     - task: JavaToolInstaller@0
       inputs:
         versionSpec: $(JAVAVER)
@@ -179,7 +174,6 @@ stages:
     timeoutInMinutes: 60
     steps:
     - template: install_deps_hsm_ca.yml
-    - checkout: self
     - script: make pull-latest-peer scenario-test-go
       displayName: Run Go SDK scenario tests
       env:
@@ -199,7 +193,6 @@ stages:
           NODEVER: 16.x
     steps:
     - template: install_deps_hsm_ca.yml
-    - checkout: self
     - task: NodeTool@0
       inputs:
         versionSpec: $(NODEVER)
@@ -226,7 +219,6 @@ stages:
           JAVAVER: 17
     steps:
       - template: install_deps.yml
-      - checkout: self
       - task: JavaToolInstaller@0
         inputs:
           versionSpec: $(JAVAVER)

--- a/ci/install_deps.yml
+++ b/ci/install_deps.yml
@@ -8,15 +8,12 @@ steps:
       sudo apt-get update
       echo "vsts  hard  nofile  65535" | sudo tee -a /etc/security/limits.conf
       echo "vsts  soft  nofile  65535" | sudo tee -a /etc/security/limits.conf
-    displayName: Install Dependencies
+    displayName: Configure environment
   - task: GoTool@0
     inputs:
       version: $(GOVER)
       goPath:  $(GOPATH)
     displayName: Install Go $(GOVER)
-  - script: |
-      go install github.com/cucumber/godog/cmd/godog@v0.12
-      go install honnef.co/go/tools/cmd/staticcheck@latest
-      go install github.com/golang/mock/mockgen@v1.6
-      go install github.com/securego/gosec/v2/cmd/gosec@latest
-    displayName: Install Go tools
+  - checkout: self
+  - script: make setup
+    displayName: Install tools


### PR DESCRIPTION
Previously this was coded into the Azure Pipelines build script, and also documented for manual set up in the README.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>