### PR TITLE
Error testing improvements in Go unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,12 +55,12 @@ unit-test: generate lint unit-test-go unit-test-node unit-test-java
 .PHONEY: unit-test-go
 unit-test-go:
 	cd '$(base_dir)' && \
-		go test -timeout 10s -coverprofile=cover.out '$(go_dir)/...'
+		go test -timeout 10s -race -coverprofile=cover.out '$(go_dir)/...'
 
 .PHONEY: unit-test-go-pkcs11
 unit-test-go-pkcs11: setup-softhsm
 	cd '$(base_dir)' && \
-		go test -tags pkcs11 -timeout 10s -coverprofile=cover.out '$(go_dir)/...'
+		go test -tags pkcs11 -race -timeout 10s -coverprofile=cover.out '$(go_dir)/...'
 
 .PHONEY: unit-test-node
 unit-test-node: build-node

--- a/node/src/blockevents.test.ts
+++ b/node/src/blockevents.test.ts
@@ -101,8 +101,7 @@ describe('Block Events', () => {
         expect(actualCreator).toEqual(gateway.getIdentity());
     }
 
-    interface TestCase {
-        description: string;
+    const testCases: Record<string, {
         mockResponse(stream: DuplexStreamResponseStub<common.Envelope, peer.DeliverResponse>): void;
         mockError(err: ServiceError): void;
         getEvents(options?: BlockEventsOptions): Promise<CloseableAsyncIterable<unknown>>;
@@ -110,11 +109,8 @@ describe('Block Events', () => {
         getCallOptions(): CallOptions[];
         newBlockResponse(blockNumber: number): peer.DeliverResponse;
         getBlockFromResponse(response: peer.DeliverResponse): common.Block | peer.FilteredBlock | peer.BlockAndPrivateData | undefined;
-    }
-
-    const testCases: TestCase[] = [
-        {
-            description: 'Blocks',
+    }> = {
+        'Blocks': {
             mockResponse(stream) {
                 client.mockBlockEventsResponse(stream);
             },
@@ -146,8 +142,7 @@ describe('Block Events', () => {
                 return response.getBlock();
             },
         },
-        {
-            description: 'Filtered blocks',
+        'Filtered blocks': {
             mockResponse(stream) {
                 client.mockFilteredBlockEventsResponse(stream);
             },
@@ -176,8 +171,7 @@ describe('Block Events', () => {
                 return response.getFilteredBlock();
             },
         },
-        {
-            description: 'Blocks and private data',
+        'Blocks and private data': {
             mockResponse(stream) {
                 client.mockBlockAndPrivateDataEventsResponse(stream);
             },
@@ -214,8 +208,9 @@ describe('Block Events', () => {
                 return response.getBlockAndPrivateData();
             },
         },
-    ];
-    testCases.forEach(testCase => describe(`${testCase.description}`, () => {
+    };
+
+    Object.entries(testCases).forEach(([testName, testCase]) => describe(`${testName}`, () => {
         it('sends valid request with default start position', async () => {
             const stream = newDuplexStreamResponse<common.Envelope, peer.DeliverResponse>([]);
             testCase.mockResponse(stream);

--- a/pkg/client/blockevents_test.go
+++ b/pkg/client/blockevents_test.go
@@ -55,7 +55,8 @@ func TestBlockEvents(t *testing.T) {
 		_, err := network.BlockEvents(ctx)
 
 		require.Equal(t, status.Code(expected), status.Code(err), "status code")
-		require.Errorf(t, err, expected.Error(), "error message")
+		require.ErrorIs(t, err, expected, "error type: %T", err)
+		require.ErrorContains(t, err, expected.Error(), "message")
 	})
 
 	t.Run("Sends valid request with default start position", func(t *testing.T) {

--- a/pkg/client/blockeventsfiltered_test.go
+++ b/pkg/client/blockeventsfiltered_test.go
@@ -36,7 +36,8 @@ func TestFilteredBlockEvents(t *testing.T) {
 		_, err := network.FilteredBlockEvents(ctx)
 
 		require.Equal(t, status.Code(expected), status.Code(err), "status code")
-		require.Errorf(t, err, expected.Error(), "error message")
+		require.ErrorIs(t, err, expected, "error type: %T", err)
+		require.ErrorContains(t, err, expected.Error(), "message")
 	})
 
 	t.Run("Sends valid request with default start position", func(t *testing.T) {

--- a/pkg/client/blockeventswithprivatedata_test.go
+++ b/pkg/client/blockeventswithprivatedata_test.go
@@ -37,7 +37,8 @@ func TestBlockAndPrivateDataEvents(t *testing.T) {
 		_, err := network.BlockAndPrivateDataEvents(ctx)
 
 		require.Equal(t, status.Code(expected), status.Code(err), "status code")
-		require.Errorf(t, err, expected.Error(), "error message")
+		require.ErrorIs(t, err, expected, "error type: %T", err)
+		require.ErrorContains(t, err, expected.Error(), "message")
 	})
 
 	t.Run("Sends valid request with default start position", func(t *testing.T) {

--- a/pkg/client/chaincodeevents_test.go
+++ b/pkg/client/chaincodeevents_test.go
@@ -56,7 +56,8 @@ func TestChaincodeEvents(t *testing.T) {
 		_, err := network.ChaincodeEvents(ctx, "CHAINCODE")
 
 		require.Equal(t, status.Code(expected), status.Code(err), "status code")
-		require.Errorf(t, err, expected.Error(), "error message")
+		require.ErrorIs(t, err, expected, "error type: %T", err)
+		require.ErrorContains(t, err, expected.Error(), "message")
 	})
 
 	t.Run("Sends valid request with default start position", func(t *testing.T) {
@@ -328,6 +329,7 @@ func TestChaincodeEvents(t *testing.T) {
 		}
 		test.AssertProtoEqual(t, expected, actual)
 	})
+
 	t.Run("Sends valid request with no start block and checkpoint transaction ID", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		mockClient := NewMockGatewayClient(controller)
@@ -375,6 +377,7 @@ func TestChaincodeEvents(t *testing.T) {
 		}
 		test.AssertProtoEqual(t, expected, actual)
 	})
+
 	t.Run("Sends valid request with with start block and checkpoint chaincode event", func(t *testing.T) {
 		controller := gomock.NewController(t)
 		mockClient := NewMockGatewayClient(controller)

--- a/pkg/client/evaluate_test.go
+++ b/pkg/client/evaluate_test.go
@@ -48,28 +48,26 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		_, err := contract.EvaluateTransaction("transaction")
 
-		require.Errorf(t, err, expected.Error(), "error message")
+		require.ErrorIs(t, err, expected, "error type: %T", err)
+		require.ErrorContains(t, err, expected.Error(), "message")
 		require.Equal(t, status.Code(expected), status.Code(err), "status code")
 	})
 
-	for _, testCase := range []struct {
-		name string
-		run  func(*testing.T, *Contract) ([]byte, error)
+	for name, testCase := range map[string]struct {
+		run func(*testing.T, *Contract) ([]byte, error)
 	}{
-		{
-			name: "EvaluateTransaction returns result",
+		"EvaluateTransaction returns result": {
 			run: func(t *testing.T, contract *Contract) ([]byte, error) {
 				return contract.EvaluateTransaction("transaction")
 			},
 		},
-		{
-			name: "EvaluateWithContext returns result",
+		"EvaluateWithContext returns result": {
 			run: func(t *testing.T, contract *Contract) ([]byte, error) {
 				return contract.EvaluateWithContext(context.Background(), "transaction")
 			},
 		},
 	} {
-		t.Run(testCase.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			expected := []byte("TRANSACTION_RESULT")
 			mockClient := NewMockGatewayClient(gomock.NewController(t))
 			mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
@@ -311,26 +309,23 @@ func TestEvaluateTransaction(t *testing.T) {
 		require.EqualValues(t, expectedPrice, actualPrice)
 	})
 
-	for _, testCase := range []struct {
-		name string
-		run  func(*testing.T, context.Context, *Contract) ([]byte, error)
+	for name, testCase := range map[string]struct {
+		run func(*testing.T, context.Context, *Contract) ([]byte, error)
 	}{
-		{
-			name: "Proposal uses specified context",
+		"Proposal uses specified context": {
 			run: func(t *testing.T, ctx context.Context, contract *Contract) ([]byte, error) {
 				proposal, err := contract.NewProposal("transaction")
 				require.NoError(t, err, "NewProposal")
 				return proposal.EvaluateWithContext(ctx)
 			},
 		},
-		{
-			name: "Contract uses specified context",
+		"Contract uses specified context": {
 			run: func(t *testing.T, ctx context.Context, contract *Contract) ([]byte, error) {
 				return contract.EvaluateWithContext(ctx, "transaction")
 			},
 		},
 	} {
-		t.Run(testCase.name, func(t *testing.T) {
+		t.Run(name, func(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
 
@@ -371,20 +366,17 @@ func TestEvaluateTransaction(t *testing.T) {
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 
-	for _, testCase := range []struct {
-		name string
-		run  func(*testing.T, *Contract, []grpc.CallOption) ([]byte, error)
+	for testName, testCase := range map[string]struct {
+		run func(*testing.T, *Contract, []grpc.CallOption) ([]byte, error)
 	}{
-		{
-			name: "Uses specified gRPC call options",
+		"Uses specified gRPC call options": {
 			run: func(t *testing.T, contract *Contract, expected []grpc.CallOption) ([]byte, error) {
 				proposal, err := contract.NewProposal("transaction")
 				require.NoError(t, err, "NewProposal")
 				return proposal.Evaluate(expected...)
 			},
 		},
-		{
-			name: "Uses specified gRPC call options with specified context",
+		"Uses specified gRPC call options with specified context": {
 			run: func(t *testing.T, contract *Contract, expected []grpc.CallOption) ([]byte, error) {
 				proposal, err := contract.NewProposal("transaction")
 				require.NoError(t, err, "NewProposal")
@@ -392,7 +384,7 @@ func TestEvaluateTransaction(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(testCase.name, func(t *testing.T) {
+		t.Run(testName, func(t *testing.T) {
 			var actual []grpc.CallOption
 			expected := grpc.WaitForReady(true)
 

--- a/pkg/client/offlinesign_test.go
+++ b/pkg/client/offlinesign_test.go
@@ -50,12 +50,11 @@ func TestOfflineSign(t *testing.T) {
 	}
 
 	type Invocation struct {
-		Description string
-		Invoke      func() error
+		Invoke func() error
 	}
 
 	type Signable struct {
-		Invocations []Invocation
+		Invocations map[string]Invocation
 		OfflineSign func([]byte) *Signable
 		State       interface{}
 		Recreate    func() *Signable
@@ -64,16 +63,14 @@ func TestOfflineSign(t *testing.T) {
 	var newSignableFromProposal func(t *testing.T, gateway *Gateway, proposal *Proposal) *Signable
 	newSignableFromProposal = func(t *testing.T, gateway *Gateway, proposal *Proposal) *Signable {
 		return &Signable{
-			Invocations: []Invocation{
-				{
-					Description: "Evaluate",
+			Invocations: map[string]Invocation{
+				"Evaluate": {
 					Invoke: func() error {
 						_, err := proposal.Evaluate()
 						return err
 					},
 				},
-				{
-					Description: "Endorse",
+				"Endorse": {
 					Invoke: func() error {
 						_, err := proposal.Endorse()
 						return err
@@ -113,9 +110,8 @@ func TestOfflineSign(t *testing.T) {
 	var newSignableFromTransaction func(t *testing.T, gateway *Gateway, transaction *Transaction) *Signable
 	newSignableFromTransaction = func(t *testing.T, gateway *Gateway, transaction *Transaction) *Signable {
 		return &Signable{
-			Invocations: []Invocation{
-				{
-					Description: "Submit",
+			Invocations: map[string]Invocation{
+				"Submit": {
 					Invoke: func() error {
 						_, err := transaction.Submit()
 						return err
@@ -153,9 +149,8 @@ func TestOfflineSign(t *testing.T) {
 	var newSignableFromCommit func(t *testing.T, gateway *Gateway, commit *Commit) *Signable
 	newSignableFromCommit = func(t *testing.T, gateway *Gateway, commit *Commit) *Signable {
 		return &Signable{
-			Invocations: []Invocation{
-				{
-					Description: "Status",
+			Invocations: map[string]Invocation{
+				"Status": {
 					Invoke: func() error {
 						_, err := commit.Status()
 						return err
@@ -193,9 +188,8 @@ func TestOfflineSign(t *testing.T) {
 	var newSignableFromChaincodeEventsRequest func(t *testing.T, gateway *Gateway, request *ChaincodeEventsRequest) *Signable
 	newSignableFromChaincodeEventsRequest = func(t *testing.T, gateway *Gateway, request *ChaincodeEventsRequest) *Signable {
 		return &Signable{
-			Invocations: []Invocation{
-				{
-					Description: "Events",
+			Invocations: map[string]Invocation{
+				"Events": {
 					Invoke: func() error {
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
@@ -234,9 +228,8 @@ func TestOfflineSign(t *testing.T) {
 	var newSignableFromBlockEventsRequest func(t *testing.T, gateway *Gateway, request *BlockEventsRequest) *Signable
 	newSignableFromBlockEventsRequest = func(t *testing.T, gateway *Gateway, request *BlockEventsRequest) *Signable {
 		return &Signable{
-			Invocations: []Invocation{
-				{
-					Description: "Events",
+			Invocations: map[string]Invocation{
+				"Events": {
 					Invoke: func() error {
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
@@ -275,9 +268,8 @@ func TestOfflineSign(t *testing.T) {
 	var newSignableFromFilteredBlockEventsRequest func(t *testing.T, gateway *Gateway, request *FilteredBlockEventsRequest) *Signable
 	newSignableFromFilteredBlockEventsRequest = func(t *testing.T, gateway *Gateway, request *FilteredBlockEventsRequest) *Signable {
 		return &Signable{
-			Invocations: []Invocation{
-				{
-					Description: "Events",
+			Invocations: map[string]Invocation{
+				"Events": {
 					Invoke: func() error {
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
@@ -316,9 +308,8 @@ func TestOfflineSign(t *testing.T) {
 	var newSignableFromBlockAndPrivateDataEventsRequest func(t *testing.T, gateway *Gateway, request *BlockAndPrivateDataEventsRequest) *Signable
 	newSignableFromBlockAndPrivateDataEventsRequest = func(t *testing.T, gateway *Gateway, request *BlockAndPrivateDataEventsRequest) *Signable {
 		return &Signable{
-			Invocations: []Invocation{
-				{
-					Description: "Events",
+			Invocations: map[string]Invocation{
+				"Events": {
 					Invoke: func() error {
 						ctx, cancel := context.WithCancel(context.Background())
 						defer cancel()
@@ -354,14 +345,10 @@ func TestOfflineSign(t *testing.T) {
 		}
 	}
 
-	type TableTest struct {
-		Description string
-		Create      func(*testing.T) *Signable
-	}
-
-	tests := []TableTest{
-		{
-			Description: "Proposal",
+	for testName, testCase := range map[string]struct {
+		Create func(*testing.T) *Signable
+	}{
+		"Proposal": {
 			Create: func(t *testing.T) *Signable {
 				mockClient := NewMockGatewayClient(gomock.NewController(t))
 				mockClient.EXPECT().Evaluate(gomock.Any(), gomock.Any()).
@@ -390,8 +377,7 @@ func TestOfflineSign(t *testing.T) {
 				return newSignableFromProposal(t, gateway, proposal)
 			},
 		},
-		{
-			Description: "Transaction",
+		"Transaction": {
 			Create: func(t *testing.T) *Signable {
 				mockClient := NewMockGatewayClient(gomock.NewController(t))
 				mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
@@ -421,8 +407,7 @@ func TestOfflineSign(t *testing.T) {
 				return newSignableFromTransaction(t, gateway, transaction)
 			},
 		},
-		{
-			Description: "Commit",
+		"Commit": {
 			Create: func(t *testing.T) *Signable {
 				mockClient := NewMockGatewayClient(gomock.NewController(t))
 				mockClient.EXPECT().Endorse(gomock.Any(), gomock.Any()).
@@ -466,8 +451,7 @@ func TestOfflineSign(t *testing.T) {
 				return newSignableFromCommit(t, gateway, commit)
 			},
 		},
-		{
-			Description: "Chaincode events",
+		"Chaincode events": {
 			Create: func(t *testing.T) *Signable {
 				controller := gomock.NewController(t)
 				mockClient := NewMockGatewayClient(controller)
@@ -493,8 +477,7 @@ func TestOfflineSign(t *testing.T) {
 				return newSignableFromChaincodeEventsRequest(t, gateway, request)
 			},
 		},
-		{
-			Description: "Block events",
+		"Block events": {
 			Create: func(t *testing.T) *Signable {
 				controller := gomock.NewController(t)
 				mockClient := NewMockDeliverClient(controller)
@@ -513,8 +496,7 @@ func TestOfflineSign(t *testing.T) {
 				return newSignableFromBlockEventsRequest(t, gateway, request)
 			},
 		},
-		{
-			Description: "Filtered block events",
+		"Filtered block events": {
 			Create: func(t *testing.T) *Signable {
 				controller := gomock.NewController(t)
 				mockClient := NewMockDeliverClient(controller)
@@ -533,8 +515,7 @@ func TestOfflineSign(t *testing.T) {
 				return newSignableFromFilteredBlockEventsRequest(t, gateway, request)
 			},
 		},
-		{
-			Description: "Block and private data events",
+		"Block and private data events": {
 			Create: func(t *testing.T) *Signable {
 				controller := gomock.NewController(t)
 				mockClient := NewMockDeliverClient(controller)
@@ -553,14 +534,12 @@ func TestOfflineSign(t *testing.T) {
 				return newSignableFromBlockAndPrivateDataEventsRequest(t, gateway, request)
 			},
 		},
-	}
+	} {
+		t.Run(testName, func(t *testing.T) {
+			unsigned := testCase.Create(t)
 
-	for _, test := range tests {
-		t.Run(test.Description, func(t *testing.T) {
-			unsigned := test.Create(t)
-
-			for i, invocation := range unsigned.Invocations {
-				t.Run(invocation.Description, func(t *testing.T) {
+			for invocationName, invocation := range unsigned.Invocations {
+				t.Run(invocationName, func(t *testing.T) {
 					t.Run("Returns error with no signer and no explicit signing", func(t *testing.T) {
 						err := invocation.Invoke()
 						require.Error(t, err)
@@ -571,18 +550,19 @@ func TestOfflineSign(t *testing.T) {
 						expected := []byte("SIGNATURE")
 
 						signed := unsigned.OfflineSign(expected)
-						err := signed.Invocations[i].Invoke()
+						err := signed.Invocations[invocationName].Invoke()
 						require.NoError(t, err)
 
 						require.EqualValues(t, expected, signature)
 					})
+
 					t.Run("retains signature", func(t *testing.T) {
 						signature = nil
 						expected := []byte("SIGNATURE")
 
 						signed := unsigned.OfflineSign(expected)
 						recreated := signed.Recreate()
-						err := recreated.Invocations[i].Invoke()
+						err := recreated.Invocations[invocationName].Invoke()
 						require.NoError(t, err)
 
 						require.EqualValues(t, expected, signature)


### PR DESCRIPTION
- Require specific error types in assertions.
- Enable race detection.
- Use map instead of slice for table tests for clarity and to avoid possibility of duplicate test names.
- Simplify InMemoryAdapter for checkpointer tests.

Also use objects instead of arrays for Node table tests, similar to the Go approach.