### PR TITLE
Use current Go version for OSV-Scanner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ vendor/
 softhsm2.conf
 .python-version
 site/
+osv-scanner.toml

--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,7 @@ scan-go-nancy:
 .PHONY: scan-go-osv-scanner
 scan-go-osv-scanner:
 	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
+	echo "GoVersionOverride = '$$(go env GOVERSION | sed 's/^go//')'" > osv-scanner.toml
 	osv-scanner scan --lockfile='$(base_dir)/go.mod' || [ \( $$? -gt 1 \) -a \( $$? -lt 127 \) ]
 
 .PHONY: scan-node


### PR DESCRIPTION
OSV-Scanner uses the Go version specified by the `go` line in the `go.mod` file. The patch level specified is deliberately a lower version than the latest to allow consumers to select their own Go patch level, provided that the major / minor version are at the required level. This behaviour results in OSV-Scanner detecting standard library vulnerabilities from the back-level Go patch level.

This change forces OSV-Scanner to use the exact version of the Go binary used to run the scan.