### PR TITLE
Remove dev dependency on jsrsasign

### DIFF
--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -25,14 +25,12 @@
     "devDependencies": {
         "@cucumber/cucumber": "^9.3.0",
         "@tsconfig/node16": "^16.1.0",
-        "@types/jsrsasign": "^10.5.8",
         "@types/node": "^16.18.39",
         "@typescript-eslint/eslint-plugin": "^6.2.1",
         "@typescript-eslint/parser": "^6.2.1",
         "cucumber-console-formatter": "^1.0.0",
         "eslint": "^8.46.0",
         "expect": "^29.6.2",
-        "jsrsasign": "^10.8.6",
         "npm-run-all": "^4.1.5",
         "typescript": "~5.1.6"
     }


### PR DESCRIPTION
Refactor generation of key identifiers for hardware security module configuration in Node scenario tests to use Node crypto library, avoiding the need for dependency on jsrsasign.