### PR TITLE
Configure NPM to prefer dedupe in Node chaincode

### DIFF
--- a/scenario/fixtures/chaincode/node/errors/.gitignore
+++ b/scenario/fixtures/chaincode/node/errors/.gitignore
@@ -1,4 +1,2 @@
 node_modules/
-dist/
-coverage/
 package-lock.json

--- a/scenario/fixtures/chaincode/node/errors/.npmrc
+++ b/scenario/fixtures/chaincode/node/errors/.npmrc
@@ -1,0 +1,1 @@
+prefer-dedupe=true


### PR DESCRIPTION
When different versions of @grpc/grpc-js are resolved in the dependency tree, the following error in the chaincode can prevent the chaincode container from starting:

    TypeError: Channel credentials must be a ChannelCredentials object

This change adds an npmrc to the test Node chaincode, which configures NPM to perform dedupe by default. This ensures that only one version of @grpc/grpc-js is resolved in the chaincode's dependency tree.