### PR TITLE
Fix CodeQL scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -28,52 +17,31 @@ permissions:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       contents: read
       security-events: write
-
     strategy:
       fail-fast: false
       matrix:
-        language:
-          - go
-          - java
-          - javascript
-        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
-        # Learn more about CodeQL language support at https://git.io/codeql-language-support
-
+        include:
+          - language: go
+            working-directory: ''
+          - language: java
+            working-directory: java
+          - language: javascript
+            working-directory: node
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-          # queries: ./path/to/local/query, your-org/your-repo/queries@main
-
-      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        if: matrix.language != 'java'
         uses: github/codeql-action/autobuild@v2
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 https://git.io/JvXDl
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-      #    and modify them (or add more) to build your code if your project
-      #    uses a compiled language
-
-      - name: Build Java
-        if: matrix.language == 'java'
-        run: make build-java
-
+        with:
+          working-directory: ${{ matrix.working-directory }}
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2

--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,12 @@ TWO_DIGIT_VERSION ?= 2.4
 
 SOFTHSM2_CONF ?= $(HOME)/softhsm2.conf
 
+.PHONEY: default
+default:
+	@echo 'No default target.'
+
 .PHONEY: build
-build: build-node
+build: build-node build-java
 
 .PHONEY: build-node
 build-node:
@@ -36,6 +40,11 @@ build-node:
 		npm run build && \
 		rm -f fabric-gateway-dev.tgz && \
 		mv $$(npm pack) fabric-gateway-dev.tgz
+
+.PHONEY: build-java
+build-java:
+	cd "$(java_dir)" && \
+		mvn -DskipTests install
 
 .PHONEY: unit-test
 unit-test: generate unit-test-go unit-test-node unit-test-java
@@ -171,8 +180,9 @@ fabric-ca-client:
 	go install -tags pkcs11 github.com/hyperledger/fabric-ca/cmd/fabric-ca-client@latest
 
 .PHONEY: generate-docs-node
-generate-docs-node: build-node
+generate-docs-node:
 	cd "$(node_dir)" && \
+		npm install && \
 		npm run generate-apidoc
 
 .PHONEY: generate-docs-java

--- a/node/package.json
+++ b/node/package.json
@@ -19,13 +19,14 @@
         "url": "https://www.hyperledger.org/use/fabric"
     },
     "scripts": {
-        "build": "npm-run-all clean compile lint copy-non-ts-source",
+        "build": "npm-run-all clean compile copy-non-ts-source",
         "clean": "rm -rf apidocs dist src/protos",
         "compile": "tsc --project tsconfig.build.json",
         "copy-non-ts-source": "rsync -rv --prune-empty-dirs --include='*.d.ts' --exclude='*.ts' src/ dist",
         "generate-apidoc": "typedoc",
         "lint": "eslint . --ext .ts",
-        "test": "jest"
+        "test": "npm-run-all lint unit-test",
+        "unit-test": "jest"
     },
     "license": "Apache-2.0",
     "dependencies": {


### PR DESCRIPTION
- Restore build-java Makefile target, which was used by CodeQL scan.
- Change the CodeQL scan to allow autobuild to be used rather than a custom build step.
- Add a no-op default Makefile target since the CodeQL autobuild runs this for Go, which did unnecessary work.
- Remove linting from build-node Makefile target and only run as part of the unit testing.