### PR TITLE
Pin typescript-eslint to avoid v8.6.0

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -59,6 +59,6 @@
         "ts-jest": "^29.2.4",
         "typedoc": "^0.26.6",
         "typescript": "~5.5.4",
-        "typescript-eslint": "^8.2.0"
+        "typescript-eslint": "~8.5"
     }
 }


### PR DESCRIPTION
typescript-eslint v8.6.0 contains a bug that causes failures when objects that use a symbol as a property name are inspected. Until this bug is fixed, pinning the dependency to v8.5.x.