### PR TITLE
Flag dependency-check failures for CVSS score of Medium or higher

### DIFF
--- a/java/dependency-suppression.xml
+++ b/java/dependency-suppression.xml
@@ -16,4 +16,13 @@
         <packageUrl regex="true">^pkg:maven/org\.hyperledger\.fabric/fabric\-protos@.*$</packageUrl>
         <cve>CVE-2022-36023</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: guava-31.1-android.jar
+        The offending com.google.common.io.Files.createTempDir() method is deprecated and not used.
+        NIST classify this CVE with a CVSS 3.x score of 3.3 (Low).
+        ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com\.google\.guava/guava@.*$</packageUrl>
+        <vulnerabilityName>CVE-2020-8908</vulnerabilityName>
+    </suppress>
 </suppressions>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -392,7 +392,7 @@
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>
                             <skipSystemScope>true</skipSystemScope>
-                            <failBuildOnCVSS>7</failBuildOnCVSS>
+                            <failBuildOnCVSS>4</failBuildOnCVSS>
                             <suppressionFiles>
                                 <suppressionFile>dependency-suppression.xml</suppressionFile>
                             </suppressionFiles>


### PR DESCRIPTION
Following security recommendations of OpenSSF Best Practices.