### PR TITLE
Scenario test oldest and newest language versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -177,8 +177,6 @@ jobs:
       matrix:
         java-version:
           - 8
-          - 11
-          - 17
           - 21
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Save build cycles by only running scenario tests using the oldest and newest versions of each of the supported languages. For example, Java scenario tests are run with only Java 8 and Java 21, not Java 11 or Java 17. Unit tests are much cheaper so are still run with all supported language versions.