### PR TITLE
Add Java code coverage

### DIFF
--- a/.github/scripts/jacoco2markdown.sh
+++ b/.github/scripts/jacoco2markdown.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+csv_to_markdown() {
+    awk 'function percentage(missed, covered,   total) {
+            total = missed + covered
+            if (total == 0) {
+                return "-"
+            }
+            return sprintf("%d", covered / total * 100)
+        }
+
+        BEGIN {
+            missed_instructions = 0
+            covered_instructions = 0
+            missed_branches = 0
+            covered_branches = 0
+            missed_lines = 0
+            covered_lines = 0
+            missed_methods = 0
+            covered_methods = 0
+
+            printf("<details>\n<summary>Details</summary>\n\n")
+            print("| Class | % Instruction | % Branch | % Line | % Method |")
+            print("| --- | ---: | ---: | ---: | ---: |")
+        }
+
+        {
+            split($0, cols, ",")
+
+            instructions = percentage(cols[4], cols[5])
+            missed_instructions += cols[4]
+            covered_instructions += cols[5]
+
+            branches = percentage(cols[6], cols[7])
+            missed_branches += cols[6]
+            covered_branches += cols[7]
+
+            lines = percentage(cols[8], cols[9])
+            missed_lines += cols[8]
+            covered_lines += cols[9]
+
+            methods = percentage(cols[12], cols[13])
+            missed_methods += cols[12]
+            covered_methods += cols[13]
+
+            printf("| %s.%s | %s | %s | %s | %s |\n",
+                cols[2], cols[3], instructions, branches, lines, methods)
+        }
+
+        END {
+            instructions = percentage(missed_instructions, covered_instructions)
+            branches = percentage(missed_branches, covered_branches)
+            lines = percentage(missed_lines, covered_lines)
+            methods = percentage(missed_methods, covered_methods)
+
+            printf("</details>\n\n")
+            print("| | % Instruction | % Branch | % Line | % Method |")
+            print("| --- | ---: | ---: | ---: | ---: |")
+            printf("| **All classes** | %s | %s | %s | %s |\n",
+                instructions, branches, lines, methods)
+        }'
+}
+
+if [[ $# == 0 ]] || [[ $1 == - ]]; then
+    tail -n +2 | sort | csv_to_markdown
+else
+    ( tail -n +2 | sort | csv_to_markdown ) < "$1"
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -156,6 +156,9 @@ jobs:
           - 11
           - 17
           - 21
+        include:
+          - java-version: 21
+            coverage: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -165,6 +168,11 @@ jobs:
           cache: maven
       - name: Run unit tests
         run: make unit-test-java
+      - name: Coverage report
+        if: ${{ matrix.coverage }}
+        run: |
+          echo '### Java unit test coverage' >> ${GITHUB_STEP_SUMMARY}
+          ${{ github.workspace }}/.github/scripts/jacoco2markdown.sh java/target/site/jacoco/jacoco.csv >> ${GITHUB_STEP_SUMMARY}
 
   java_scenario:
     needs: verify-versions

--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ unit-test-node: build-node
 .PHONY: unit-test-java
 unit-test-java:
 	cd '$(java_dir)' && \
-		mvn test
+		mvn test jacoco:report
 
 .PHONY: lint
 lint: staticcheck golangci-lint
@@ -271,4 +271,3 @@ format-node:
 .PHONY: format-java
 format-java:
 	cd '$(java_dir)' && mvn spotless:apply
-

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -263,6 +263,46 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.12</version>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-prepare-agent-integration</id>
+                        <goals>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules/>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.7.0</version>

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -u -o pipefail
+
 fileCount=0
 failCount=0
 


### PR DESCRIPTION
Use Jacoco to generate test coverage reports. Results are located in `java/target/site/jacoco` after `make unit-test-java` is run.

Closes #734