### PR TITLE
Remove unnecessary GitHub Actions permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,9 +5,6 @@ on:
     - cron: "15 23 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,13 +11,18 @@ jobs:
 
   publish-docs:
     needs: build
-    name: Publish API documentation
+    name: Publish documentation
     permissions:
       pages: write
       id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
+    # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+    # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     runs-on: ubuntu-latest
     steps:
       - name: Download site
@@ -34,6 +39,8 @@ jobs:
         with:
           name: node-doc
           path: ${{ github.ref_name }}/api/node
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
       - name: Upload GitHub Pages content
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -5,9 +5,6 @@ on:
     - cron: "20 23 * * *"
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Explicit default permissions in workflows are not required with read-only permissions set at the repository level.

Also use a concurrency group for GitHub Pages deployment.

Closes #712