### PR TITLE
Use Java 17 for publishing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -75,7 +75,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 17
           distribution: temurin
           cache: maven
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 17
           distribution: temurin
           cache: maven
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
@@ -58,7 +58,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
-          java-version: 8
+          java-version: 17
           distribution: temurin
           cache: maven
           server-id: ossrh

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,7 +39,6 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javaVersion>8</javaVersion>
         <grpcVersion>1.57.1</grpcVersion>
-        <enforceJavaVersion>1.8</enforceJavaVersion> <!-- this is overridden in the release profile -->
         <bouncyCastleVersion>1.76</bouncyCastleVersion>
         <skipUnitTests>${skipTests}</skipUnitTests>
     </properties>
@@ -160,7 +159,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>${enforceJavaVersion}</version>
+                                    <version>${javaVersion}</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>3.6.3</version>
@@ -366,7 +365,6 @@
                             </dependency>
                         </dependencies>
                     </plugin>
-
                 </plugins>
             </build>
         </profile>
@@ -427,9 +425,6 @@
         </profile>
         <profile>
             <id>release</id>
-            <properties>
-                <enforceJavaVersion>[1.8,1.9)</enforceJavaVersion> <!-- must use 1.8 JDK for release build -->
-            </properties>
             <build>
                 <plugins>
                     <plugin>
@@ -508,5 +503,4 @@
             </build>
         </profile>
     </profiles>
-
 </project>

--- a/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
@@ -16,16 +16,16 @@ import java.util.function.UnaryOperator;
 
 /**
  * The Gateway provides the connection point for an application to access the Fabric network as a specific user. It is
- * instantiated from a Builder instance that is created using {@link #newInstance()} and configured using a gateway URL
- * and a signing identity. It can then be connected to a fabric network using the
- * {@link Builder#connect()} method. Once connected, it can then access individual {@link Network} instances (channels)
- * using the {@link #getNetwork(String) getNetwork} method which in turn can access the {@link Contract} installed on a
- * network and {@link Contract#submitTransaction(String, String...) submit transactions} to the ledger.
+ * instantiated from a Builder instance that is created using {@link #newInstance()}, and configured using a gateway
+ * URL and a signing identity. It can then be connected to a fabric network using the Builder's
+ * {@link Builder#connect() connect()} method. Once connected, it can then access individual {@link Network} instances
+ * (channels) using the {@link #getNetwork(String) getNetwork()} method which in turn can access the {@link Contract}
+ * installed on a network and {@link Contract#submitTransaction(String, String...) submit transactions} to the ledger.
  *
  * <p>Gateway instances should be reused for multiple transaction invocations and only closed once connection to the
  * Fabric network is no longer required.</p>
  *
- * <p>Multiple Gateway instances may share the same underlying gRPC connection by supplying the gRPC {@code Channel} as
+ * <p>Multiple Gateway instances may share the same underlying gRPC connection by supplying the gRPC {@link Channel} as
  * an option to the Gateway connect.</p>
  *
  * <pre>{@code

--- a/java/src/main/java/org/hyperledger/fabric/client/package-info.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/package-info.java
@@ -9,9 +9,11 @@
  * interact with a Fabric blockchain network. It provides a simple API to
  * submit transactions to a ledger or query the contents of a ledger with minimal code.
  * The Gateway SDK implements the Fabric programming model as described in the
- * <a href="https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html">Developing Applications</a>
- * chapter of the Fabric documentation.</p>
+ * <a href="https://hyperledger-fabric.readthedocs.io/en/latest/write_first_app.html">Running a Fabric Application</a>
+ * tutorial of the Fabric documentation.</p>
  *
- * @see <a href="https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html">Developing Fabric Applications</a>
+ * <p>The entry point into this package is {@link org.hyperledger.fabric.client.Gateway Gateway}.</p>
+ *
+ * @see <a href="https://hyperledger-fabric.readthedocs.io/en/latest/write_first_app.html">Running a Fabric Application</a>
  */
 package org.hyperledger.fabric.client;

--- a/java/src/main/javadoc/overview.html
+++ b/java/src/main/javadoc/overview.html
@@ -7,8 +7,8 @@
 	<p>The Fabric Gateway SDK allows applications to interact with a Fabric blockchain network. It provides a simple API
     to submit transactions to a ledger or query the contents of a ledger with minimal code. The Gateway SDK implements
     the Fabric programming model as described in the
-    <a href="https://hyperledger-fabric.readthedocs.io/en/latest/developapps/developing_applications.html">Developing Applications</a>
-	chapter of the Fabric documentation.</p>
+    <a href="https://hyperledger-fabric.readthedocs.io/en/latest/write_first_app.html">Running a Fabric Application</a>
+	tutorial of the Fabric documentation.</p>
 
     <p>Client applications interact with the blockchain network using a Fabric Gateway. A session for a given client
     identity is established by building and connecting to a Fabric Gateway using a gRPC connection to the Gateway

--- a/java/src/site/site.xml
+++ b/java/src/site/site.xml
@@ -16,7 +16,7 @@
   <skin>
     <groupId>org.apache.maven.skins</groupId>
     <artifactId>maven-fluido-skin</artifactId>
-    <version>1.7</version>
+    <version>1.12.0</version>
   </skin>
 
   <body>


### PR DESCRIPTION
Java 8 was used for safety, since the intention is to maintain compatibility with Java 8 by compiling compatible bytecode and only using Java 8 standard libraries. This caused a Javadoc failure when linking to Javadoc built with later versions of Java, since they produce a different format of package-list / element-list file. This problem surfaced when gRPC-Java started to publish builds using Java 11 instead of Java 8, and caused Javadoc warnings linking to their published Javadoc.

Use Java 17 for publishing, relying on the maven.compiler.release (javac --release) option to ensure that compiled output links to the Java 8 standard libraries. To allow this, no longer enforce exactly Java 8 in the Maven release profile.

Fix some broken links in Javadoc.