### PR TITLE
Use built-in npm capability to generate SBOM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,8 +126,8 @@ scan-node-npm-audit:
 scan-node-osv-scanner:
 	go install github.com/google/osv-scanner/cmd/osv-scanner@latest
 	cd '$(node_dir)' && \
-		npm install && \
-		npm run sbom && \
+		npm install --package-lock-only && \
+		npm sbom --omit dev --package-lock-only --sbom-format cyclonedx > sbom.json && \
 		osv-scanner scan --sbom=sbom.json
 
 .PHONY: scan-java

--- a/node/package.json
+++ b/node/package.json
@@ -27,7 +27,6 @@
         "format:fix": "prettier '**/*.{ts,js}' --write",
         "generate-apidoc": "typedoc",
         "lint": "eslint src",
-        "sbom": "cyclonedx-npm --omit dev --output-format JSON --output-file sbom.json",
         "test": "npm-run-all lint format unit-test",
         "unit-test": "jest"
     },
@@ -42,7 +41,6 @@
         "pkcs11js": "^2.1.0"
     },
     "devDependencies": {
-        "@cyclonedx/cyclonedx-npm": "^1.19.3",
         "@eslint/eslintrc": "^3.1.0",
         "@eslint/js": "^9.9.0",
         "@tsconfig/node18": "^18.2.4",


### PR DESCRIPTION
Instead of using a separate `@cyclonedx/cyclonedx-npm` package dependency for SBOM generation, use the built-in (since npm v9) `npm sbom` command. This avoids the need to install all dependencies in order to generate an SBOM as part of an OSV-Scanner vulnerability scan.