### PR TITLE
Improve golangci-lint performance

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,4 +18,4 @@ jobs:
     name: Pull request success
     runs-on: ubuntu-latest
     steps:
-      - run: true
+      - run: 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
       - uses: actions/checkout@v3
       - run: make shellcheck
       
-  lint:
+  staticcheck:
     needs: verify-versions
     runs-on: ubuntu-latest
-    name: Lint
+    name: Staticcheck
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
@@ -34,7 +34,23 @@ jobs:
       - name: Generate mocks
         run: make generate
       - name: Lint
-        run: make lint
+        run: make staticcheck
+
+  golangci:
+    needs: verify-versions
+    runs-on: ubuntu-latest
+    name: golangci-lint
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ env.DEFAULT_GO_VERSION }}
+      - name: Generate mocks
+        run: make generate
+      - name: Lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
 
   go:
     needs: verify-versions

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ vendor/
 .DS_Store
 *.iml
 softhsm2.conf
-.cache/

--- a/Makefile
+++ b/Makefile
@@ -80,13 +80,8 @@ staticcheck:
 
 .PHONEY: golangci-lint
 golangci-lint:
-	docker pull golangci/golangci-lint:latest
-	docker run --tty --rm \
-		--volume '$(base_dir)/.cache/golangci-lint:/root/.cache' \
-		--volume '$(base_dir):/app' \
-		--workdir /app \
-		golangci/golangci-lint \
-		golangci-lint run --verbose
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
+	golangci-lint run
 
 .PHONEY: scan
 scan: scan-go scan-node scan-java
@@ -222,7 +217,7 @@ pull-latest-peer:
 	# also need to retag the following images for the chaincode builder
 	for IMAGE in baseos ccenv javaenv nodeenv; do \
 		docker pull hyperledger/fabric-$${IMAGE}:$(TWO_DIGIT_VERSION) || docker pull --platform amd64 hyperledger/fabric-$${IMAGE}:$(TWO_DIGIT_VERSION); \
-		docker tag hyperledger/fabric-$${IMAGE}:$(TWO_DIGIT_VERSION) hyperledger/fabric-$$IMAGE:$(PEER_IMAGE_TAG); \
+		docker tag hyperledger/fabric-$${IMAGE}:$(TWO_DIGIT_VERSION) hyperledger/fabric-$${IMAGE}:$(PEER_IMAGE_TAG); \
 	done
 
 .PHONEY: clean


### PR DESCRIPTION
- For local runs, use binary instead of Docker image.
- For CI, use GitHub Action.