### PR TITLE
Add restrictive default permissions to workflows

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,6 +2,9 @@ name: Build documentation
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   node:
     runs-on: ubuntu-22.04

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,9 @@ on:
     - cron: "15 23 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,10 @@ name: Release
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - "v[0-9]+.[0-9]+.[0-9]+"
+
+permissions:
+  contents: read
 
 jobs:
   verify-versions:
@@ -18,7 +21,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 18
-          registry-url: 'https://registry.npmjs.org'
+          registry-url: "https://registry.npmjs.org"
       - name: Build
         run: make build-node
       - name: Publish

--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -5,6 +5,9 @@ on:
     - cron: "32 23 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   main:
     uses: ./.github/workflows/test.yml

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        uses: ossf/scorecard-action@dc50aa9510b46c811795eb24b2f1ba02a914e534 # v2.3.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,9 @@ name: Test
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   verify-versions:
     uses: ./.github/workflows/verify-versions.yml

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -3,6 +3,9 @@ name: Verify versions
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 env:
   GATEWAY_VERSION: 1.5.2
 

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -5,6 +5,9 @@ on:
     - cron: "20 23 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   go:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The default workflow permissions configured on the repository are already restrictive but explicitly setting permissions in each workflow makes the OSSF Scorecard checks happier.