### PR TITLE
Fix GatewayException.printStackTrace(PrintStream)

### DIFF
--- a/java/src/main/java/org/hyperledger/fabric/client/GatewayException.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GatewayException.java
@@ -63,7 +63,9 @@ public class GatewayException extends Exception {
      */
     @Override
     public void printStackTrace(final PrintStream out) {
-        printStackTrace(new PrintWriter(out));
+        PrintWriter writer = new PrintWriter(out);
+        printStackTrace(writer);
+        writer.flush();
     }
 
     /**
@@ -76,7 +78,6 @@ public class GatewayException extends Exception {
 
         try (PrintWriter printer = new PrintWriter(message)) {
             super.printStackTrace(printer);
-            printer.flush();
         }
 
         List<ErrorDetail> details = getDetails();


### PR DESCRIPTION
The printStackTrace() implementation taking a PrintStream (rather than a PrintWriter) in the Java GatewayException class failed to print output. This was due to the PrinterWriter used to wrap the supplied PrintStream not being flushed.

This change calls the PrintStream overload with unit tests, instead of the PrintWriter overload (to which it defers) to ensure both variants behave correctly. The printStackTrace() implementation is updated to correctly flush the PrintWriter used internally to wrap the supplied PrintStream.