### PR TITLE
Publish Java release builds to GitHub Packages

### DIFF
--- a/.github/scripts/maven_publish_release.sh
+++ b/.github/scripts/maven_publish_release.sh
@@ -2,8 +2,10 @@
 
 set -eu -o pipefail
 
+PUBLISH_PROFILE="${1:?}"
+
 POM_VERSION=$(mvn org.apache.maven.plugins:maven-help-plugin:evaluate -Dexpression=project.version -q -DforceStdout)
 PUBLISH_VERSION="${POM_VERSION%%-*}"
 
 mvn --batch-mode --no-transfer-progress versions:set -DnewVersion="${PUBLISH_VERSION}"
-mvn --batch-mode --no-transfer-progress --activate-profiles release -DskipTests deploy
+mvn --batch-mode --no-transfer-progress --activate-profiles "release,${PUBLISH_PROFILE}" -DskipTests deploy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,30 @@ jobs:
         run: ${{ github.workspace }}/.github/scripts/npm_publish.sh latest
         working-directory: node
 
-  publish-java:
+  publish-java-github:
+    needs: verify-versions
+    name: Publish Java artifact to GitHub Packages
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: temurin
+          cache: maven
+          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
+          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+      - name: Publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+        run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh github
+        working-directory: java
+
+  publish-java-ossrh:
     needs: verify-versions
     name: Publish Java artifact to Maven Central
     runs-on: ubuntu-22.04
@@ -48,5 +71,5 @@ jobs:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-        run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh
+        run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh ossrh
         working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -31,6 +31,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/hyperledger/fabric-gateway.git</connection>
+        <developerConnection>scm:git:git://github.com/hyperledger/fabric-gateway.git</developerConnection>
         <url>https://github.com/hyperledger/fabric-gateway</url>
     </scm>
 
@@ -42,19 +43,6 @@
         <enforceJavaVersion>1.8</enforceJavaVersion> <!-- this is overridden in the release profile -->
         <bouncyCastleVersion>1.72</bouncyCastleVersion>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>fabric-maven</id>
-            <url>https://hyperledger-fabric.jfrog.io/artifactory/fabric-maven</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -342,12 +330,8 @@
             </plugin>
         </plugins>
     </reporting>
+
     <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <name>Central Repository OSSRH</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
         <snapshotRepository>
             <uniqueVersion>true</uniqueVersion>
             <id>github</id>
@@ -355,6 +339,7 @@
             <url>https://maven.pkg.github.com/hyperledger/fabric-gateway</url>
         </snapshotRepository>
     </distributionManagement>
+
     <profiles>
         <profile>
             <id>javadoc-no-module-directories</id>
@@ -440,17 +425,6 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
-                        <extensions>true</extensions>
-                        <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                        </configuration>
-                    </plugin>
-                    <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
                         <version>3.4.2</version>
                         <configuration>
@@ -470,6 +444,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -485,6 +460,41 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>github</id>
+            <distributionManagement>
+                <repository>
+                    <id>github</id>
+                    <name>GitHub Packages</name>
+                    <url>https://maven.pkg.github.com/hyperledger/fabric-gateway</url>
+                </repository>
+            </distributionManagement>
+        </profile>
+        <profile>
+            <id>ossrh</id>
+            <distributionManagement>
+                <repository>
+                    <id>ossrh</id>
+                    <name>Central Repository OSSRH</name>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
To improve the chances of a Java release artifact being published successfully, publish to GitHub Packages in addition to Maven Central.