### PR TITLE
Require Go gRPC client connection interface for Gateway connect

### DIFF
--- a/pkg/client/gateway.go
+++ b/pkg/client/gateway.go
@@ -97,7 +97,7 @@ func WithHash(hash hash.Hash) ConnectOption {
 // WithClientConnection uses the supplied gRPC client connection to a Fabric Gateway. This should be shared by all
 // Gateway instances connecting to the same Fabric Gateway. The client connection will not be closed when the Gateway
 // is closed.
-func WithClientConnection(clientConnection *grpc.ClientConn) ConnectOption {
+func WithClientConnection(clientConnection grpc.ClientConnInterface) ConnectOption {
 	return func(gw *Gateway) error {
 		gw.client.grpcGatewayClient = gateway.NewGatewayClient(clientConnection)
 		gw.client.grpcDeliverClient = peer.NewDeliverClient(clientConnection)


### PR DESCRIPTION
The code previously required the concrete client connection type, which is likely a hang-over from early development of the API where Gateway instances might call Close() on the concrete type. The current design deliberately leaves management of the gRPC connection to the caller so only requires the client connection interface used by gRPC service stubs. This is a non-breaking change since the interface is a subset of the methods provided by the concrete type.