### PR TITLE
Update fabric-protos dependencies for Fabric v2.5 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/cucumber/godog v0.12.5
 	github.com/cucumber/messages-go/v16 v16.0.1
 	github.com/golang/mock v1.6.0
-	github.com/hyperledger/fabric-protos-go-apiv2 v0.0.0-20220615102044-467be1c7b2e7
+	github.com/hyperledger/fabric-protos-go-apiv2 v0.2.0
 	github.com/miekg/pkcs11 v1.1.1
-	github.com/stretchr/testify v1.7.1
+	github.com/stretchr/testify v1.8.1
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
 )

--- a/go.sum
+++ b/go.sum
@@ -117,8 +117,8 @@ github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
-github.com/hyperledger/fabric-protos-go-apiv2 v0.0.0-20220615102044-467be1c7b2e7 h1:loYDK6Vrf7z3fff6YBVKFkFeCGCoKr8O2ed02CESBUQ=
-github.com/hyperledger/fabric-protos-go-apiv2 v0.0.0-20220615102044-467be1c7b2e7/go.mod h1:smwq1q6eKByqQAp0SYdVvE1MvDoneF373j11XwWajgA=
+github.com/hyperledger/fabric-protos-go-apiv2 v0.2.0 h1:+J5f5uPzlgyfyeQ0nnqmuFYQvARGYG8SnZ8xODXlAsI=
+github.com/hyperledger/fabric-protos-go-apiv2 v0.2.0/go.mod h1:smwq1q6eKByqQAp0SYdVvE1MvDoneF373j11XwWajgA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -194,11 +194,15 @@ github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
+github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javaVersion>8</javaVersion>
-        <grpcVersion>1.50.1</grpcVersion>
+        <grpcVersion>1.51.1</grpcVersion>
         <protobufVersion>3.21.7</protobufVersion> <!-- keep in step with the version used by io.grpc:grpc-protobuf -->
         <enforceJavaVersion>1.8</enforceJavaVersion> <!-- this is overridden in the release profile -->
         <bouncyCastleVersion>1.72</bouncyCastleVersion>
@@ -60,7 +60,7 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.9.0</version>
+                <version>7.10.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -162,12 +162,12 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.9.1</version>
+            <version>2.10</version>
         </dependency>
         <dependency>
             <groupId>org.hyperledger.fabric</groupId>
             <artifactId>fabric-protos</artifactId>
-            <version>0.1.5</version>
+            <version>0.2.0</version>
         </dependency>
     </dependencies>
 
@@ -377,7 +377,7 @@
                             <dependency>
                                 <groupId>com.puppycrawl.tools</groupId>
                                 <artifactId>checkstyle</artifactId>
-                                <version>10.4</version>
+                                <version>10.5.0</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/node/package.json
+++ b/node/package.json
@@ -29,7 +29,7 @@
     },
     "license": "Apache-2.0",
     "dependencies": {
-        "@hyperledger/fabric-protos": "^0.1.5",
+        "@hyperledger/fabric-protos": "~0.2.0",
         "asn1.js": "^5.4.1",
         "elliptic": "^6.5.4"
     },
@@ -51,6 +51,6 @@
         "npm-run-all": "^4.1.5",
         "ts-jest": "^29.0.3",
         "typedoc": "^0.23.2",
-        "typescript": "~4.8.4"
+        "typescript": "~4.9.4"
     }
 }

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -18,7 +18,7 @@
     "license": "Apache-2.0",
     "dependencies": {
         "@hyperledger/fabric-gateway": "file:../../node/fabric-gateway-dev.tgz",
-        "@hyperledger/fabric-protos": "^0.1.0-dev.2300102001.1"
+        "@hyperledger/fabric-protos": "~0.2.0"
     },
     "devDependencies": {
         "@cucumber/cucumber": "^8.2.0",
@@ -29,10 +29,10 @@
         "@typescript-eslint/parser": "^5.3.0",
         "cucumber-console-formatter": "^1.0.0",
         "eslint": "^8.1.0",
-        "expect": "^28.1.0",
+        "expect": "^29.3.1",
         "jsrsasign": "^10.4.0",
         "npm-run-all": "^4.1.5",
         "ts-node": "^10.8.0",
-        "typescript": "~4.7.2"
+        "typescript": "~4.9.4"
     }
 }


### PR DESCRIPTION
v0.2.x of fabric-protos correspond to the forthcoming Fabric v2.5 LTS release.

Updates other dependencies to latest versions.