### PR TITLE
Update Node dependencies

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -29,7 +29,7 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
-        "@hyperledger/fabric-protos": "^0.1.0-dev.2300102001.1",
+        "@hyperledger/fabric-protos": "^0.1.5",
         "asn1.js": "^5.4.1",
         "elliptic": "^6.5.4"
     },
@@ -40,17 +40,17 @@
         "@tsconfig/node14": "^1.0.1",
         "@types/elliptic": "^6.4.14",
         "@types/google-protobuf": "^3.15.5",
-        "@types/jest": "^28.1.0",
+        "@types/jest": "^29.2.0",
         "@types/node": "^14.17.32",
         "@typescript-eslint/eslint-plugin": "^5.3.0",
         "@typescript-eslint/parser": "^5.3.0",
         "eslint": "^8.1.0",
-        "eslint-plugin-jest": "^26.1.0",
+        "eslint-plugin-jest": "^27.1.3",
         "eslint-plugin-tsdoc": "^0.2.14",
-        "jest": "^28.1.0",
+        "jest": "^29.2.1",
         "npm-run-all": "^4.1.5",
-        "ts-jest": "^28.0.2",
+        "ts-jest": "^29.0.3",
         "typedoc": "^0.23.2",
-        "typescript": "~4.7.2"
+        "typescript": "~4.8.4"
     }
 }

--- a/node/src/blockevents.test.ts
+++ b/node/src/blockevents.test.ts
@@ -438,7 +438,7 @@ describe('Block Events', () => {
             const events = await testCase.getEvents();
             events.close();
 
-            expect(stream.cancel).toBeCalled();
+            expect(stream.cancel).toHaveBeenCalled();
         });
     }));
 });

