### PR TITLE
Update compatibility matrix for Go 1.21

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,7 +42,7 @@ The following table shows versions of Fabric, programming language runtimes, and
 |     | Tested | Supported |
 | --- | ------ | --------- |
 | **Fabric** | 2.5 | 2.4.4+ |
-| **Go** | 1.19, 1.20 | 1.19, 1.20 |
+| **Go** | 1.19, 1.20, 1.21 | 1.19, 1.20, 1.21 |
 | **Node** | 16, 18 | 16, 18 |
 | **Java** | 8, 11, 17 | 8, 11, 17 |
 | **Platform** | Ubuntu 22.04 | |


### PR DESCRIPTION
Closes #612 