### PR TITLE
Document need for Gradle platform import

### DIFF
--- a/java/README.md
+++ b/java/README.md
@@ -48,13 +48,18 @@ A suitable gRPC channel service provider must also be specified (as described in
 Add the following dependency to your project's `build.gradle` file:
 
 ```groovy
-implementation 'org.hyperledger.fabric:fabric-gateway:1.6.0'
+implementation platform('org.hyperledger.fabric:fabric-gateway:1.6.0')
+implementation 'org.hyperledger.fabric:fabric-gateway'
 ```
+
+Note the **platform** import, which ensures that any transitive dependency management required by the fabric-gateway package is also applied to your Gradle project.
 
 A suitable gRPC channel service provider must also be specified (as described in the [gRPC security documentation](https://github.com/grpc/grpc-java/blob/master/SECURITY.md#transport-security-tls)), such as:
 
 ```groovy
-runtimeOnly 'io.grpc:grpc-netty-shaded:1.67.1'
+implementation platform('io.grpc:grpc-bom:1.67.1')
+compileOnly 'io.grpc:grpc-api'
+runtimeOnly 'io.grpc:grpc-netty-shaded'
 ```
 
 ## Compatibility

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -48,7 +48,7 @@
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
-                <version>7.20.0</version>
+                <version>7.20.1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -66,7 +66,7 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <!-- Override transitive dependency from grpc-protobuf to avoid CVE-2024-7254 -->
+            <!-- Protobuf v4 required for fabric-protos:0.3.4+ -->
             <dependency>
                 <groupId>com.google.protobuf</groupId>
                 <artifactId>protobuf-bom</artifactId>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.14.1</version>
+            <version>5.14.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -214,7 +214,7 @@
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.5.1</version>
                 <dependencies>
                     <dependency>
                         <groupId>me.fabriciorby</groupId>
@@ -315,7 +315,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.10.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <show>public</show>
                     <doctitle>Hyperledger Fabric Gateway client API for Java</doctitle>
@@ -530,7 +530,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.6</version>
+                        <version>3.2.7</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>


### PR DESCRIPTION
The latest fabric-protos require protobuf-java v4. This transitive dependency requirement is specified for Maven consumers in the POM file's dependency management, but a Gradle platform import is required for Gradle consumers to apply this dependency management configuration.

Depending on the gRPC version used, failure to apply the specified transitive dependency management can result in Gradle consumers resolving protobuf-java v3 and experiencing the following runtume failure:

    java.lang.NoClassDefFoundError: com/google/protobuf/RuntimeVersion$RuntimeDomain