### PR TITLE
Re-enable Java dependency-check scan

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   go:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -32,7 +32,7 @@ jobs:
         run: make scan-go-${{ matrix.target }}
 
   node:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -41,47 +41,68 @@ jobs:
           - osv-scanner
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js
+      - name: Set up Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
       - name: Set up Go
-        if: matrix.target == 'osv-scanner'
+        if: ${{ matrix.target == 'osv-scanner' }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Scan
         run: make scan-node-${{ matrix.target }}
 
-  java:
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          # - dependency-check
-          - osv-scanner
+  java_osv_scanner:
+    name: "java (osv-scanner)"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - name: Scan
+        run: make scan-java-osv-scanner
+
+  java_dependency_check:
+    name: "java (dependency-check)"
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java
-        if: matrix.target != 'osv-scanner'
         uses: actions/setup-java@v4
         with:
           java-version: 21
           distribution: temurin
           cache: maven
-      - name: Set up Go
-        if: matrix.target == 'osv-scanner'
-        uses: actions/setup-go@v5
+      - name: Get Date
+        id: get-date
+        shell: bash
+        run: echo "datetime=$(/bin/date -u '+%Y%m%d%H')" >> $GITHUB_OUTPUT
+      - name: Restore cached Maven dependencies
+        uses: actions/cache/restore@v4
         with:
-          go-version: ${{ env.GO_VERSION }}
+          path: ~/.m2/repository
+          # Using datetime in cache key as OWASP database may change, without the pom changing
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}
+            ${{ runner.os }}-maven-
       - name: Scan
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: make scan-java-${{ matrix.target }}
+        run: make scan-java-dependency-check
       - name: "Archive dependency-check report"
-        if: (success() || failure()) && matrix.target == 'dependency-check'
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: dependency-check-report
           path: java/target/dependency-check-report.html
+      - name: Cache Maven dependencies
+        if: ${{ !cancelled() }}
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}
+        

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.14.1</version>
+                <version>7.15.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.24.2</version>
+            <version>3.25.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -234,8 +234,16 @@
                             <consoleOutputReporter>
                                 <disable>true</disable>
                             </consoleOutputReporter>
-                            <statelessTestsetInfoReporter
-                                    implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporterUnicode">
+                            <statelessTestsetInfoReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5StatelessTestsetInfoTreeReporter">
+                                <theme>UNICODE</theme>
+                                <printStacktraceOnError>true</printStacktraceOnError>
+                                <printStacktraceOnFailure>true</printStacktraceOnFailure>
+                                <printStdoutOnError>true</printStdoutOnError>
+                                <printStdoutOnFailure>true</printStdoutOnFailure>
+                                <printStdoutOnSuccess>false</printStdoutOnSuccess>
+                                <printStderrOnError>true</printStderrOnError>
+                                <printStderrOnFailure>true</printStderrOnFailure>
+                                <printStderrOnSuccess>false</printStderrOnSuccess>
                             </statelessTestsetInfoReporter>
                         </configuration>
                     </execution>
@@ -379,7 +387,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>9.0.7</version>
+                        <version>9.0.9</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>
@@ -408,7 +416,7 @@
                     <plugin>
                         <groupId>org.cyclonedx</groupId>
                         <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <version>2.7.10</version>
+                        <version>2.7.11</version>
                         <configuration>
                             <includeCompileScope>true</includeCompileScope>
                             <includeProvidedScope>false</includeProvidedScope>


### PR DESCRIPTION
Use cache action to restore previous OWASP database state and avoid downloading entire NVD dataset on each run.