### PR TITLE
Update GitHub Actions actions/checkout to avoid warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,12 @@ name: "CodeQL"
 
 on:
   # push:
-  #   branches: ["main"]
+  #   branches:
+  #     - main
   # pull_request:
   #   # The branches below must be a subset of the branches above
-  #   branches: ["main"]
+  #   branches:
+  #     - main
   schedule:
     - cron: "15 23 * * *"
 
@@ -32,13 +34,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ["go", "java", "javascript"]
+        language:
+          - go
+          - java
+          - javascript
         # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
         # Learn more about CodeQL language support at https://git.io/codeql-language-support
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
CodeQL scan used actions/checkout@v2, which produces build warnings. Updated to actions/checkout@v3.

Signed-off-by: Mark S. Lewis <mark_lewis@uk.ibm.com>