### PR TITLE
Ensure all vulnerability checks run regardless of failures

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -7,6 +7,12 @@ on:
 jobs:
   go:
     runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - govulncheck
+          - nancy
     steps:
       - uses: actions/checkout@v3
       - name: Set up Go
@@ -15,7 +21,7 @@ jobs:
           go-version: 1.19
           check-latest: true
       - name: Scan
-        run: make scan-go
+        run: make scan-go-${{ matrix.target }}
 
   node:
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -23,13 +23,6 @@ PEER_IMAGE_TAG ?= 2.5
 # In fabric-gateway main branch it should typically be the latest released chaincode version available in dockerhub.
 TWO_DIGIT_VERSION ?= 2.4
 
-PKGNAME = github.com/hyperledger/fabric-gateway
-ARCH=$(shell go env GOARCH)
-MARCH=$(shell go env GOOS)-$(shell go env GOARCH)
-
-GO_VER = 1.17.8
-GO_TAGS ?=
-
 .PHONEY: build
 build: build-node build-java
 
@@ -80,10 +73,16 @@ lint:
 scan: scan-go scan-node scan-java
 
 .PHONEY: scan-go
-scan-go:
-	go list -json -deps "$(go_dir)/..." | docker run --rm --interactive sonatypecommunity/nancy:latest sleuth
+scan-go: scan-go-govulncheck scan-go-nancy
+
+.PHONEY: scan-go-govulncheck
+scan-go-govulncheck:
 	go install golang.org/x/vuln/cmd/govulncheck@latest
 	govulncheck "$(go_dir)/..."
+
+.PHONEY: scan-go-nancy
+scan-go-nancy:
+	go list -json -deps "$(go_dir)/..." | docker run --rm --interactive sonatypecommunity/nancy:latest sleuth
 
 .PHONEY: scan-node
 scan-node:


### PR DESCRIPTION
The Go scan uses two scanning tools and a failure of the first would stop the second running. Split them into separate Makefile targets and run them as a matrix with fail-fast disabled.