--- a/node/src/chaincodeevents.test.ts
+++ b/node/src/chaincodeevents.test.ts
@@ -354,7 +354,7 @@ describe('Chaincode Events', () => {
             const events = await network.getChaincodeEvents('CHAINCODE');
             events.close();
 
-            expect(responseStream.cancel).toBeCalled();
+            expect(responseStream.cancel).toHaveBeenCalled();
         });
 
         it('throws GatewayError on call ServiceError', async () => {

--- a/node/src/identity/hsmsigner.test.ts
+++ b/node/src/identity/hsmsigner.test.ts
@@ -107,10 +107,10 @@ describe('when creating or disposing of an HSM Signer Factory', () => {
     it('throws if library option is not valid', () => {
         pkcs11Stub.C_Initialize = () => { throw new Error('Some Error'); };
         expect(() => newHSMSignerFactory('somelibrary'))
-            .toThrowError('Some Error');
+            .toThrow('Some Error');
 
         expect(() => newHSMSignerFactory(''))
-            .toThrowError('library must be provided');
+            .toThrow('library must be provided');
     });
 
     it('can be disposed', () => {
@@ -155,44 +155,44 @@ describe('When using an HSM Signer', () => {
         };
 
         expect(() => hsmSignerFactory.newSigner(badHSMOptions))
-            .toThrowError('label property must be provided');
+            .toThrow('label property must be provided');
 
         badHSMOptions.label = 'ForFabric';
         badHSMOptions.pin = '';
         expect(() => hsmSignerFactory.newSigner(badHSMOptions))
-            .toThrowError('pin property must be provided');
+            .toThrow('pin property must be provided');
 
         badHSMOptions.pin = '98765432';
         badHSMOptions.identifier = '';
         expect(() => hsmSignerFactory.newSigner(badHSMOptions))
-            .toThrowError('identifier property must be provided');
+            .toThrow('identifier property must be provided');
 
         const noLabelOptions = {
             pin: '98765432',
             identifier: 'id'
         };
         expect(() => hsmSignerFactory.newSigner(noLabelOptions as HSMSignerOptions))
-            .toThrowError('label property must be provided');
+            .toThrow('label property must be provided');
 
         const noPinOptions = {
             label: 'ForFabric',
             identifier: 'id'
         };
         expect(() => hsmSignerFactory.newSigner(noPinOptions as HSMSignerOptions))
-            .toThrowError('pin property must be provided');
+            .toThrow('pin property must be provided');
 
         const noIdentifierOptions = {
             label: 'ForFabric',
             pin: '98765432'
         };
         expect(() => hsmSignerFactory.newSigner(noIdentifierOptions as HSMSignerOptions))
-            .toThrowError('identifier property must be provided');
+            .toThrow('identifier property must be provided');
     });
 
     it('throws an error if no slots are returned', () => {
         pkcs11Stub.C_GetSlotList = () => [];
         expect(() => hsmSignerFactory.newSigner(hsmOptions))
-            .toThrowError('No pkcs11 slots can be found');
+            .toThrow('No pkcs11 slots can be found');
     });
 
     it('throws an error if label cannot be found and there are slots', () => {
@@ -203,21 +203,21 @@ describe('When using an HSM Signer', () => {
         };
 
         expect(() => hsmSignerFactory.newSigner(badHSMOptions))
-            .toThrowError('label someunknownlabel cannot be found in the pkcs11 slot list');
+            .toThrow('label someunknownlabel cannot be found in the pkcs11 slot list');
     });
 
     it('finds the correct slot when the correct label is available', () => {
         pkcs11Stub.C_OpenSession = jest.fn();
         expect(() => hsmSignerFactory.newSigner(hsmOptions))
             .not.toThrow();
-        expect(pkcs11Stub.C_OpenSession).toBeCalledWith(slot1, CKF_SERIAL_SESSION);
+        expect(pkcs11Stub.C_OpenSession).toHaveBeenCalledWith(slot1, CKF_SERIAL_SESSION);
     });
 
     it('defaults to a CKU_USER if none provided', () => {
         pkcs11Stub.C_Login = jest.fn();
         expect(() => hsmSignerFactory.newSigner(hsmOptions))
             .not.toThrow();
-        expect(pkcs11Stub.C_Login).toBeCalledWith(mockSession, CKU_USER, hsmOptions.pin);
+        expect(pkcs11Stub.C_Login).toHaveBeenCalledWith(mockSession, CKU_USER, hsmOptions.pin);
     });
 
     it('uses usertype if provided', () => {
@@ -231,13 +231,13 @@ describe('When using an HSM Signer', () => {
         pkcs11Stub.C_Login = jest.fn();
         expect(() => hsmSignerFactory.newSigner(hsmOptionsWithUserType))
             .not.toThrow();
-        expect(pkcs11Stub.C_Login).toBeCalledWith(mockSession, hsmOptionsWithUserType.userType, hsmOptions.pin);
+        expect(pkcs11Stub.C_Login).toHaveBeenCalledWith(mockSession, hsmOptionsWithUserType.userType, hsmOptions.pin);
     });
 
     it('throws if pkcs11 open session throws an error', () => {
         pkcs11Stub.C_OpenSession = () => { throw new Error('Some Error'); };
         expect(() => hsmSignerFactory.newSigner(hsmOptions))
-            .toThrowError('Some Error');
+            .toThrow('Some Error');
     });
 
     it('throws if pkcs11 login throws an error', () => {
@@ -245,8 +245,8 @@ describe('When using an HSM Signer', () => {
         pkcs11Stub.C_CloseSession = jest.fn();
         pkcs11Stub.C_GetSlotList = () => [slot1, slot2];
         expect(() => hsmSignerFactory.newSigner(hsmOptions))
-            .toThrowError('Some Error');
-        expect(pkcs11Stub.C_CloseSession).toBeCalledWith(mockSession);
+            .toThrow('Some Error');
+        expect(pkcs11Stub.C_CloseSession).toHaveBeenCalledWith(mockSession);
     });
 
     it('Ignores already logged in errors at login time', () => {
@@ -261,16 +261,16 @@ describe('When using an HSM Signer', () => {
         pkcs11Stub.C_Login = () => { throw alreadyLoggedInError; };
         expect(() => hsmSignerFactory.newSigner(hsmOptions))
             .not.toThrow();
-        expect(pkcs11Stub.C_CloseSession).not.toBeCalled();
+        expect(pkcs11Stub.C_CloseSession).not.toHaveBeenCalled();
     });
 
     it('throws and calls find final if it cannot find the HSM object', () => {
         pkcs11Stub.C_CloseSession = jest.fn();
         pkcs11Stub.C_FindObjects = jest.fn(() => { return []; });
         expect(() => hsmSignerFactory.newSigner(hsmOptions))
-            .toThrowError('Unable to find object in HSM with ID id');
-        expect(pkcs11Stub.C_FindObjectsFinal).toBeCalled();
-        expect(pkcs11Stub.C_CloseSession).toBeCalledWith(mockSession);
+            .toThrow('Unable to find object in HSM with ID id');
+        expect(pkcs11Stub.C_FindObjectsFinal).toHaveBeenCalled();
+        expect(pkcs11Stub.C_CloseSession).toHaveBeenCalledWith(mockSession);
     });
 
     it('finds the HSM object if it exists', () => {
@@ -283,9 +283,9 @@ describe('When using an HSM Signer', () => {
             { type: CKA_KEY_TYPE, value: CKK_EC },
         ];
 
-        expect(pkcs11Stub.C_FindObjectsInit).toBeCalledWith(mockSession, expect.arrayContaining(expectedTemplate));
-        expect(pkcs11Stub.C_FindObjects).toBeCalledWith(mockSession, 1);
-        expect(pkcs11Stub.C_FindObjects).toBeCalledWith(mockSession, 1);
+        expect(pkcs11Stub.C_FindObjectsInit).toHaveBeenCalledWith(mockSession, expect.arrayContaining(expectedTemplate));
+        expect(pkcs11Stub.C_FindObjects).toHaveBeenCalledWith(mockSession, 1);
+        expect(pkcs11Stub.C_FindObjects).toHaveBeenCalledWith(mockSession, 1);
     });
 
     it('signs using the HSM', async () => {
@@ -298,8 +298,8 @@ describe('When using an HSM Signer', () => {
         const signed = await signer(digest);
         expect(signed).toEqual(new Uint8Array(Buffer.from(DERSignature, 'hex')));
 
-        expect(pkcs11Stub.C_SignInit).toBeCalledWith(mockSession, { mechanism: CKM_ECDSA }, mockPrivateKeyHandle);
-        expect(pkcs11Stub.C_Sign).toBeCalledWith(mockSession, digest, expect.anything());
+        expect(pkcs11Stub.C_SignInit).toHaveBeenCalledWith(mockSession, { mechanism: CKM_ECDSA }, mockPrivateKeyHandle);
+        expect(pkcs11Stub.C_Sign).toHaveBeenCalledWith(mockSession, digest, expect.anything());
     });
 
     it('can be closed', () => {

--- a/node/src/identity/signers.test.ts
+++ b/node/src/identity/signers.test.ts
@@ -11,14 +11,14 @@ describe('signers', () => {
     it('throws for public key', () => {
         const { publicKey } = generateKeyPairSync('ec', { namedCurve: 'P-256' });
         expect(() => newPrivateKeySigner(publicKey))
-            .toThrowError(publicKey.type);
+            .toThrow(publicKey.type);
     });
 
     it('throws for unsupported private key type', () => {
         const { privateKey } = generateKeyPairSync('dsa', { modulusLength: 2048, divisorLength: 256 });
 
         expect(() => newPrivateKeySigner(privateKey))
-            .toThrowError(privateKey.asymmetricKeyType);
+            .toThrow(privateKey.asymmetricKeyType);
     });
 
     describe('EC', () => {
@@ -49,7 +49,7 @@ describe('signers', () => {
         it('throws for unsupported curve', () => {
             const { privateKey } = generateKeyPairSync('ec', { namedCurve: 'secp256k1' });
             expect(() => newPrivateKeySigner(privateKey))
-                .toThrowError('1.3.132.0.10');
+                .toThrow('1.3.132.0.10');
         });
     });
 });

--- a/node/src/signingidentity.test.ts
+++ b/node/src/signingidentity.test.ts
@@ -79,7 +79,7 @@ describe('SigningIdentity', () => {
             const signingIdentity = new SigningIdentity({ identity });
             const digest = Buffer.from('DIGEST');
 
-            await expect(signingIdentity.sign(digest)).rejects.toThrowError();
+            await expect(signingIdentity.sign(digest)).rejects.toThrow();
         });
 
         it('uses supplied signer', async () => {


### PR DESCRIPTION
Includes a TypeScript version update, and matching the fabric-protos versions used by Go and Java implementations. Minor changes to test code are required to satisfy new ESLint Jest rules.