### PR TITLE
Run CodeQL on pull requests

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,8 +1,12 @@
 name: "CodeQL"
 
 on:
-  schedule:
-    - cron: "15 23 * * *"
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
More rigorous static analysis is already a gating factor on pull request build success. Add CodeQL as an additional (currently unenforced) step in the pull request build so results can be assessed before changes are delivered instead of as a scheduled workflow on committed changes.