### PR TITLE
Use @noble/curves for Node signing

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -32,8 +32,8 @@
     "dependencies": {
         "@grpc/grpc-js": "^1.8.7",
         "@hyperledger/fabric-protos": "~0.2.0",
+        "@noble/curves": "^0.7.3",
         "asn1.js": "^5.4.1",
-        "elliptic": "^6.5.4",
         "google-protobuf": "^3.21.2"
     },
     "optionalDependencies": {

--- a/node/src/identity/asn1.ts
+++ b/node/src/identity/asn1.ts
@@ -8,7 +8,6 @@
 // @ts-nocheck
 
 import { define } from 'asn1.js';
-import BN from 'bn.js';
 import { KeyObject } from 'crypto';
 
 const ECPrivateKey = define('ECPrivateKey', function() {
@@ -20,13 +19,6 @@ const ECPrivateKey = define('ECPrivateKey', function() {
     );
 });
 
-const ECSignature = define('ECSignature', function() {
-    return this.seq().obj(
-        this.key('r').int(),
-        this.key('s').int()
-    );
-});
-
 export function ecPrivateKeyAsRaw(privateKey: KeyObject): { privateKey: Buffer, curveObjectId: number[] } {
     const privateKeyPem = privateKey.export({ format: 'der', type: 'sec1' });
     const decodedDer = ECPrivateKey.decode(privateKeyPem, 'der');
@@ -34,8 +26,4 @@ export function ecPrivateKeyAsRaw(privateKey: KeyObject): { privateKey: Buffer, 
         privateKey: decodedDer.privateKey,
         curveObjectId: decodedDer.parameters,
     };
-}
-
-export function ecRawSignatureAsDer(r: BN, s: BN): Buffer {
-    return ECSignature.encode({ r, s }, 'der');
 }


### PR DESCRIPTION
This package is newer than elliptic, has fewer dependencies, is better typed, and appears to be faster.

Closes #524