### PR TITLE
Fix Java OSV-Scanner scan

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,9 @@ scan-java-dependency-check:
 .PHONEY: scan-java-osv-scanner
 scan-java-osv-scanner:
 	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-	mvn --file '$(java_dir)/pom.xml' help:effective-pom -Doutput='$(TMPDIR)/pom.xml'
-	osv-scanner --lockfile='$(TMPDIR)/pom.xml'
+	cd '$(java_dir)' && \
+		mvn --activate-profiles sbom -DskipTests install
+	osv-scanner --sbom='$(java_dir)/target/bom.json'
 
 .PHONEY: generate
 generate:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -399,6 +399,33 @@
             </build>
         </profile>
         <profile>
+            <id>sbom</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.cyclonedx</groupId>
+                        <artifactId>cyclonedx-maven-plugin</artifactId>
+                        <version>2.7.9</version>
+                        <configuration>
+                            <includeCompileScope>true</includeCompileScope>
+                            <includeProvidedScope>false</includeProvidedScope>
+                            <includeRuntimeScope>true</includeRuntimeScope>
+                            <includeSystemScope>false</includeSystemScope>
+                            <includeTestScope>false</includeTestScope>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>makeAggregateBom</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>release</id>
             <properties>
                 <enforceJavaVersion>[1.8,1.9)</enforceJavaVersion> <!-- must use 1.8 JDK for release build -->


### PR DESCRIPTION
Transitive dependencies were missed from the effective POM generated using the Maven Help plugin. Instead, generate a CycloneDX Software Bill of Materials (SBOM), and run OSV-Scanner on that SBOM.