### PR TITLE
Include all linters checked by Go Report Card

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,9 +6,20 @@ run:
   timeout: 5m
 
 linters:
+  disable-all: true
   enable:
+    - errcheck
+    - gocyclo
     - gofmt
     - goimports
     - gosec
-  disable:
-    - staticcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - typecheck
+    - unused
+
+linters-settings:
+  gocyclo:
+    min-complexity: 10

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -298,7 +298,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.3.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pkg/client/example_contract_test.go
+++ b/pkg/client/example_contract_test.go
@@ -62,7 +62,7 @@ func ExampleContract_Submit_errorHandling() {
 	if err != nil {
 		switch err := err.(type) {
 		case *client.EndorseError:
-			panic(fmt.Errorf("transaction %s failed to endrose with gRPC status %v: %w", err.TransactionID, status.Code(err), err))
+			panic(fmt.Errorf("transaction %s failed to endorse with gRPC status %v: %w", err.TransactionID, status.Code(err), err))
 		case *client.SubmitError:
 			panic(fmt.Errorf("transaction %s failed to submit to the orderer with gRPC status %v: %w", err.TransactionID, status.Code(err), err))
 		case *client.CommitStatusError:


### PR DESCRIPTION
See https://goreportcard.com/report/github.com/hyperledger/fabric-gateway

Simplify chaincode deployment in scenario tests to pass cyclomatic complexity checks.

For clarity, change golangci-lint configuration to explicitly specify the linters run rather than relying on default linters.

Also fix Maven plugin warning in Java build.