### PR TITLE
Tidy-up Java dependencies

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,6 +39,7 @@
         <grpcVersion>1.47.0</grpcVersion>
         <protobufVersion>3.19.2</protobufVersion> <!-- keep in step with the version used by io.grpc:grpc-protobuf -->
         <enforceJavaVersion>1.8</enforceJavaVersion> <!-- this is overridden in the release profile -->
+        <bouncyCastleVersion>1.71</bouncyCastleVersion>
     </properties>
 
     <repositories>
@@ -59,7 +60,7 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.3.4</version>
+                <version>7.4.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -90,17 +91,13 @@
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-params</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -131,21 +128,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.1.4</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish</groupId>
-            <artifactId>javax.json</artifactId>
-            <version>1.1.4</version>
-            <scope>test</scope>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>${bouncyCastleVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
-            <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.70</version>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>${bouncyCastleVersion}</version>
         </dependency>
         <dependency> <!-- Necessary for Java 9+, according to https://github.com/grpc/grpc-java#readme -->
             <groupId>org.apache.tomcat</groupId>
@@ -321,6 +311,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.3.0</version>
             </plugin>
         </plugins>
     </build>

--- a/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
@@ -6,12 +6,13 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.function.UnaryOperator;
-
 import io.grpc.CallOptions;
 import io.grpc.Channel;
 import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.client.identity.Signer;
+
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
 
 /**
  * The Gateway provides the connection point for an application to access the Fabric network as a specific user. It is
@@ -231,7 +232,7 @@ public interface Gateway extends AutoCloseable {
          * @param hash A hashing function.
          * @return The builder instance, allowing multiple configuration options to be chained.
          */
-        Builder hash(UnaryOperator<byte[]> hash);
+        Builder hash(Function<byte[], byte[]> hash);
 
         /**
          * Specify the default call options for evaluating transactions.

--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayImpl.java
@@ -6,9 +6,6 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.Objects;
-import java.util.function.UnaryOperator;
-
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.CallOptions;
 import io.grpc.Channel;
@@ -23,6 +20,10 @@ import org.hyperledger.fabric.protos.gateway.ProposedTransaction;
 import org.hyperledger.fabric.protos.gateway.SignedChaincodeEventsRequest;
 import org.hyperledger.fabric.protos.gateway.SignedCommitStatusRequest;
 
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+
 final class GatewayImpl implements Gateway {
     public static final class Builder implements Gateway.Builder {
         private static final Signer UNDEFINED_SIGNER = (digest) -> {
@@ -32,7 +33,7 @@ final class GatewayImpl implements Gateway {
         private Channel grpcChannel;
         private Identity identity;
         private Signer signer = UNDEFINED_SIGNER; // No signer implementation is required if only offline signing is used
-        private UnaryOperator<byte[]> hash = Hash::sha256;
+        private Function<byte[], byte[]> hash = Hash::sha256;
         private final DefaultCallOptions.Builder optionsBuilder = DefaultCallOptions.newBuiler();
 
         @Override
@@ -57,7 +58,7 @@ final class GatewayImpl implements Gateway {
         }
 
         @Override
-        public Builder hash(final UnaryOperator<byte[]> hash) {
+        public Builder hash(final Function<byte[], byte[]> hash) {
             Objects.requireNonNull(hash, "hash");
             this.hash = hash;
             return this;

--- a/java/src/main/java/org/hyperledger/fabric/client/SigningIdentity.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/SigningIdentity.java
@@ -6,19 +6,19 @@
 
 package org.hyperledger.fabric.client;
 
-import java.security.GeneralSecurityException;
-import java.util.function.UnaryOperator;
-
 import org.hyperledger.fabric.client.identity.Identity;
 import org.hyperledger.fabric.client.identity.Signer;
 
+import java.security.GeneralSecurityException;
+import java.util.function.Function;
+
 final class SigningIdentity {
     private final Identity identity;
-    private final UnaryOperator<byte[]> hash;
+    private final Function<byte[], byte[]> hash;
     private final Signer signer;
     private final byte[] creator;
 
-    SigningIdentity(final Identity identity, final UnaryOperator<byte[]> hash, final Signer signer) {
+    SigningIdentity(final Identity identity, final Function<byte[], byte[]> hash, final Signer signer) {
         this.identity = identity;
         this.hash = hash;
         this.signer = signer;

--- a/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/EvaluateTransactionTest.java
@@ -6,15 +6,6 @@
 
 package org.hyperledger.fabric.client;
 
-import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import io.grpc.CallOptions;
@@ -29,12 +20,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.entry;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 public final class EvaluateTransactionTest {
     private static final TestUtils utils = TestUtils.getInstance();
@@ -164,8 +160,8 @@ public final class EvaluateTransactionTest {
     @Test
     void uses_hash() throws GatewayException {
         AtomicReference<String> actual = new AtomicReference<>();
-        UnaryOperator<byte[]> hash = (message) -> "MY_DIGEST".getBytes(StandardCharsets.UTF_8);
-        Signer signer = (digest) -> {
+        Function<byte[], byte[]> hash = message -> "MY_DIGEST".getBytes(StandardCharsets.UTF_8);
+        Signer signer = digest -> {
             actual.set(new String(digest, StandardCharsets.UTF_8));
             return "SIGNATURE".getBytes(StandardCharsets.UTF_8);
         };

--- a/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
@@ -6,16 +6,6 @@
 
 package org.hyperledger.fabric.client;
 
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-import java.util.function.UnaryOperator;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import com.google.protobuf.ByteString;
 import io.grpc.CallOptions;
 import io.grpc.Deadline;
@@ -32,10 +22,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.Assertions.catchThrowableOfType;
-import static org.assertj.core.api.Assertions.entry;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
@@ -300,8 +297,8 @@ public final class SubmitTransactionTest {
     @Test
     void uses_hash() throws Exception {
         List<String> actual = new ArrayList<>();
-        UnaryOperator<byte[]> hash = (message) -> "MY_DIGEST".getBytes(StandardCharsets.UTF_8);
-        Signer signer = (digest) -> {
+        Function<byte[], byte[]> hash = message -> "MY_DIGEST".getBytes(StandardCharsets.UTF_8);
+        Signer signer = digest -> {
             actual.add(new String(digest, StandardCharsets.UTF_8));
             return "SIGNATURE".getBytes(StandardCharsets.UTF_8);
         };


### PR DESCRIPTION
Includes removing using of javax.json in scenario test code and standardising all JSON manipulation on Gson, which is used in the implementation code.
    
Also revert a change to the signature for the hash function to ensure compatibility.