### PR TITLE
Update Java dependency-check version

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -392,7 +392,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>7.3.2</version>
+                        <version>7.4.4</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>


### PR DESCRIPTION
Resolves an issue that prevented dependency-check running due to long CVE content.