### PR TITLE
Use Temurin distribution of Java 21

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: oracle
+          distribution: temurin
           cache: maven
       - name: Generate JavaDoc
         run: make generate-docs-java

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: oracle
+          distribution: temurin
           cache: maven
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: oracle
+          distribution: temurin
           cache: maven
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: oracle
+          distribution: temurin
           cache: maven
           server-id: ossrh
           server-username: MAVEN_USERNAME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,21 +157,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - java-version: 8
-            distribution: temurin
-          - java-version: 11
-            distribution: temurin
-          - java-version: 17
-            distribution: temurin
-          - java-version: 21
-            distribution: oracle
+        java-version:
+          - 8
+          - 11
+          - 17
+          - 21
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: ${{ matrix.distribution }}
+          distribution: temurin
           cache: maven
       - name: Run unit tests
         run: make unit-test-java
@@ -183,21 +179,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - java-version: 8
-            distribution: temurin
-          - java-version: 11
-            distribution: temurin
-          - java-version: 17
-            distribution: temurin
-          - java-version: 21
-            distribution: oracle
+        java-version:
+          - 8
+          - 11
+          - 17
+          - 21
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java-version }}
-          distribution: ${{ matrix.distribution }}
+          distribution: temurin
           cache: maven
       - uses: actions/setup-go@v4
         with:

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: oracle
+          distribution: temurin
           cache: maven
       - name: Check Java artifact version
         shell: bash

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -68,7 +68,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           java-version: 21
-          distribution: oracle
+          distribution: temurin
           cache: maven
       - name: Set up Go
         if: matrix.target == 'osv-scanner'


### PR DESCRIPTION
Use the Temurin distribution for all Java versions now that Java 21 releases are available.