### PR TITLE
Update release versions

### DIFF
--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GATEWAY_VERSION: 1.6.1
+  GATEWAY_VERSION: 1.7.0
 
 jobs:
   go:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,15 +12,15 @@ Here are a few guidelines to help you contribute successfully...
 
 ## Issues
 
-Issues are tracked in the GitHub repository [Issues](https://github.com/hyperledger/fabric-gateway/issues). *Please do not use issues to ask questions.*
+Issues are tracked in the GitHub repository [Issues](https://github.com/hyperledger/fabric-gateway/issues). _Please do not use issues to ask questions._
 
 If you find a bug which we don't already know about, you can help us by creating a new issue describing the problem. Please include as much detail as possible to help us track down the cause.
 
 ## Enhancements
 
-If you have a proposal for new functionality, either for the community to consider or that you would like to contribute yourself, please first raise an issue describing this functionality. Make the title something reasonably short but descriptive, and include a [user story](https://en.wikipedia.org/wiki/User_story) description of the enhancement, followed by any supporting information. For example, [issue #198](https://github.com/hyperledger/fabric-gateway/issues/198). The *"So that"* statement provides useful context about the motivation for the enhancement, and helps in determining whether any changes successfully satisfy the requirement.
+If you have a proposal for new functionality, either for the community to consider or that you would like to contribute yourself, please first raise an issue describing this functionality. Make the title something reasonably short but descriptive, and include a [user story](https://en.wikipedia.org/wiki/User_story) description of the enhancement, followed by any supporting information. For example, [issue #198](https://github.com/hyperledger/fabric-gateway/issues/198). The _"So that"_ statement provides useful context about the motivation for the enhancement, and helps in determining whether any changes successfully satisfy the requirement.
 
-*Make sure you have the support of the maintainers and community before investing a lot of effort in project enhancements.*
+_Make sure you have the support of the maintainers and community before investing a lot of effort in project enhancements._
 
 ## Contributing code
 
@@ -36,7 +36,7 @@ It is helpful to create work-in-progress pull requests as [draft](https://docs.g
 
 ### Go
 
-Go code uses [testify](https://github.com/stretchr/testify) for assertions, and [gomock](https://github.com/uber-go/mock) for mock implementations. The standard [errors](https://pkg.go.dev/errors) package is used; not any third-party error packages.
+Go code uses [testify](https://github.com/stretchr/testify) for assertions, and [mockery](https://vektra.github.io/mockery/) for mock implementations. The standard [errors](https://pkg.go.dev/errors) package is used; not any third-party error packages.
 
 Consider recommendations from these resources:
 
@@ -54,7 +54,7 @@ Node code is written only in [TypeScript](https://www.typescriptlang.org/), and 
 
 ### Java
 
-Java code uses [JUnit](https://junit.org/) as the test runner, [AssertJ](https://assertj.github.io/doc/) for assertions, and [Mockito](https://site.mockito.org/) for mock implementations. [PMD](https://pmd.github.io/) is used to perform static analysis of the code, and [Spotless](https://github.com/diffplug/spotless) (with [Palantir Java format](https://github.com/palantir/palantir-java-format) rules) checks consistent code formatting. 
+Java code uses [JUnit](https://junit.org/) as the test runner, [AssertJ](https://assertj.github.io/doc/) for assertions, and [Mockito](https://site.mockito.org/) for mock implementations. [PMD](https://pmd.github.io/) is used to perform static analysis of the code, and [Spotless](https://github.com/diffplug/spotless) (with [Palantir Java format](https://github.com/palantir/palantir-java-format) rules) checks consistent code formatting.
 
 Consider recommendations from these resources:
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hyperledger.fabric</groupId>
     <artifactId>fabric-gateway</artifactId>
-    <version>1.6.1-SNAPSHOT</version>
+    <version>1.7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>fabric-gateway</name>

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.6.1",
+    "version": "1.7.0",
     "description": "Hyperledger Fabric Gateway client API for Node",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
@@ -42,21 +42,21 @@
     },
     "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",
-        "@eslint/js": "^9.11.0",
+        "@eslint/js": "^9.12.0",
         "@tsconfig/node18": "^18.2.4",
         "@types/google-protobuf": "^3.15.12",
-        "@types/jest": "^29.5.12",
-        "@types/node": "^18.19.50",
-        "eslint": "^9.11.0",
+        "@types/jest": "^29.5.13",
+        "@types/node": "^18.19.56",
+        "eslint": "^9.12.0",
         "eslint-config-prettier": "^9.1.0",
-        "eslint-plugin-jest": "^28.8.0",
+        "eslint-plugin-jest": "^28.8.3",
         "eslint-plugin-tsdoc": "^0.3.0",
         "jest": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3",
-        "ts-jest": "^29.2.4",
-        "typedoc": "^0.26.6",
-        "typescript": "~5.5.4",
-        "typescript-eslint": "^8.7.0"
+        "ts-jest": "^29.2.5",
+        "typedoc": "^0.26.10",
+        "typescript": "~5.6.3",
+        "typescript-eslint": "^8.10.0"
     }
 }

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -25,16 +25,16 @@
         "@hyperledger/fabric-protos": "^0.3.0"
     },
     "devDependencies": {
-        "@cucumber/cucumber": "^10.9.0",
+        "@cucumber/cucumber": "^11.0.1",
         "@tsconfig/node18": "^18.2.4",
-        "@types/node": "^18.19.45",
+        "@types/node": "^18.19.56",
         "cucumber-console-formatter": "^1.0.0",
-        "eslint": "^9.11.0",
+        "eslint": "^9.12.0",
         "eslint-config-prettier": "^9.1.0",
         "expect": "^29.7.0",
         "npm-run-all": "^4.1.5",
         "prettier": "^3.3.3",
-        "typescript": "~5.5.4",
-        "typescript-eslint": "~8.5.0"
+        "typescript": "~5.6.3",
+        "typescript-eslint": "^8.10.0"
     }
 }


### PR DESCRIPTION
The protobuf update (for Java at least) is significant enough that a minor rather than patch-level version increase is probably warranted.

Also update dev dependencies to latest versions.