### PR TITLE
Remove support for Node 16

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
       - name: Build
         run: make build-node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
       - name: Build
         run: make build-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
           - 18
           - 20
     env:
@@ -126,7 +125,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 16
           - 18
           - 20
     env:

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ See the [gateway.proto file](https://github.com/hyperledger/fabric-protos/blob/m
 This repository comprises three functionally equivalent client APIs, written in Go, Typescript, and Java. In order to
 build these components, the following need to be installed and available in the PATH:
 - [Go 1.20+](https://go.dev/)
-- [Node 16+](https://nodejs.org/)
+- [Node 18+](https://nodejs.org/)
 - [Java 8+](https://adoptium.net/)
 - [Docker](https://www.docker.com/)
 - [Make](https://www.gnu.org/software/make/)

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "engines": {
-        "node": ">=16.13.0"
+        "node": ">=18.12.0"
     },
     "repository": {
         "type": "git",
@@ -42,21 +42,21 @@
         "pkcs11js": "^1.3.0"
     },
     "devDependencies": {
-        "@cyclonedx/cyclonedx-npm": "^1.14.0",
-        "@tsconfig/node16": "^16.1.1",
-        "@types/elliptic": "^6.4.14",
-        "@types/google-protobuf": "^3.15.6",
-        "@types/jest": "^29.5.4",
-        "@types/node": "^16.18.48",
-        "@typescript-eslint/eslint-plugin": "^6.6.0",
-        "@typescript-eslint/parser": "^6.6.0",
-        "eslint": "^8.49.0",
-        "eslint-plugin-jest": "^27.2.3",
+        "@cyclonedx/cyclonedx-npm": "^1.14.1",
+        "@tsconfig/node18": "^18.2.2",
+        "@types/elliptic": "^6.4.16",
+        "@types/google-protobuf": "^3.15.9",
+        "@types/jest": "^29.5.6",
+        "@types/node": "^18.18.6",
+        "@typescript-eslint/eslint-plugin": "^6.8.0",
+        "@typescript-eslint/parser": "^6.8.0",
+        "eslint": "^8.51.0",
+        "eslint-plugin-jest": "^27.4.2",
         "eslint-plugin-tsdoc": "^0.2.17",
-        "jest": "^29.6.4",
+        "jest": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "ts-jest": "^29.1.1",
-        "typedoc": "^0.25.1",
+        "typedoc": "^0.25.2",
         "typescript": "~5.2.2"
     }
 }

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -1,8 +1,8 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
-        "lib": ["es2021", "esnext.disposable"],
+        "lib": ["es2023", "esnext.disposable"],
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "description": "Scenario test for Fabric Gateway",
     "engines": {
-        "node": ">=16.13.0"
+        "node": ">=18.12.0"
     },
     "scripts": {
         "build": "npm-run-all clean compile lint",
@@ -24,13 +24,13 @@
     },
     "devDependencies": {
         "@cucumber/cucumber": "^9.5.1",
-        "@tsconfig/node16": "^16.1.1",
-        "@types/node": "^16.18.48",
-        "@typescript-eslint/eslint-plugin": "^6.6.0",
-        "@typescript-eslint/parser": "^6.6.0",
+        "@tsconfig/node18": "^18.2.2",
+        "@types/node": "^18.18.6",
+        "@typescript-eslint/eslint-plugin": "^6.8.0",
+        "@typescript-eslint/parser": "^6.8.0",
         "cucumber-console-formatter": "^1.0.0",
-        "eslint": "^8.49.0",
-        "expect": "^29.6.4",
+        "eslint": "^8.51.0",
+        "expect": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "typescript": "~5.2.2"
     }

--- a/scenario/node/tsconfig.json
+++ b/scenario/node/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node18/tsconfig.json",
     "compilerOptions": {
         "declaration": false,
         "sourceMap": true,


### PR DESCRIPTION
Node 16 reached [end of life](https://github.com/nodejs/release#end-of-life-releases) on 2023-09-11, and is no longer a supported Node version.

Closes #614