### PR TITLE
Use preferred command-line options for Node security scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ scan-go:
 scan-node:
 	cd "$(node_dir)" && \
 		npm install --package-lock-only && \
-		npm audit --production
+		npm audit --omit=dev
 
 .PHONEY: scan-java
 scan-java:


### PR DESCRIPTION
The `--production` option to `npm audit` generates a warning. `--omit=dev` is the current recommendation.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>