### PR TITLE
Update Mockito to v5 for Java tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -150,7 +150,6 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 8
           - 11
           - 17
           - 21
@@ -172,7 +171,7 @@ jobs:
       fail-fast: false
       matrix:
         java-version:
-          - 8
+          - 11
           - 21
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ build these components, the following need to be installed and available in the 
 
 - [Go 1.21+](https://go.dev/)
 - [Node 18+](https://nodejs.org/)
-- [Java 8+](https://adoptium.net/)
+- [Java 11+](https://adoptium.net/)
 - [Docker](https://www.docker.com/)
 - [Make](https://www.gnu.org/software/make/)
 - [Maven](https://maven.apache.org/)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,10 +4,10 @@ Each minor release version of Fabric Gateway client API targets the current supp
 
 The following table shows versions of Fabric, programming language runtimes, and other dependencies that are explicitly tested and that are supported for use with the latest version of the Fabric Gateway client API.
 
-|              | Tested        | Supported     |
-| ------------ | ------------- | ------------- |
-| **Fabric**   | 2.5           | 2.4.4+        |
-| **Go**       | 1.21, 1.22    | 1.21, 1.22    |
-| **Node**     | 18, 20        | 18, 20        |
-| **Java**     | 8, 11, 17, 21 | 8, 11, 17, 21 |
-| **Platform** | Ubuntu 22.04  |               |
+|              | Tested       | Supported     |
+| ------------ | ------------ | ------------- |
+| **Fabric**   | 2.5          | 2.4.4+        |
+| **Go**       | 1.21, 1.22   | 1.21, 1.22    |
+| **Node**     | 18, 20       | 18, 20        |
+| **Java**     | 11, 17, 21   | 8, 11, 17, 21 |
+| **Platform** | Ubuntu 22.04 |               |

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -189,7 +189,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.12.1</version>
                 <configuration>
                     <source>${javaVersion}</source>
                     <target>${javaVersion}</target>
@@ -440,7 +440,7 @@
                     <plugin>
                         <groupId>org.cyclonedx</groupId>
                         <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <version>2.8.0</version>
+                        <version>2.7.11</version>
                         <configuration>
                             <includeCompileScope>true</includeCompileScope>
                             <includeProvidedScope>false</includeProvidedScope>
@@ -466,7 +466,7 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-assembly-plugin</artifactId>
-                        <version>3.7.1</version>
+                        <version>3.6.0</version>
                         <configuration>
                             <descriptorRefs>
                                 <descriptorRef>jar-with-dependencies</descriptorRef>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -47,7 +47,7 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.16.1</version>
+                <version>7.18.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -82,13 +82,13 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.25.3</version>
+            <version>3.26.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>4.11.0</version>
+            <version>5.12.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -153,7 +153,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
-                <version>3.4.1</version>
+                <version>3.5.0</version>
                 <executions>
                     <execution>
                         <id>enforce-version</id>
@@ -163,7 +163,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>${javaVersion}</version>
+                                    <version>11</version>
                                 </requireJavaVersion>
                                 <requireMavenVersion>
                                     <version>3.6.3</version>
@@ -176,7 +176,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-help-plugin</artifactId>
-                <version>3.4.0</version>
+                <version>3.4.1</version>
                 <executions>
                     <execution>
                         <id>show-profiles</id>
@@ -204,7 +204,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.3.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>me.fabriciorby</groupId>
@@ -264,7 +264,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.6.3</version>
+                <version>3.7.0</version>
                 <configuration>
                     <show>public</show>
                     <doctitle>Hyperledger Fabric Gateway client API for Java</doctitle>
@@ -295,7 +295,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>3.3.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -411,7 +411,7 @@
                     <plugin>
                         <groupId>org.owasp</groupId>
                         <artifactId>dependency-check-maven</artifactId>
-                        <version>9.1.0</version>
+                        <version>9.2.0</version>
                         <configuration>
                             <skipProvidedScope>true</skipProvidedScope>
                             <skipTestScope>true</skipTestScope>
@@ -484,7 +484,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.2</version>
+                        <version>3.2.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -528,7 +528,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>1.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>

--- a/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/ChaincodeEventsTest.java
@@ -96,13 +96,11 @@ public final class ChaincodeEventsTest {
         StatusRuntimeException expected = new StatusRuntimeException(Status.UNAVAILABLE);
         doThrow(expected).when(stub).chaincodeEvents(any());
 
-        GatewayRuntimeException e = catchThrowableOfType(
-                () -> {
-                    try (CloseableIterator<ChaincodeEvent> events = network.getChaincodeEvents("CHAINCODE_NAME")) {
-                        events.forEachRemaining(event -> {});
-                    }
-                },
-                GatewayRuntimeException.class);
+        GatewayRuntimeException e = catchThrowableOfType(GatewayRuntimeException.class, () -> {
+            try (CloseableIterator<ChaincodeEvent> events = network.getChaincodeEvents("CHAINCODE_NAME")) {
+                events.forEachRemaining(event -> {});
+            }
+        });
         assertThat(e.getStatus()).isEqualTo(expected.getStatus());
         assertThat(e).hasCauseInstanceOf(StatusRuntimeException.class);
     }
@@ -322,7 +320,7 @@ public final class ChaincodeEventsTest {
         }
 
         GatewayRuntimeException e =
-                catchThrowableOfType(() -> eventIter.forEachRemaining(event -> {}), GatewayRuntimeException.class);
+                catchThrowableOfType(GatewayRuntimeException.class, () -> eventIter.forEachRemaining(event -> {}));
         assertThat(e).hasCauseInstanceOf(StatusRuntimeException.class);
         assertThat(e.getStatus().getCode()).isEqualTo(Status.Code.CANCELLED);
     }

--- a/java/src/test/java/org/hyperledger/fabric/client/CommonBlockEventsTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/CommonBlockEventsTest.java
@@ -122,13 +122,11 @@ public abstract class CommonBlockEventsTest<E> {
         StatusRuntimeException expected = new StatusRuntimeException(Status.UNAVAILABLE);
         stubDoThrow(expected);
 
-        GatewayRuntimeException e = catchThrowableOfType(
-                () -> {
-                    try (CloseableIterator<?> iter = getEvents()) {
-                        iter.forEachRemaining(event -> {});
-                    }
-                },
-                GatewayRuntimeException.class);
+        GatewayRuntimeException e = catchThrowableOfType(GatewayRuntimeException.class, () -> {
+            try (CloseableIterator<?> iter = getEvents()) {
+                iter.forEachRemaining(event -> {});
+            }
+        });
 
         assertThat(e.getStatus()).isEqualTo(expected.getStatus());
         assertThat(e).hasCauseInstanceOf(StatusRuntimeException.class);

--- a/java/src/test/java/org/hyperledger/fabric/client/GatewayMocker.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/GatewayMocker.java
@@ -119,58 +119,42 @@ public final class GatewayMocker implements AutoCloseable {
     }
 
     public EndorseRequest captureEndorse() {
-        synchronized (gatewaySpy) {
-            Mockito.verify(gatewaySpy).endorse(endorseRequestCaptor.capture());
-        }
+        Mockito.verify(gatewaySpy).endorse(endorseRequestCaptor.capture());
         return endorseRequestCaptor.getValue();
     }
 
     public EvaluateRequest captureEvaluate() {
-        synchronized (gatewaySpy) {
-            Mockito.verify(gatewaySpy).evaluate(evaluateRequestCaptor.capture());
-        }
+        Mockito.verify(gatewaySpy).evaluate(evaluateRequestCaptor.capture());
         return evaluateRequestCaptor.getValue();
     }
 
     public SubmitRequest captureSubmit() {
-        synchronized (gatewaySpy) {
-            Mockito.verify(gatewaySpy).submit(submitRequestCaptor.capture());
-        }
+        Mockito.verify(gatewaySpy).submit(submitRequestCaptor.capture());
         return submitRequestCaptor.getValue();
     }
 
     public SignedCommitStatusRequest captureCommitStatus() {
-        synchronized (gatewaySpy) {
-            Mockito.verify(gatewaySpy).commitStatus(commitStatusRequestCaptor.capture());
-        }
+        Mockito.verify(gatewaySpy).commitStatus(commitStatusRequestCaptor.capture());
         return commitStatusRequestCaptor.getValue();
     }
 
     public SignedChaincodeEventsRequest captureChaincodeEvents() {
-        synchronized (gatewaySpy) {
-            Mockito.verify(gatewaySpy).chaincodeEvents(chaincodeEventsRequestCaptor.capture());
-        }
+        Mockito.verify(gatewaySpy).chaincodeEvents(chaincodeEventsRequestCaptor.capture());
         return chaincodeEventsRequestCaptor.getValue();
     }
 
     public Stream<Envelope> captureBlockEvents() {
-        synchronized (deliverSpy) {
-            Mockito.verify(deliverSpy).blockEvents(deliverRequestCaptor.capture());
-        }
+        Mockito.verify(deliverSpy).blockEvents(deliverRequestCaptor.capture());
         return deliverRequestCaptor.getValue();
     }
 
     public Stream<Envelope> captureFilteredBlockEvents() {
-        synchronized (deliverSpy) {
-            Mockito.verify(deliverSpy).filteredBlockEvents(deliverFilteredRequestCaptor.capture());
-        }
+        Mockito.verify(deliverSpy).filteredBlockEvents(deliverFilteredRequestCaptor.capture());
         return deliverFilteredRequestCaptor.getValue();
     }
 
     public Stream<Envelope> captureBlockAndPrivateDataEvents() {
-        synchronized (deliverSpy) {
-            Mockito.verify(deliverSpy).blockAndPrivateDataEvents(deliverWithPrivateDataRequestCaptor.capture());
-        }
+        Mockito.verify(deliverSpy).blockAndPrivateDataEvents(deliverWithPrivateDataRequestCaptor.capture());
         return deliverWithPrivateDataRequestCaptor.getValue();
     }
 

--- a/java/src/test/java/org/hyperledger/fabric/client/MockDeliverService.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/MockDeliverService.java
@@ -26,25 +26,19 @@ public final class MockDeliverService extends DeliverGrpc.DeliverImplBase {
 
     @Override
     public StreamObserver<Envelope> deliver(final StreamObserver<DeliverResponse> responseObserver) {
-        synchronized (stub) {
-            return testUtils.invokeStubDuplexCall(
-                    stub::blockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
-        }
+        return testUtils.invokeStubDuplexCall(
+                stub::blockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
     }
 
     @Override
     public StreamObserver<Envelope> deliverFiltered(final StreamObserver<DeliverResponse> responseObserver) {
-        synchronized (stub) {
-            return testUtils.invokeStubDuplexCall(
-                    stub::filteredBlockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
-        }
+        return testUtils.invokeStubDuplexCall(
+                stub::filteredBlockEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
     }
 
     @Override
     public StreamObserver<Envelope> deliverWithPrivateData(final StreamObserver<DeliverResponse> responseObserver) {
-        synchronized (stub) {
-            return testUtils.invokeStubDuplexCall(
-                    stub::blockAndPrivateDataEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
-        }
+        return testUtils.invokeStubDuplexCall(
+                stub::blockAndPrivateDataEvents, (ServerCallStreamObserver<DeliverResponse>) responseObserver, 1);
     }
 }

--- a/java/src/test/java/org/hyperledger/fabric/client/MockGatewayService.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/MockGatewayService.java
@@ -33,39 +33,29 @@ public final class MockGatewayService extends GatewayGrpc.GatewayImplBase {
 
     @Override
     public void endorse(final EndorseRequest request, final StreamObserver<EndorseResponse> responseObserver) {
-        synchronized (stub) {
-            testUtils.invokeStubUnaryCall(stub::endorse, request, responseObserver);
-        }
+        testUtils.invokeStubUnaryCall(stub::endorse, request, responseObserver);
     }
 
     @Override
     public void submit(final SubmitRequest request, final StreamObserver<SubmitResponse> responseObserver) {
-        synchronized (stub) {
-            testUtils.invokeStubUnaryCall(stub::submit, request, responseObserver);
-        }
+        testUtils.invokeStubUnaryCall(stub::submit, request, responseObserver);
     }
 
     @Override
     public void evaluate(final EvaluateRequest request, final StreamObserver<EvaluateResponse> responseObserver) {
-        synchronized (stub) {
-            testUtils.invokeStubUnaryCall(stub::evaluate, request, responseObserver);
-        }
+        testUtils.invokeStubUnaryCall(stub::evaluate, request, responseObserver);
     }
 
     @Override
     public void commitStatus(
             final SignedCommitStatusRequest request, final StreamObserver<CommitStatusResponse> responseObserver) {
-        synchronized (stub) {
-            testUtils.invokeStubUnaryCall(stub::commitStatus, request, responseObserver);
-        }
+        testUtils.invokeStubUnaryCall(stub::commitStatus, request, responseObserver);
     }
 
     @Override
     public void chaincodeEvents(
             final SignedChaincodeEventsRequest request,
             final StreamObserver<ChaincodeEventsResponse> responseObserver) {
-        synchronized (stub) {
-            testUtils.invokeStubServerStreamingCall(stub::chaincodeEvents, request, responseObserver);
-        }
+        testUtils.invokeStubServerStreamingCall(stub::chaincodeEvents, request, responseObserver);
     }
 }

--- a/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
+++ b/java/src/test/java/org/hyperledger/fabric/client/SubmitTransactionTest.java
@@ -317,7 +317,7 @@ public final class SubmitTransactionTest {
 
         Proposal proposal = contract.newProposal("TRANSACTION_NAME").build();
 
-        EndorseException e = catchThrowableOfType(proposal::endorse, EndorseException.class);
+        EndorseException e = catchThrowableOfType(EndorseException.class, proposal::endorse);
         assertThat(e.getTransactionId()).isEqualTo(proposal.getTransactionId());
         assertThat(e.getStatus()).isEqualTo(expected.getStatus());
         assertThat(e).hasCauseInstanceOf(StatusRuntimeException.class);
@@ -331,7 +331,7 @@ public final class SubmitTransactionTest {
         Transaction transaction =
                 contract.newProposal("TRANSACTION_NAME").build().endorse();
 
-        SubmitException e = catchThrowableOfType(transaction::submit, SubmitException.class);
+        SubmitException e = catchThrowableOfType(SubmitException.class, transaction::submit);
         assertThat(e.getTransactionId()).isEqualTo(transaction.getTransactionId());
         assertThat(e.getStatus()).isEqualTo(expected.getStatus());
         assertThat(e).hasCauseInstanceOf(StatusRuntimeException.class);
@@ -345,7 +345,7 @@ public final class SubmitTransactionTest {
         SubmittedTransaction commit =
                 contract.newProposal("TRANSACTION_NAME").build().endorse().submitAsync();
 
-        CommitStatusException e = catchThrowableOfType(commit::getStatus, CommitStatusException.class);
+        CommitStatusException e = catchThrowableOfType(CommitStatusException.class, commit::getStatus);
         assertThat(e.getTransactionId()).isEqualTo(commit.getTransactionId());
         assertThat(e.getStatus()).isEqualTo(expected.getStatus());
         assertThat(e).hasCauseInstanceOf(StatusRuntimeException.class);
@@ -360,7 +360,7 @@ public final class SubmitTransactionTest {
         Transaction transaction =
                 contract.newProposal("TRANSACTION_NAME").build().endorse();
 
-        CommitException e = catchThrowableOfType(transaction::submit, CommitException.class);
+        CommitException e = catchThrowableOfType(CommitException.class, transaction::submit);
 
         assertThat(e).hasMessageContaining(TxValidationCode.MVCC_READ_CONFLICT.name());
         assertThat(e.getCode()).isEqualTo(TxValidationCode.MVCC_READ_CONFLICT);


### PR DESCRIPTION
v4 is no longer supported. v5 does require a minimum of Java 11 but Java 8 is still targeted as the release version.

Also revert commit f026b2cff5c021216da330cf2b48e8a9eac69753 since the synchronization added there did not resolve intermittent test failures in the automated build.