### PR TITLE
Update pkcs11js to v2

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -41,7 +41,7 @@
         "google-protobuf": "^3.21.0"
     },
     "optionalDependencies": {
-        "pkcs11js": "^1.3.0"
+        "pkcs11js": "^2.1.0"
     },
     "devDependencies": {
         "@cyclonedx/cyclonedx-npm": "^1.14.3",


### PR DESCRIPTION
This uses the newer Node-API for native code integration instead of the older Native Abstractions for Node.js API. There should be no functional difference but it removes one external dependency (on the `nan` package) and keeps fabric-gateway on the latest supported pkcs11js version.