### PR TITLE
chore(docs): fix nodejs async for loop examples 

### DIFF
--- a/node/src/blockeventsrequest.ts
+++ b/node/src/blockeventsrequest.ts
@@ -78,7 +78,7 @@ export interface BlockAndPrivateDataEventsRequest extends Signable {
      * ```typescript
      * const events = await network.getBlockAndPrivateEventsData();
      * try {
-     *     for async (const event of events) {
+     *     for await (const event of events) {
      *         // Process block and private data event
      *     }
      * } finally {

--- a/node/src/chaincodeeventsrequest.ts
+++ b/node/src/chaincodeeventsrequest.ts
@@ -25,7 +25,7 @@ export interface ChaincodeEventsRequest extends Signable {
      * ```typescript
      * const events = await request.getEvents();
      * try {
-     *     for async (const event of events) {
+     *     for await (const event of events) {
      *         // Process event
      *     }
      * } finally {

--- a/node/src/network.ts
+++ b/node/src/network.ts
@@ -32,7 +32,7 @@ import { SigningIdentity } from './signingidentity';
  *         startBlock: BigInt(101), // Ignored if the checkpointer has checkpoint state
  *     });
  *     try {
- *         for async (const event of events) {
+ *         for await (const event of events) {
  *             // Process then checkpoint event
  *             await checkpointer.checkpointChaincodeEvent(event)
  *         }
@@ -54,7 +54,7 @@ import { SigningIdentity } from './signingidentity';
  *         startBlock: BigInt(101), // Ignored if the checkpointer has checkpoint state
  *     });
  *     try {
- *         for async (const event of events) {
+ *         for await (const event of events) {
  *             // Process then checkpoint block
  *             await checkpointer.checkpointBlock(event.getHeader().getNumber())
  *         }
@@ -91,7 +91,7 @@ export interface Network {
      * ```typescript
      * const events = await network.getChaincodeEvents(chaincodeName, { startBlock: BigInt(101) });
      * try {
-     *     for async (const event of events) {
+     *     for await (const event of events) {
      *         // Process event
      *     }
      * } finally {
@@ -173,7 +173,7 @@ export interface Network {
      * ```typescript
      * const events = await network.getBlockAndPrivateEventsData({ startBlock: BigInt(101) });
      * try {
-     *     for async (const event of events) {
+     *     for await (const event of events) {
      *         // Process block and private data event
      *     }
      * } finally {


### PR DESCRIPTION
The block event examples do not seem to work and I have never heard of `for async`. I assume they are supposed to be `for await`, which is what the fabric samples use [here](https://github.com/hyperledger/fabric-samples/blob/c0a0104ca1ca9107cb7cea8af3758d1ec256df02/asset-transfer-events/application-gateway-typescript/src/app.ts#L79).