### PR TITLE
Remove CycloneDX Java SBOM generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ scan-go-nancy:
 .PHONY: scan-go-osv-scanner
 scan-go-osv-scanner:
 	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-	osv-scanner --lockfile='$(base_dir)/go.mod' || [ \( $$? -gt 1 \) -a \( $$? -lt 127 \) ]
+	osv-scanner scan --lockfile='$(base_dir)/go.mod' || [ \( $$? -gt 1 \) -a \( $$? -lt 127 \) ]
 
 .PHONY: scan-node
 scan-node: scan-node-npm-audit scan-node-osv-scanner
@@ -127,7 +127,7 @@ scan-node-osv-scanner:
 	cd '$(node_dir)' && \
 		npm install && \
 		npm run sbom && \
-		osv-scanner --sbom=sbom.json
+		osv-scanner scan --sbom=sbom.json
 
 .PHONY: scan-java
 scan-java: scan-java-dependency-check scan-java-osv-scanner
@@ -140,9 +140,7 @@ scan-java-dependency-check:
 .PHONY: scan-java-osv-scanner
 scan-java-osv-scanner:
 	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
-	cd '$(java_dir)' && \
-		mvn --activate-profiles sbom -DskipTests install
-	osv-scanner --sbom='$(java_dir)/target/bom.json'
+	osv-scanner scan --lockfile='$(java_dir)/pom.xml'
 
 .PHONY: generate
 generate:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -434,33 +434,6 @@
             </build>
         </profile>
         <profile>
-            <id>sbom</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.cyclonedx</groupId>
-                        <artifactId>cyclonedx-maven-plugin</artifactId>
-                        <version>2.7.11</version>
-                        <configuration>
-                            <includeCompileScope>true</includeCompileScope>
-                            <includeProvidedScope>false</includeProvidedScope>
-                            <includeRuntimeScope>true</includeRuntimeScope>
-                            <includeSystemScope>false</includeSystemScope>
-                            <includeTestScope>false</includeTestScope>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>makeAggregateBom</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>release</id>
             <build>
                 <plugins>


### PR DESCRIPTION
This was used to generate an SBOM containing transitive dependencies for OSV-Scanner. OSV-Scanner v1.8.1 and later can natively scan transitive dependencies in Maven pom.xml files so the CycloneDX SBOM generation step is no longer required.