### PR TITLE
Add pkcs11 Go build tag to CodeQL autobuild

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,8 @@ jobs:
           languages: ${{ matrix.language }}
       - name: Autobuild
         uses: github/codeql-action/autobuild@v3
+        env:
+          GOFLAGS: "-tags=pkcs11"
         with:
           working-directory: ${{ matrix.working-directory }}
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
Allows CodeQL to scan Go files excluded by this build contraint.