### PR TITLE
Use nancy directly as a Go tool to avoid Docker dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ scan-go-govulncheck:
 
 .PHONEY: scan-go-nancy
 scan-go-nancy:
-	go list -json -deps "$(go_dir)/..." | docker run --rm --interactive sonatypecommunity/nancy:latest sleuth
+	go install github.com/sonatype-nexus-community/nancy@latest
+	go list -json -deps "$(go_dir)/..." | nancy sleuth
 
 .PHONEY: scan-node
 scan-node:


### PR DESCRIPTION
Initially the Docker approach was attractive as it kept a nice separation of the nancy environment used to do Go code vulnerability scans. The build uses lots of Go tools directly already so it seems simpler to do the same with nancy too. This should make it easier to use a local exclude file checked into the repository if necessary, make it easier to keep the nancy version up-to-date, and remove the need for Docker outside of the scenario tests.