### PR TITLE
Update golangci-lint action to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Staticcheck
         run: make staticcheck
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@2221aee28499deb9551e403a0d876df4b0e70067
+        uses: golangci/golangci-lint-action@v4
         with:
           version: latest
           skip-pkg-cache: true


### PR DESCRIPTION
This release version uses a non-deprecated Node version, avoiding the need to use a specific commit hash in the development branch.