### PR TITLE
Support Go 1.19

### DIFF
--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -35,7 +35,7 @@ variables:
   - name: PATH
     value: $(Agent.BuildDirectory)/go/bin:/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/usr/local/sbin
   - name: GOVER
-    value: 1.17.8
+    value: 1.17
   - name: NODEVER
     value: 14.x
   - name: JAVAVER
@@ -132,6 +132,14 @@ stages:
       vmImage: ubuntu-20.04
     dependsOn: []
     timeoutInMinutes: 60
+    strategy:
+      matrix:
+        go1.17:
+          GOVER: 1.17
+        go1.18:
+          GOVER: 1.18
+        go1.19:
+          GOVER: 1.19
     steps:
     - template: install_deps_hsm.yml
     - checkout: self
@@ -177,6 +185,14 @@ stages:
       vmImage: ubuntu-20.04
     dependsOn: []
     timeoutInMinutes: 60
+    strategy:
+      matrix:
+        go1.17:
+          GOVER: 1.17
+        go1.18:
+          GOVER: 1.18
+        go1.19:
+          GOVER: 1.19
     steps:
     - template: install_deps_hsm_ca.yml
     - checkout: self

--- a/pkg/client/contract.go
+++ b/pkg/client/contract.go
@@ -52,7 +52,7 @@ func (contract *Contract) ContractName() string {
 //
 // This method is equivalent to:
 //
-//     contract.Evaluate(name, WithArguments(args...))
+//	contract.Evaluate(name, WithArguments(args...))
 func (contract *Contract) EvaluateTransaction(name string, args ...string) ([]byte, error) {
 	return contract.Evaluate(name, WithArguments(args...))
 }
@@ -78,7 +78,7 @@ func (contract *Contract) Evaluate(transactionName string, options ...ProposalOp
 //
 // This method is equivalent to:
 //
-//     contract.Submit(name, client.WithArguments(args...))
+//	contract.Submit(name, client.WithArguments(args...))
 func (contract *Contract) SubmitTransaction(name string, args ...string) ([]byte, error) {
 	return contract.Submit(name, WithArguments(args...))
 }

--- a/pkg/client/example_test.go
+++ b/pkg/client/example_test.go
@@ -8,7 +8,7 @@ package client_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
 	"github.com/hyperledger/fabric-gateway/pkg/identity"
@@ -56,7 +56,7 @@ func Example() {
 
 // NewIdentity creates a client identity for this Gateway connection using an X.509 certificate.
 func NewIdentity() *identity.X509Identity {
-	certificatePEM, err := ioutil.ReadFile("certificate.pem")
+	certificatePEM, err := os.ReadFile("certificate.pem")
 	if err != nil {
 		panic(err)
 	}
@@ -76,7 +76,7 @@ func NewIdentity() *identity.X509Identity {
 
 // NewSign creates a function that generates a digital signature from a message digest using a private key.
 func NewSign() identity.Sign {
-	privateKeyPEM, err := ioutil.ReadFile("privateKey.pem")
+	privateKeyPEM, err := os.ReadFile("privateKey.pem")
 	if err != nil {
 		panic(err)
 	}

--- a/scenario/go/connection_test.go
+++ b/scenario/go/connection_test.go
@@ -15,7 +15,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/hyperledger/fabric-gateway/pkg/client"
@@ -122,7 +121,7 @@ func NewGatewayConnectionWithHSMSigner(user string, mspID string) (*GatewayConne
 }
 
 func newIdentity(mspID string, certPath string) (*identity.X509Identity, error) {
-	certificatePEM, err := ioutil.ReadFile(certPath)
+	certificatePEM, err := os.ReadFile(certPath)
 	if err != nil {
 		return nil, err
 	}
@@ -136,7 +135,7 @@ func newIdentity(mspID string, certPath string) (*identity.X509Identity, error) 
 }
 
 func NewSign(keyPath string) (identity.Sign, error) {
-	privateKeyPEM, err := ioutil.ReadFile(keyPath)
+	privateKeyPEM, err := os.ReadFile(keyPath)
 	if err != nil {
 		return nil, err
 	}
@@ -162,7 +161,7 @@ func NewHSMSigner(user string) (identity.Sign, identity.HSMSignClose, error) {
 		}
 	}
 
-	certificatePEM, err := ioutil.ReadFile(hsmCertificatePath(user, ""))
+	certificatePEM, err := os.ReadFile(hsmCertificatePath(user, ""))
 	if err != nil {
 		return nil, nil, err
 	}

--- a/scenario/go/scenario_test.go
+++ b/scenario/go/scenario_test.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"strconv"
@@ -202,7 +201,7 @@ func useGateway(name string) error {
 }
 
 func loadX509Cert(certFile string) (*x509.Certificate, error) {
-	cf, e := ioutil.ReadFile(certFile)
+	cf, e := os.ReadFile(certFile)
 	if e != nil {
 		return nil, e
 	}


### PR DESCRIPTION
Just allows the main branch to be developed using Go 1.19. Support for Go 1.17 to be removed later, once a new minor version release is ready.