### PR TITLE
Fix Node OSV-Scanner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,8 +125,9 @@ scan-node-npm-audit:
 scan-node-osv-scanner:
 	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
 	cd '$(node_dir)' && \
-		npm install --package-lock-only && \
-		osv-scanner --lockfile=package-lock.json
+		npm install && \
+		npm run sbom && \
+		osv-scanner --sbom=sbom.json
 
 .PHONEY: scan-java
 scan-java: scan-java-dependency-check scan-java-osv-scanner

--- a/node/.gitignore
+++ b/node/.gitignore
@@ -5,3 +5,4 @@ coverage/
 src/protos/
 apidocs/
 package-lock.json
+sbom.json

--- a/node/package.json
+++ b/node/package.json
@@ -25,6 +25,7 @@
         "copy-non-ts-source": "rsync -rv --prune-empty-dirs --include='*.d.ts' --exclude='*.ts' src/ dist",
         "generate-apidoc": "typedoc",
         "lint": "eslint . --ext .ts",
+        "sbom": "cyclonedx-npm --omit dev --output-format JSON --output-file sbom.json",
         "test": "npm-run-all lint unit-test",
         "unit-test": "jest"
     },
@@ -39,6 +40,7 @@
         "pkcs11js": "^1.3.0"
     },
     "devDependencies": {
+        "@cyclonedx/cyclonedx-npm": "^1.12.1",
         "@tsconfig/node16": "^1.0.3",
         "@types/google-protobuf": "^3.15.5",
         "@types/jest": "^29.2.0",


### PR DESCRIPTION
OSV-Scanner run against the package-lock.json could detect vulnerabilities in dev packages. Instead, generate a CycloneDX Software Bill of Materials (SBOM), excluding dev dependencies, and run OSV-Scanner against the SBOM.