### PR TITLE
Use staticcheck binary for linting

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,4 +18,4 @@ jobs:
     name: Pull request success
     runs-on: ubuntu-latest
     steps:
-    - run: true
+      - run: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,15 +3,12 @@
 run:
   build-tags:
     - pkcs11
+  timeout: 5m
 
 linters:
   enable:
-    - errcheck
     - gofmt
     - goimports
     - gosec
-    - gosimple
-    - govet
+  disable:
     - staticcheck
-    - typecheck
-    - unused

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,0 +1,1 @@
+checks = ["all"]


### PR DESCRIPTION
The staticcheck linter in golangci-lint is not the real staticcheck binary. Disable the staticcheck linter in golangci-lint and use the real staticcheck binary, just to ensure the latest rules are being applied.

Previous refactor of build jobs ensures that linting (including staticcheck) is only run with a Go version supported by staticcheck.