### PR TITLE
Remove support for Go 1.21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.21"
           - "1.22"
           - "1.23"
         include:
@@ -85,7 +84,7 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.21"
+          - "1.22"
           - "1.23"
     env:
       SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GATEWAY_VERSION: 1.5.2
+  GATEWAY_VERSION: 1.6.0
 
 jobs:
   go:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See the [gateway.proto file](https://github.com/hyperledger/fabric-protos/blob/m
 This repository comprises three functionally equivalent client APIs, written in Go, Typescript, and Java. In order to
 build these components, the following need to be installed and available in the PATH:
 
-- [Go 1.21+](https://go.dev/)
+- [Go 1.22+](https://go.dev/)
 - [Node 18+](https://nodejs.org/)
 - [Java 11+](https://adoptium.net/)
 - [Docker](https://www.docker.com/)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,10 +4,10 @@ Each minor release version of Fabric Gateway client API targets the current supp
 
 The following table shows versions of Fabric, programming language runtimes, and other dependencies that are explicitly tested and that are supported for use with the latest version of the Fabric Gateway client API.
 
-|              | Tested           | Supported        |
-| ------------ | ---------------- | ---------------- |
-| **Fabric**   | 2.5              | 2.4.4+           |
-| **Go**       | 1.21, 1.22, 1.23 | 1.21, 1.22, 1.23 |
-| **Node**     | 18, 20, 22       | 18, 20, 22       |
-| **Java**     | 11, 17, 21       | 8, 11, 17, 21    |
-| **Platform** | Ubuntu 24.04     |                  |
+|              | Tested       | Supported     |
+| ------------ | ------------ | ------------- |
+| **Fabric**   | 2.5          | 2.4.4+        |
+| **Go**       | 1.22, 1.23   | 1.22, 1.23    |
+| **Node**     | 18, 20, 22   | 18, 20, 22    |
+| **Java**     | 11, 17, 21   | 8, 11, 17, 21 |
+| **Platform** | Ubuntu 24.04 |               |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway
 
-go 1.21.0
+go 1.22.0
 
 require (
 	github.com/cucumber/godog v0.14.1

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hyperledger.fabric</groupId>
     <artifactId>fabric-gateway</artifactId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>1.6.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>fabric-gateway</name>
@@ -62,7 +62,7 @@
             <dependency>
                 <groupId>io.grpc</groupId>
                 <artifactId>grpc-bom</artifactId>
-                <version>1.66.0</version>
+                <version>1.68.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -307,7 +307,7 @@
                             <goal>check</goal>
                         </goals>
                         <configuration>
-                            <rules/>
+                            <rules />
                         </configuration>
                     </execution>
                 </executions>
@@ -453,8 +453,8 @@
                         <configuration>
                             <checkSkip>${skipUnitTests}</checkSkip>
                             <java>
-                                <trimTrailingWhitespace/>
-                                <endWithNewline/>
+                                <trimTrailingWhitespace />
+                                <endWithNewline />
                                 <palantirJavaFormat>
                                     <version>2.47.0</version>
                                     <style>PALANTIR</style>

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.5.2",
+    "version": "1.6.0",
     "description": "Hyperledger Fabric Gateway client API for Node",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -42,12 +42,12 @@
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "^9.9.0",
+        "@eslint/js": "^9.11.0",
         "@tsconfig/node18": "^18.2.4",
         "@types/google-protobuf": "^3.15.12",
         "@types/jest": "^29.5.12",
-        "@types/node": "^18.19.45",
-        "eslint": "^9.9.0",
+        "@types/node": "^18.19.50",
+        "eslint": "^9.11.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-jest": "^28.8.0",
         "eslint-plugin-tsdoc": "^0.3.0",

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -29,7 +29,7 @@
         "@tsconfig/node18": "^18.2.4",
         "@types/node": "^18.19.45",
         "cucumber-console-formatter": "^1.0.0",
-        "eslint": "^9.9.0",
+        "eslint": "^9.11.0",
         "eslint-config-prettier": "^9.1.0",
         "expect": "^29.7.0",
         "npm-run-all": "^4.1.5",


### PR DESCRIPTION
Since the release of Go 1.23 on 2024-08-13, Go 1.21 is no longer a supported Go release.