### PR TITLE
Use SHA256 to hash salted creator bytes for transaction ID

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/TransactionContext.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/TransactionContext.java
@@ -6,12 +6,12 @@
 
 package org.hyperledger.fabric.client;
 
-import java.nio.charset.StandardCharsets;
-import java.security.SecureRandom;
-
 import com.google.protobuf.ByteString;
 import org.bouncycastle.util.encoders.Hex;
 import org.hyperledger.fabric.protos.common.SignatureHeader;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
 
 final class TransactionContext {
     private static final int NONCE_LENGTH = 24;
@@ -38,7 +38,7 @@ final class TransactionContext {
 
     private String newTransactionId() {
         byte[] saltedCreator = GatewayUtils.concat(nonce, signingIdentity.getCreator());
-        byte[] rawTransactionId = signingIdentity.hash(saltedCreator);
+        byte[] rawTransactionId = Hash.sha256(saltedCreator);
         byte[] hexTransactionId = Hex.encode(rawTransactionId);
         return new String(hexTransactionId, StandardCharsets.UTF_8);
     }

--- a/node/src/transactioncontext.ts
+++ b/node/src/transactioncontext.ts
@@ -6,6 +6,7 @@
 
 import { common } from '@hyperledger/fabric-protos';
 import { randomBytes } from 'crypto';
+import { sha256 } from './hash/hashes';
 import { SigningIdentity } from './signingidentity';
 
 export class TransactionContext {
@@ -17,7 +18,7 @@ export class TransactionContext {
         const creator = signingIdentity.getCreator();
 
         const saltedCreator = Buffer.concat([nonce, creator]);
-        const rawTransactionId = signingIdentity.hash(saltedCreator);
+        const rawTransactionId = sha256(saltedCreator);
         this.#transactionId = Buffer.from(rawTransactionId).toString('hex');
 
         this.#signatureHeader = new common.SignatureHeader();

--- a/pkg/client/transactioncontext.go
+++ b/pkg/client/transactioncontext.go
@@ -10,6 +10,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 
+	"github.com/hyperledger/fabric-gateway/pkg/hash"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 )
 
@@ -30,7 +31,7 @@ func newTransactionContext(signingIdentity *signingIdentity) (*transactionContex
 	}
 
 	saltedCreator := append(nonce, creator...)
-	rawTransactionID := signingIdentity.hash(saltedCreator)
+	rawTransactionID := hash.SHA256(saltedCreator)
 	transactionID := hex.EncodeToString(rawTransactionID)
 
 	signatureHeader := &common.SignatureHeader{


### PR DESCRIPTION
Code previously used whichever hash function the client supplied when connecting the Gateway. For some implementations this hash function may use a different algorithm or even just pass through bytes unchanged. Fabric requires that the salted creator bytes be SHA256 hashed when generating a transaction ID. Any other algorithm would cause an invalid transaction ID to be generated.