### PR TITLE
Synchronization for Java eventing unit tests

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.15.0</version>
+                <version>7.16.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -189,7 +189,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.12.1</version>
+                <version>3.13.0</version>
                 <configuration>
                     <source>${javaVersion}</source>
                     <target>${javaVersion}</target>
@@ -373,7 +373,7 @@
                             <dependency>
                                 <groupId>com.puppycrawl.tools</groupId>
                                 <artifactId>checkstyle</artifactId>
-                                <version>10.14.0</version>
+                                <version>10.14.2</version>
                             </dependency>
                         </dependencies>
                     </plugin>
@@ -387,7 +387,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>9.0.9</version>
+                        <version>9.0.10</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>
@@ -416,7 +416,7 @@
                     <plugin>
                         <groupId>org.cyclonedx</groupId>
                         <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <version>2.7.11</version>
+                        <version>2.8.0</version>
                         <configuration>
                             <includeCompileScope>true</includeCompileScope>
                             <includeProvidedScope>false</includeProvidedScope>
@@ -442,7 +442,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.6.0</version>
+                        <version>3.7.1</version>
                         <configuration>
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>
@@ -460,7 +460,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.2</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/java/src/test/java/org/hyperledger/fabric/client/GatewayMocker.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/GatewayMocker.java
@@ -104,42 +104,58 @@ public final class GatewayMocker implements AutoCloseable {
     }
 
     public EndorseRequest captureEndorse() {
-        Mockito.verify(gatewaySpy).endorse(endorseRequestCaptor.capture());
+        synchronized (gatewaySpy) {
+            Mockito.verify(gatewaySpy).endorse(endorseRequestCaptor.capture());
+        }
         return endorseRequestCaptor.getValue();
     }
 
     public EvaluateRequest captureEvaluate() {
-        Mockito.verify(gatewaySpy).evaluate(evaluateRequestCaptor.capture());
+        synchronized (gatewaySpy) {
+            Mockito.verify(gatewaySpy).evaluate(evaluateRequestCaptor.capture());
+        }
         return evaluateRequestCaptor.getValue();
     }
 
     public SubmitRequest captureSubmit() {
-        Mockito.verify(gatewaySpy).submit(submitRequestCaptor.capture());
+        synchronized (gatewaySpy) {
+            Mockito.verify(gatewaySpy).submit(submitRequestCaptor.capture());
+        }
         return submitRequestCaptor.getValue();
     }
 
     public SignedCommitStatusRequest captureCommitStatus() {
-        Mockito.verify(gatewaySpy).commitStatus(commitStatusRequestCaptor.capture());
+        synchronized (gatewaySpy) {
+            Mockito.verify(gatewaySpy).commitStatus(commitStatusRequestCaptor.capture());
+        }
         return commitStatusRequestCaptor.getValue();
     }
 
     public SignedChaincodeEventsRequest captureChaincodeEvents() {
-        Mockito.verify(gatewaySpy).chaincodeEvents(chaincodeEventsRequestCaptor.capture());
+        synchronized (gatewaySpy) {
+            Mockito.verify(gatewaySpy).chaincodeEvents(chaincodeEventsRequestCaptor.capture());
+        }
         return chaincodeEventsRequestCaptor.getValue();
     }
 
     public Stream<Envelope> captureBlockEvents() {
-        Mockito.verify(deliverSpy).blockEvents(deliverRequestCaptor.capture());
+        synchronized (deliverSpy) {
+            Mockito.verify(deliverSpy).blockEvents(deliverRequestCaptor.capture());
+        }
         return deliverRequestCaptor.getValue();
     }
 
     public Stream<Envelope> captureFilteredBlockEvents() {
-        Mockito.verify(deliverSpy).filteredBlockEvents(deliverFilteredRequestCaptor.capture());
+        synchronized (deliverSpy) {
+            Mockito.verify(deliverSpy).filteredBlockEvents(deliverFilteredRequestCaptor.capture());
+        }
         return deliverFilteredRequestCaptor.getValue();
     }
 
     public Stream<Envelope> captureBlockAndPrivateDataEvents() {
-        Mockito.verify(deliverSpy).blockAndPrivateDataEvents(deliverWithPrivateDataRequestCaptor.capture());
+        synchronized (deliverSpy) {
+            Mockito.verify(deliverSpy).blockAndPrivateDataEvents(deliverWithPrivateDataRequestCaptor.capture());
+        }
         return deliverWithPrivateDataRequestCaptor.getValue();
     }
 

