### PR TITLE
Update scenario test PEER_IMAGE_TAG to 3.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ PEER_IMAGE_PULL ?= hyperledger-fabric.jfrog.io/fabric-peer:amd64-latest
 
 # PEER_IMAGE_TAG is what to tag the pulled peer image as, it will also be used in docker-compose to reference the image
 # In fabric-gateway main branch this version tag should correspond to the version in the fabric main branch
-PEER_IMAGE_TAG ?= 2.5
+PEER_IMAGE_TAG ?= 3.0
 
 # TWO_DIGIT_VERSION specifies which chaincode images to pull, they will be tagged to be consistent with PEER_IMAGE_TAG
 # In fabric-gateway main branch it should typically be the latest released chaincode version available in dockerhub.

--- a/scenario/fixtures/docker-compose/.env
+++ b/scenario/fixtures/docker-compose/.env
@@ -2,7 +2,7 @@
 # Typically we'll want to test with the latest released orderer and tools images from dockerhub, but latest unreleased peer image that has been pulled and tagged
 ORDERER_IMAGE_TAG=2.4
 TOOLS_IMAGE_TAG=2.4
-PEER_IMAGE_TAG=2.5
+PEER_IMAGE_TAG=3.0
 FABRIC_CA_IMAGE_TAG=1.5
 COUCHDB_IMAGE_TAG=3.1.1
 DOCKER_DEBUG=info:dockercontroller,gateway=debug


### PR DESCRIPTION
Scenario tests utilize latest peer image pushed to hyperledger-fabric.jfrog.io/fabric-peer:amd64-latest. Currently this is version 3.0.
Update PEER_IMAGE_TAG to 3.0, this will also be used as the tag for the chaincode images (peer 3.0 will look for chaincode images 3.0).

Signed-off-by: David Enyeart <enyeart@us.ibm.com>