### PR TITLE
Use latest stable Go and Node releases in CI

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "lts/*"
       - name: Generate documentation
         run: make generate-docs-node
       - name: Upload documentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,6 @@ name: Test
 on:
   workflow_call:
 
-env:
-  DEFAULT_GO_VERSION: "1.22"
-
 jobs:
   verify-versions:
     uses: ./.github/workflows/verify-versions.yml
@@ -32,7 +29,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          go-version: stable
       - name: Generate mocks
         run: make generate
       - name: Staticcheck
@@ -135,7 +132,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          go-version: stable
       - name: Install SoftHSM
         run: sudo apt install -y softhsm
         env:
@@ -186,7 +183,7 @@ jobs:
           cache: maven
       - uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.DEFAULT_GO_VERSION }}
+          go-version: stable
       - name: Pull Fabric Docker images
         run: make pull-latest-peer
       - name: Run scenario tests

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GO_VERSION: "1.22"
-
 jobs:
   go:
     runs-on: ubuntu-latest
@@ -26,7 +23,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: stable
           check-latest: true
       - name: Scan
         run: make scan-go-${{ matrix.target }}
@@ -44,12 +41,12 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "lts/*"
       - name: Set up Go
         if: ${{ matrix.target == 'osv-scanner' }}
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: stable
       - name: Scan
         run: make scan-node-${{ matrix.target }}
 
@@ -61,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ env.GO_VERSION }}
+          go-version: stable
       - name: Scan
         run: make scan-java-osv-scanner
 


### PR DESCRIPTION
For GitHub Actions jobs that are not sensitive to the version of Go or Node used, use "stable" or "lts/*" as the version for Go and Node respectively.

Previously the version number was specified explicitly, which requires more ongoing maintenance and conveys less clarity of the intent that the latest stable version should be used.