### PR TITLE
CI: Use ubuntu-22.04 at pipelines

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   go:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -18,7 +18,7 @@ jobs:
         run: make scan-go
 
   node:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js
@@ -29,7 +29,7 @@ jobs:
         run: make scan-node
 
   java:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
       - name: Set up Java

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -46,7 +46,7 @@ stages:
   jobs:
   - job: VerifyNodeModuleVersion
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     steps:
       - checkout: self
@@ -61,7 +61,7 @@ stages:
           GATEWAY_VERSION: $(GATEWAY_VERSION)
   - job: VerifyJavaArtifactVersion
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     steps:
       - checkout: self
@@ -77,7 +77,7 @@ stages:
   # The Go module version is the git tag
   - job: VerifyGoModuleVersion
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     condition: startsWith(variables['Build.SourceBranch'], 'refs/tags')
     steps:
@@ -97,7 +97,7 @@ stages:
   jobs:
   - job: GenerateNodeDocs
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     steps:
@@ -109,7 +109,7 @@ stages:
       artifact: NodeDocs
   - job: GenerateJavaDocs
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     steps:
@@ -129,7 +129,7 @@ stages:
   jobs:
   - job: UnitTestGo
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     strategy:
@@ -147,7 +147,7 @@ stages:
       displayName: Run Go unit tests with pkcs11
   - job: UnitTestNode
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     steps:
@@ -162,7 +162,7 @@ stages:
       artifact: NodeBuild
   - job: UnitTestJava
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     steps:
@@ -182,7 +182,7 @@ stages:
 
   - job: ScenarioTestGo
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     strategy:
@@ -201,7 +201,7 @@ stages:
 
   - job: ScenarioTestNode
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     strategy:
@@ -221,7 +221,7 @@ stages:
 
   - job: ScenarioTestJava
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     dependsOn: []
     timeoutInMinutes: 60
     strategy:
@@ -250,7 +250,7 @@ stages:
   jobs:
   - job: PublishDocs
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
     - checkout: self
     - script: |
@@ -280,7 +280,7 @@ stages:
       displayName: 'Update gh-pages branch'
   - job: PublishNode
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
       - download: current
         artifact: NodeBuild
@@ -329,7 +329,7 @@ stages:
           BUILD_NUMBER: $(BUILD_NUMBER)
   - job: PublishJava
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
     steps:
       - task: JavaToolInstaller@0
         inputs:


### PR DESCRIPTION
The CI pipeline currently uses Ubuntu 20.04. Ubuntu 22.04.1 LTS was released in August 2022, and became a recommended release for server deployments.

This PR change the Ubuntu version used by pipelines, should complete https://github.com/hyperledger/fabric-gateway/issues/484