--- a/java/src/test/java/org/hyperledger/fabric/client/MockDeliverService.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/MockDeliverService.java
@@ -26,16 +26,22 @@ public final class MockDeliverService extends DeliverGrpc.DeliverImplBase {
 
     @Override
     public StreamObserver<Envelope> deliver(final StreamObserver<DeliverResponse> responseObserver) {
-        return testUtils.invokeStubDuplexCall(stub::blockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
+        synchronized (stub) {
+            return testUtils.invokeStubDuplexCall(stub::blockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
+        }
     }
 
     @Override
     public StreamObserver<Envelope> deliverFiltered(final StreamObserver<DeliverResponse> responseObserver) {
-        return testUtils.invokeStubDuplexCall(stub::filteredBlockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
+        synchronized (stub) {
+            return testUtils.invokeStubDuplexCall(stub::filteredBlockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
+        }
     }
 
     @Override
     public StreamObserver<Envelope> deliverWithPrivateData(final StreamObserver<DeliverResponse> responseObserver) {
-        return testUtils.invokeStubDuplexCall(stub::blockAndPrivateDataEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
+        synchronized (stub) {
+            return testUtils.invokeStubDuplexCall(stub::blockAndPrivateDataEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
+        }
     }
 }

--- a/java/src/test/java/org/hyperledger/fabric/client/MockGatewayService.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/MockGatewayService.java
@@ -33,27 +33,37 @@ public final class MockGatewayService extends GatewayGrpc.GatewayImplBase {
 
     @Override
     public void endorse(final EndorseRequest request, final StreamObserver<EndorseResponse> responseObserver) {
-        testUtils.invokeStubUnaryCall(stub::endorse, request, responseObserver);
+        synchronized (stub) {
+            testUtils.invokeStubUnaryCall(stub::endorse, request, responseObserver);
+        }
     }
 
     @Override
     public void submit(final SubmitRequest request, final StreamObserver<SubmitResponse> responseObserver) {
-        testUtils.invokeStubUnaryCall(stub::submit, request, responseObserver);
+        synchronized (stub) {
+            testUtils.invokeStubUnaryCall(stub::submit, request, responseObserver);
+        }
     }
 
     @Override
     public void evaluate(final EvaluateRequest request, final StreamObserver<EvaluateResponse> responseObserver) {
-        testUtils.invokeStubUnaryCall(stub::evaluate, request, responseObserver);
+        synchronized (stub) {
+            testUtils.invokeStubUnaryCall(stub::evaluate, request, responseObserver);
+        }
     }
 
     @Override
     public void commitStatus(final SignedCommitStatusRequest request, final StreamObserver<CommitStatusResponse> responseObserver) {
-        testUtils.invokeStubUnaryCall(stub::commitStatus, request, responseObserver);
+        synchronized (stub) {
+            testUtils.invokeStubUnaryCall(stub::commitStatus, request, responseObserver);
+        }
     }
 
     @Override
     public void chaincodeEvents(final SignedChaincodeEventsRequest request, final StreamObserver<ChaincodeEventsResponse> responseObserver) {
-        testUtils.invokeStubServerStreamingCall(stub::chaincodeEvents, request, responseObserver);
+        synchronized (stub) {
+            testUtils.invokeStubServerStreamingCall(stub::chaincodeEvents, request, responseObserver);
+        }
     }
 
 }


### PR DESCRIPTION
Eventing request messages are sometimes not captured correctly. The suspicion is that this is caused by the multi-threaded nature of the eventing flow. Explicit synchronization to the unit test stubs at the point of service invocation and when capturing invocation arguments, in an attempt to ensure consistency.

Resolves #696