### PR TITLE
Use full go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/cucumber/godog v0.14.0

--- a/scenario/fixtures/chaincode/golang/basic/go.mod
+++ b/scenario/fixtures/chaincode/golang/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway/scenario/fixtures/chaincode/go/basic
 
-go 1.21
+go 1.21.0
 
 require github.com/hyperledger/fabric-contract-api-go v1.2.2
 

--- a/scenario/fixtures/chaincode/golang/private/go.mod
+++ b/scenario/fixtures/chaincode/golang/private/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway/scenario/fixtures/chaincode/go/private
 
-go 1.21
+go 1.21.0
 
 require (
 	github.com/hyperledger/fabric-chaincode-go v0.0.0-20240124143825-7dec3c7e7d45


### PR DESCRIPTION
From Go 1.21, in the absence of a toolchain line in the go.mod file, the go line is used as the minimum toolchain version. Toolchain versions must be a full Go version, including patch level.