### PR TITLE
Tidy up CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -19,9 +19,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        language:
+          - go
+          - java
+          - javascript
         include:
-          - language: go
-            working-directory: ""
           - language: java
             working-directory: java
           - language: javascript
@@ -38,6 +40,6 @@ jobs:
         env:
           GOFLAGS: "-tags=pkcs11"
         with:
-          working-directory: ${{ matrix.working-directory }}
+          working-directory: ${{ matrix.working-directory || '' }}
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
Augment the matrix values with a working-directory only if a non-default value is needed. This avoids the augmented values appearing as a distraction in the workflow UI. For example, `Analyze (javascript)` instead of `Analyze (javascript, node)`.