### PR TITLE
Support mutual TLS for block eventing

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/BlockAndPrivateDataEventsBuilder.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/BlockAndPrivateDataEventsBuilder.java
@@ -6,21 +6,27 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.Objects;
-
+import com.google.protobuf.ByteString;
 import org.hyperledger.fabric.protos.common.Envelope;
+
+import java.util.Objects;
 
 final class BlockAndPrivateDataEventsBuilder implements BlockAndPrivateDataEventsRequest.Builder {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
     private final BlockEventsEnvelopeBuilder envelopeBuilder;
 
-    BlockAndPrivateDataEventsBuilder(final GatewayClient client, final SigningIdentity signingIdentity, final String channelName) {
+    BlockAndPrivateDataEventsBuilder(
+        final GatewayClient client,
+        final SigningIdentity signingIdentity,
+        final String channelName,
+        final ByteString tlsCertificateHash
+    ) {
         Objects.requireNonNull(channelName, "channel name");
 
         this.client = client;
         this.signingIdentity = signingIdentity;
-        this.envelopeBuilder = new BlockEventsEnvelopeBuilder(signingIdentity, channelName);
+        this.envelopeBuilder = new BlockEventsEnvelopeBuilder(signingIdentity, channelName, tlsCertificateHash);
     }
 
     @Override

--- a/java/src/main/java/org/hyperledger/fabric/client/BlockEventsBuilder.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/BlockEventsBuilder.java
@@ -6,21 +6,27 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.Objects;
-
+import com.google.protobuf.ByteString;
 import org.hyperledger.fabric.protos.common.Envelope;
+
+import java.util.Objects;
 
 final class BlockEventsBuilder implements BlockEventsRequest.Builder {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
     private final BlockEventsEnvelopeBuilder envelopeBuilder;
 
-    BlockEventsBuilder(final GatewayClient client, final SigningIdentity signingIdentity, final String channelName) {
+    BlockEventsBuilder(
+        final GatewayClient client,
+        final SigningIdentity signingIdentity,
+        final String channelName,
+        final ByteString tlsCertificateHash
+    ) {
         Objects.requireNonNull(channelName, "channel name");
 
         this.client = client;
         this.signingIdentity = signingIdentity;
-        this.envelopeBuilder = new BlockEventsEnvelopeBuilder(signingIdentity, channelName);
+        this.envelopeBuilder = new BlockEventsEnvelopeBuilder(signingIdentity, channelName, tlsCertificateHash);
     }
 
     @Override

--- a/java/src/main/java/org/hyperledger/fabric/client/BlockEventsEnvelopeBuilder.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/BlockEventsEnvelopeBuilder.java
@@ -18,11 +18,17 @@ import org.hyperledger.fabric.protos.orderer.SeekInfo;
 final class BlockEventsEnvelopeBuilder {
     private final SigningIdentity signingIdentity;
     private final String channelName;
+    private final ByteString tlsCertificateHash;
     private final StartPositionBuilder startPositionBuilder = new StartPositionBuilder();
 
-    BlockEventsEnvelopeBuilder(final SigningIdentity signingIdentity, final String channelName) {
+    BlockEventsEnvelopeBuilder(
+        final SigningIdentity signingIdentity,
+        final String channelName,
+        final ByteString tlsCertificateHash
+    ) {
         this.signingIdentity = signingIdentity;
         this.channelName = channelName;
+        this.tlsCertificateHash = tlsCertificateHash;
     }
 
     public BlockEventsEnvelopeBuilder startBlock(final long blockNumber) {
@@ -56,6 +62,7 @@ final class BlockEventsEnvelopeBuilder {
                 .setEpoch(0)
                 .setTimestamp(GatewayUtils.getCurrentTimestamp())
                 .setType(HeaderType.DELIVER_SEEK_INFO_VALUE)
+                .setTlsCertHash(tlsCertificateHash)
                 .build();
     }
 

--- a/java/src/main/java/org/hyperledger/fabric/client/FilteredBlockEventsBuilder.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/FilteredBlockEventsBuilder.java
@@ -6,21 +6,27 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.Objects;
-
+import com.google.protobuf.ByteString;
 import org.hyperledger.fabric.protos.common.Envelope;
+
+import java.util.Objects;
 
 final class FilteredBlockEventsBuilder implements FilteredBlockEventsRequest.Builder {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
     private final BlockEventsEnvelopeBuilder envelopeBuilder;
 
-    FilteredBlockEventsBuilder(final GatewayClient client, final SigningIdentity signingIdentity, final String channelName) {
+    FilteredBlockEventsBuilder(
+        final GatewayClient client,
+        final SigningIdentity signingIdentity,
+        final String channelName,
+        final ByteString tlsCertificateHash
+    ) {
         Objects.requireNonNull(channelName, "channel name");
 
         this.client = client;
         this.signingIdentity = signingIdentity;
-        this.envelopeBuilder = new BlockEventsEnvelopeBuilder(signingIdentity, channelName);
+        this.envelopeBuilder = new BlockEventsEnvelopeBuilder(signingIdentity, channelName, tlsCertificateHash);
     }
 
     @Override

--- a/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/Gateway.java
@@ -237,6 +237,15 @@ public interface Gateway extends AutoCloseable {
         Builder hash(Function<byte[], byte[]> hash);
 
         /**
+         * Specify the SHA-256 hash of the TLS client certificate. This option is required only if mutual TLS
+         * authentication is used for the gRPC connection to the Gateway peer.
+         *
+         * @param certificateHash A SHA-256 hash.
+         * @return The builder instance, allowing multiple configuration options to be chained.
+         */
+        Builder tlsClientCertificateHash(byte[] certificateHash);
+
+        /**
          * Specify the default call options for evaluating transactions.
          * <p>A call of:</p>
          * <pre>{@code

--- a/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/NetworkImpl.java
@@ -6,25 +6,33 @@
 
 package org.hyperledger.fabric.client;
 
-import java.util.Objects;
-import java.util.function.UnaryOperator;
-
+import com.google.protobuf.ByteString;
 import io.grpc.CallOptions;
 import org.hyperledger.fabric.protos.common.Block;
 import org.hyperledger.fabric.protos.peer.BlockAndPrivateData;
 import org.hyperledger.fabric.protos.peer.FilteredBlock;
 
+import java.util.Objects;
+import java.util.function.UnaryOperator;
+
 final class NetworkImpl implements Network {
     private final GatewayClient client;
     private final SigningIdentity signingIdentity;
     private final String channelName;
+    private final ByteString tlsCertificateHash;
 
-    NetworkImpl(final GatewayClient client, final SigningIdentity signingIdentity, final String channelName) {
+    NetworkImpl(
+        final GatewayClient client,
+        final SigningIdentity signingIdentity,
+        final String channelName,
+        final ByteString tlsCertificateHash
+    ) {
         Objects.requireNonNull(channelName, "network name");
 
         this.client = client;
         this.signingIdentity = signingIdentity;
         this.channelName = channelName;
+        this.tlsCertificateHash = tlsCertificateHash;
     }
 
     @Override
@@ -59,7 +67,7 @@ final class NetworkImpl implements Network {
 
     @Override
     public BlockEventsRequest.Builder newBlockEventsRequest() {
-        return new BlockEventsBuilder(client, signingIdentity, channelName);
+        return new BlockEventsBuilder(client, signingIdentity, channelName, tlsCertificateHash);
     }
 
     @Override
@@ -69,7 +77,7 @@ final class NetworkImpl implements Network {
 
     @Override
     public FilteredBlockEventsRequest.Builder newFilteredBlockEventsRequest() {
-        return new FilteredBlockEventsBuilder(client, signingIdentity, channelName);
+        return new FilteredBlockEventsBuilder(client, signingIdentity, channelName, tlsCertificateHash);
     }
 
     @Override
@@ -79,6 +87,6 @@ final class NetworkImpl implements Network {
 
     @Override
     public BlockAndPrivateDataEventsRequest.Builder newBlockAndPrivateDataEventsRequest() {
-        return new BlockAndPrivateDataEventsBuilder(client, signingIdentity, channelName);
+        return new BlockAndPrivateDataEventsBuilder(client, signingIdentity, channelName, tlsCertificateHash);
     }
 }

--- a/node/src/blockeventsbuilder.ts
+++ b/node/src/blockeventsbuilder.ts
@@ -37,6 +37,7 @@ export interface BlockEventsBuilderOptions extends EventsOptions {
     client: GatewayClient;
     signingIdentity: SigningIdentity;
     channelName: string;
+    tlsCertificateHash?: Uint8Array;
 }
 
 export class BlockEventsBuilder {
@@ -133,6 +134,9 @@ class BlockEventsEnvelopeBuilder {
         result.setEpoch(0);
         result.setTimestamp(Timestamp.fromDate(new Date()));
         result.setType(common.HeaderType.DELIVER_SEEK_INFO);
+        if (this.#options.tlsCertificateHash) {
+            result.setTlsCertHash(this.#options.tlsCertificateHash);
+        }
         return result;
     }
 

--- a/node/src/network.ts
+++ b/node/src/network.ts
@@ -8,6 +8,7 @@ import { common, peer } from '@hyperledger/fabric-protos';
 import {
     BlockAndPrivateDataEventsBuilder,
     BlockEventsBuilder,
+    BlockEventsBuilderOptions,
     BlockEventsOptions,
     FilteredBlockEventsBuilder,
 } from './blockeventsbuilder';
@@ -204,17 +205,20 @@ export interface NetworkOptions {
     client: GatewayClient;
     signingIdentity: SigningIdentity;
     channelName: string;
+    tlsCertificateHash?: Uint8Array;
 }
 
 export class NetworkImpl implements Network {
     readonly #client: GatewayClient;
     readonly #signingIdentity: SigningIdentity;
     readonly #channelName: string;
+    readonly #tlsCertificateHash?: Uint8Array;
 
     constructor(options: Readonly<NetworkOptions>) {
         this.#client = options.client;
         this.#signingIdentity = options.signingIdentity;
         this.#channelName = options.channelName;
+        this.#tlsCertificateHash = options.tlsCertificateHash;
     }
 
     getName(): string {
@@ -257,13 +261,8 @@ export class NetworkImpl implements Network {
     }
 
     newBlockEventsRequest(options: Readonly<BlockEventsOptions> = {}): BlockEventsRequest {
-        return new BlockEventsBuilder(
-            Object.assign({}, options, {
-                channelName: this.#channelName,
-                client: this.#client,
-                signingIdentity: this.#signingIdentity,
-            }),
-        ).build();
+        const builderOptions = this.#newBlockEventsBuilderOptions(options);
+        return new BlockEventsBuilder(builderOptions).build();
     }
 
     async getFilteredBlockEvents(
@@ -273,13 +272,8 @@ export class NetworkImpl implements Network {
     }
 
     newFilteredBlockEventsRequest(options: Readonly<BlockEventsOptions> = {}): FilteredBlockEventsRequest {
-        return new FilteredBlockEventsBuilder(
-            Object.assign({}, options, {
-                channelName: this.#channelName,
-                client: this.#client,
-                signingIdentity: this.#signingIdentity,
-            }),
-        ).build();
+        const builderOptions = this.#newBlockEventsBuilderOptions(options);
+        return new FilteredBlockEventsBuilder(builderOptions).build();
     }
 
     async getBlockAndPrivateDataEvents(
@@ -289,12 +283,16 @@ export class NetworkImpl implements Network {
     }
 
     newBlockAndPrivateDataEventsRequest(options: Readonly<BlockEventsOptions> = {}): BlockAndPrivateDataEventsRequest {
-        return new BlockAndPrivateDataEventsBuilder(
-            Object.assign({}, options, {
-                channelName: this.#channelName,
-                client: this.#client,
-                signingIdentity: this.#signingIdentity,
-            }),
-        ).build();
+        const builderOptions = this.#newBlockEventsBuilderOptions(options);
+        return new BlockAndPrivateDataEventsBuilder(builderOptions).build();
+    }
+
+    #newBlockEventsBuilderOptions(options: Readonly<BlockEventsOptions>): BlockEventsBuilderOptions {
+        return Object.assign({}, options, {
+            channelName: this.#channelName,
+            client: this.#client,
+            signingIdentity: this.#signingIdentity,
+            tlsCertificateHash: this.#tlsCertificateHash,
+        });
     }
 }

--- a/pkg/client/blockeventsbuilder.go
+++ b/pkg/client/blockeventsbuilder.go
@@ -27,6 +27,7 @@ func seekLargestBlockNumber() *orderer.SeekPosition {
 
 type baseBlockEventsBuilder struct {
 	eventsBuilder
+	tlsCertificateHash []byte
 }
 
 func (builder *baseBlockEventsBuilder) payloadBytes() ([]byte, error) {
@@ -58,10 +59,11 @@ func (builder *baseBlockEventsBuilder) payloadBytes() ([]byte, error) {
 
 func (builder *baseBlockEventsBuilder) channelHeaderBytes() ([]byte, error) {
 	channelHeader := &common.ChannelHeader{
-		Type:      int32(common.HeaderType_DELIVER_SEEK_INFO),
-		Timestamp: timestamppb.Now(),
-		ChannelId: builder.eventsBuilder.channelName,
-		Epoch:     0,
+		Type:        int32(common.HeaderType_DELIVER_SEEK_INFO),
+		Timestamp:   timestamppb.Now(),
+		ChannelId:   builder.eventsBuilder.channelName,
+		Epoch:       0,
+		TlsCertHash: builder.tlsCertificateHash,
 	}
 
 	return proto.Marshal(channelHeader)

--- a/pkg/client/blockeventsfiltered_test.go
+++ b/pkg/client/blockeventsfiltered_test.go
@@ -312,4 +312,38 @@ func TestFilteredBlockEvents(t *testing.T) {
 
 		require.Contains(t, actual, expected, "CallOptions")
 	})
+
+	t.Run("Sends request with TLS client certificate hash", func(t *testing.T) {
+		expected := []byte("TLS_CLIENT_CERTIFICATE_HASH")
+
+		controller := gomock.NewController(t)
+		mockClient := NewMockDeliverClient(controller)
+		mockEvents := NewMockDeliver_DeliverClient(controller)
+
+		mockClient.EXPECT().DeliverFiltered(gomock.Any(), gomock.Any()).
+			Return(mockEvents, nil)
+
+		payload := &common.Payload{}
+		mockEvents.EXPECT().Send(gomock.Any()).
+			Do(func(in *common.Envelope) {
+				test.AssertUnmarshal(t, in.GetPayload(), payload)
+			}).
+			Return(nil).
+			Times(1)
+		mockEvents.EXPECT().Recv().
+			Return(nil, errors.New("fake")).
+			AnyTimes()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := AssertNewTestNetwork(t, "NETWORK", WithDeliverClient(mockClient), WithTLSClientCertificateHash(expected))
+		_, err := network.FilteredBlockEvents(ctx)
+		require.NoError(t, err)
+
+		channelHeader := &common.ChannelHeader{}
+		test.AssertUnmarshal(t, payload.GetHeader().GetChannelHeader(), channelHeader)
+
+		require.Equal(t, expected, channelHeader.GetTlsCertHash())
+	})
 }

--- a/pkg/client/blockeventswithprivatedata_test.go
+++ b/pkg/client/blockeventswithprivatedata_test.go
@@ -340,4 +340,38 @@ func TestBlockAndPrivateDataEvents(t *testing.T) {
 
 		require.Contains(t, actual, expected, "CallOptions")
 	})
+
+	t.Run("Sends request with TLS client certificate hash", func(t *testing.T) {
+		expected := []byte("TLS_CLIENT_CERTIFICATE_HASH")
+
+		controller := gomock.NewController(t)
+		mockClient := NewMockDeliverClient(controller)
+		mockEvents := NewMockDeliver_DeliverClient(controller)
+
+		mockClient.EXPECT().DeliverWithPrivateData(gomock.Any(), gomock.Any()).
+			Return(mockEvents, nil)
+
+		payload := &common.Payload{}
+		mockEvents.EXPECT().Send(gomock.Any()).
+			Do(func(in *common.Envelope) {
+				test.AssertUnmarshal(t, in.GetPayload(), payload)
+			}).
+			Return(nil).
+			Times(1)
+		mockEvents.EXPECT().Recv().
+			Return(nil, errors.New("fake")).
+			AnyTimes()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		network := AssertNewTestNetwork(t, "NETWORK", WithDeliverClient(mockClient), WithTLSClientCertificateHash(expected))
+		_, err := network.BlockAndPrivateDataEvents(ctx)
+		require.NoError(t, err)
+
+		channelHeader := &common.ChannelHeader{}
+		test.AssertUnmarshal(t, payload.GetHeader().GetChannelHeader(), channelHeader)
+
+		require.Equal(t, expected, channelHeader.GetTlsCertHash())
+	})
 }

--- a/pkg/client/gateway.go
+++ b/pkg/client/gateway.go
@@ -29,9 +29,10 @@ import (
 
 // Gateway representing the connection of a specific client identity to a Fabric Gateway.
 type Gateway struct {
-	signingID *signingIdentity
-	client    *gatewayClient
-	cancel    context.CancelFunc
+	signingID          *signingIdentity
+	client             *gatewayClient
+	cancel             context.CancelFunc
+	tlsCertificateHash []byte
 }
 
 // Connect to a Fabric Gateway using a client identity, gRPC connection and signing implementation.
@@ -145,6 +146,15 @@ func WithCommitStatusTimeout(timeout time.Duration) ConnectOption {
 	}
 }
 
+// WithTLSClientCertificateHash specifies the SHA-256 hash of the TLS client certificate. This option is required only
+// if mutual TLS authentication is used for the gRPC connection to the Gateway peer.
+func WithTLSClientCertificateHash(certificateHash []byte) ConnectOption {
+	return func(gw *Gateway) error {
+		gw.tlsCertificateHash = certificateHash
+		return nil
+	}
+}
+
 // Close a Gateway when it is no longer required. This releases all resources associated with Networks and Contracts
 // obtained using the Gateway, including removing event listeners.
 func (gw *Gateway) Close() error {
@@ -160,9 +170,10 @@ func (gw *Gateway) Identity() identity.Identity {
 // GetNetwork returns a Network representing the named Fabric channel.
 func (gw *Gateway) GetNetwork(name string) *Network {
 	return &Network{
-		client:    gw.client,
-		signingID: gw.signingID,
-		name:      name,
+		client:             gw.client,
+		signingID:          gw.signingID,
+		name:               name,
+		tlsCertificateHash: gw.tlsCertificateHash,
 	}
 }
 

--- a/pkg/client/network.go
+++ b/pkg/client/network.go
@@ -20,9 +20,10 @@ import (
 // To safely handle connection errors during eventing, it is recommended to use a checkpointer to track eventing
 // progress. This allows eventing to be resumed with no loss or duplication of events.
 type Network struct {
-	client    *gatewayClient
-	signingID *signingIdentity
-	name      string
+	client             *gatewayClient
+	signingID          *signingIdentity
+	name               string
+	tlsCertificateHash []byte
 }
 
 // Name of the Fabric channel this network represents.
@@ -103,11 +104,12 @@ func (network *Network) BlockEvents(ctx context.Context, options ...BlockEventsO
 func (network *Network) NewBlockEventsRequest(options ...BlockEventsOption) (*BlockEventsRequest, error) {
 	builder := &blockEventsBuilder{
 		baseBlockEventsBuilder{
-			eventsBuilder{
+			eventsBuilder: eventsBuilder{
 				signingID:   network.signingID,
 				channelName: network.name,
 				client:      network.client,
 			},
+			tlsCertificateHash: network.tlsCertificateHash,
 		},
 	}
 
@@ -134,11 +136,12 @@ func (network *Network) FilteredBlockEvents(ctx context.Context, options ...Bloc
 func (network *Network) NewFilteredBlockEventsRequest(options ...BlockEventsOption) (*FilteredBlockEventsRequest, error) {
 	builder := &filteredBlockEventsBuilder{
 		baseBlockEventsBuilder{
-			eventsBuilder{
+			eventsBuilder: eventsBuilder{
 				signingID:   network.signingID,
 				channelName: network.name,
 				client:      network.client,
 			},
+			tlsCertificateHash: network.tlsCertificateHash,
 		},
 	}
 
@@ -165,11 +168,12 @@ func (network *Network) BlockAndPrivateDataEvents(ctx context.Context, options .
 func (network *Network) NewBlockAndPrivateDataEventsRequest(options ...BlockEventsOption) (*BlockAndPrivateDataEventsRequest, error) {
 	builder := &blockAndPrivateDataEventsBuilder{
 		baseBlockEventsBuilder{
-			eventsBuilder{
+			eventsBuilder: eventsBuilder{
 				signingID:   network.signingID,
 				channelName: network.name,
 				client:      network.client,
 			},
+			tlsCertificateHash: network.tlsCertificateHash,
 		},
 	}
 


### PR DESCRIPTION
Fabric requires a SHA-256 hash of the client certificate used for mutual TLS authentication to be included in a block events request. This is to avoid replay attacks by ensuring that no TLS proxy (or man-in-the-middle) exists between the client and the Fabric Deliver service. Fabric checks that the hash of the client certificate included in the request matches the hash of the client certificate used to establish the TLS connection.

This change adds a Gateway connect option to specify the hash of the TLS client certificate, which is then included in the ChannelHeader for any block events request. This option is required only if using block eventing over a gRPC connection that uses mutual TLS authentication.

Closes #684