### PR TITLE
Use Java dependency-check GitHub Action

### DIFF
--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -62,6 +62,9 @@ jobs:
   java_dependency_check:
     name: "java (dependency-check)"
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: java
     steps:
       - uses: actions/checkout@v4
       - name: Set up Java
@@ -70,32 +73,23 @@ jobs:
           java-version: 21
           distribution: temurin
           cache: maven
-      - name: Get Date
-        id: get-date
-        shell: bash
-        run: echo "datetime=$(/bin/date -u '+%Y%m%d%H')" >> $GITHUB_OUTPUT
-      - name: Restore cached Maven dependencies
-        uses: actions/cache/restore@v4
-        with:
-          path: ~/.m2/repository
-          # Using datetime in cache key as OWASP database may change, without the pom changing
-          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}
-            ${{ runner.os }}-maven-
+      - name: Download dependencies
+        run: mvn dependency:copy-dependencies -DincludeScope=runtime
       - name: Scan
         env:
-          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        run: make scan-java-dependency-check
-      - name: "Archive dependency-check report"
+          JAVA_HOME: /opt/jdk
+        uses: dependency-check/Dependency-Check_Action@main
+        with:
+          project: fabric-gateway
+          path: java/target/dependency
+          format: HTML
+          out: reports
+          args: >
+            --suppression java/dependency-suppression.xml
+            --failOnCVSS 4
+      - name: Archive dependency-check report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: dependency-check-report
-          path: java/target/dependency-check-report.html
-      - name: Cache Maven dependencies
-        if: ${{ !cancelled() }}
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.datetime }}-${{ hashFiles('**/pom.xml') }}
+          path: reports


### PR DESCRIPTION
The Maven dependency-check plugin is tricky to run due to:

- Need for NVD API token.
- Need to cache vulnerability database to avoid downloading the whole database on every invocation.
- Unreliability of the NVD API endpoint.

The action uses a Docker container that includes an up-to-date copy of the vulnerability database so avoids the need to use the NVD API.