### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+Notable changes in each release are documented on the project's [GitHub releases](https://github.com/hyperledger/fabric-gateway/releases) page.


### PR DESCRIPTION
This is required by the Hyperledger repository structure guidelines to ensure that any fork of the repository also contains release version details. The changelog simply links to the main repository's GitHub releases pages where notable changes in each release are recorded.