### PR TITLE
Pull Docker images before scenario tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,8 @@ jobs:
           TMPDIR: ${{ runner.temp }}
       - name: Generate mocks
         run: make generate
+      - name: Pull Docker images
+        run: make pull-docker-images
       - name: Run scenario tests
         run: make scenario-test-go
 
@@ -147,6 +149,8 @@ jobs:
         run: sudo apt install -y softhsm2
         env:
           TMPDIR: ${{ runner.temp }}
+      - name: Pull Docker images
+        run: make pull-docker-images
       - name: Run scenario tests
         run: make scenario-test-node
 
@@ -199,5 +203,7 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
+      - name: Pull Docker images
+        run: make pull-docker-images
       - name: Run scenario tests
         run: make scenario-test-java

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ machine_hardware := $(shell uname -m)
 export SOFTHSM2_CONF ?= $(base_dir)/softhsm2.conf
 TMPDIR ?= /tmp
 
+# These should match names in Docker .env file
+export FABRIC_VERSION ?= 2.5
+export NODEENV_VERSION ?= 2.5
+export CA_VERSION ?= 1.5
+
 .PHONY: default
 default:
 	@echo 'No default target.'
@@ -188,6 +193,14 @@ scenario-test: scenario-test-go scenario-test-node scenario-test-java
 
 .PHONY: scenario-test-no-hsm
 scenario-test-no-hsm: scenario-test-go-no-hsm scenario-test-node-no-hsm scenario-test-java
+
+.PHONY: pull-docker-images
+pull-docker-images:
+	for IMAGE in peer orderer baseos ccenv tools; do \
+		docker pull --quiet "hyperledger/fabric-$${IMAGE}:$(FABRIC_VERSION)"; \
+	done
+	docker pull --quiet 'hyperledger/fabric-nodeenv:$(NODEENV_VERSION)'
+	docker pull --quiet 'hyperledger/fabric-ca:$(CA_VERSION)'
 
 .PHONY: fabric-ca-client
 fabric-ca-client:

--- a/scenario/fixtures/docker-compose/.env
+++ b/scenario/fixtures/docker-compose/.env
@@ -1,8 +1,6 @@
 # Environment variables will be overridden if set in user environment or Makefile.
 # Typically we'll want to test with the latest released orderer and tools images from dockerhub, but latest unreleased peer image that has been pulled and tagged
-ORDERER_IMAGE_TAG=2.5
-TOOLS_IMAGE_TAG=2.5
-PEER_IMAGE_TAG=2.5
-FABRIC_CA_IMAGE_TAG=1.5
+FABRIC_VERSION=2.5
+CA_VERSION=1.5
 DOCKER_DEBUG=info:dockercontroller,gateway=debug
 DOCKER_SOCK=/var/run/docker.sock

--- a/scenario/fixtures/docker-compose/docker-compose-base.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-base.yaml
@@ -15,7 +15,7 @@ version: "3.8"
 
 services:
   ca0:
-    image: hyperledger/fabric-ca:${FABRIC_CA_IMAGE_TAG}
+    image: hyperledger/fabric-ca:${CA_VERSION}
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org1
@@ -30,7 +30,7 @@ services:
     container_name: ca_peerOrg1
 
   ca1:
-    image: hyperledger/fabric-ca:${FABRIC_CA_IMAGE_TAG}
+    image: hyperledger/fabric-ca:${CA_VERSION}
     environment:
       - FABRIC_CA_HOME=/etc/hyperledger/fabric-ca-server
       - FABRIC_CA_SERVER_CA_NAME=ca-org2
@@ -45,7 +45,7 @@ services:
 
   orderer:
     container_name: orderer
-    image: hyperledger/fabric-orderer:${ORDERER_IMAGE_TAG}
+    image: hyperledger/fabric-orderer:${FABRIC_VERSION}
     environment:
       - ORDERER_GENERAL_LOGLEVEL=${DOCKER_DEBUG}
       - ORDERER_GENERAL_LISTENADDRESS=0.0.0.0
@@ -75,7 +75,7 @@ services:
 
   peer:
     container_name: peer
-    image: hyperledger/fabric-peer:${PEER_IMAGE_TAG}
+    image: hyperledger/fabric-peer:${FABRIC_VERSION}
     environment:
       - CORE_VM_ENDPOINT=unix:///host/var/run/docker.sock
       - CORE_PEER_ADDRESSAUTODETECT=true

--- a/scenario/fixtures/docker-compose/docker-compose-cli.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-cli.yaml
@@ -17,7 +17,7 @@ version: "3.8"
 services:
   clinopeer:
     container_name: cli
-    image: hyperledger/fabric-tools:${TOOLS_IMAGE_TAG}
+    image: hyperledger/fabric-tools:${FABRIC_VERSION}
     tty: true
     environment:
       # LOGGING SETTINGS


### PR DESCRIPTION
The previous change to not pull Docker images prior to running scenario tests seems to have introduced potential failures due to the time taken to pull images during chaincode deployment. This change explicitly pulls Docker images prior to running scenario tests in the automated build.