### PR TITLE
Update DevContainer configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,21 @@
 {
     "name": "Ubuntu",
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
-        "ghcr.io/devcontainers/features/go:1": {},
+        "ghcr.io/devcontainers/features/go:1": {
+            "version": "latest"
+        },
         "ghcr.io/devcontainers/features/java:1": {
+            "version": "lts",
+            "jdkDistro": "tem",
             "installMaven": true
         },
-        "ghcr.io/devcontainers/features/node:1": {},
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "lts"
+        },
         "ghcr.io/devcontainers/features/python:1": {
+            "version": "latest",
             "installTools": false
         },
         "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {
@@ -22,6 +29,7 @@
     "customizations": {
         "vscode": {
             "settings": {
+                "editor.defaultFormatter": "esbenp.prettier-vscode",
                 "go.buildTags": "pkcs11"
             },
             "extensions": [
@@ -32,5 +40,7 @@
             ]
         }
     },
-    "postStartCommand": ["make", "generate"]
+    "postCreateCommand": {
+        "generate": ["make", "generate"]
+    }
 }

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,9 @@ staticcheck:
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b '$(go_bin_dir)'
+	curl --fail --location --show-error --silent \
+		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+		| sh -s -- -b '$(go_bin_dir)'
 
 $(go_bin_dir)/golangci-lint:
 	$(MAKE) install-golangci-lint
@@ -141,7 +143,7 @@ scan-java-osv-scanner:
 
 .PHONY: install-mockery
 install-mockery:
-	curl --fail --location \
+	curl --fail --location --show-error --silent \
 		'https://github.com/vektra/mockery/releases/download/v$(mockery_version)/mockery_$(mockery_version)_$(kernel_name)_$(machine_hardware).tar.gz' \
 		| tar -C '$(go_bin_dir)' -xzf - mockery
 
@@ -239,7 +241,7 @@ clean: clean-generated clean-node clean-java clean-docs
 
 .PHONY: clean-node
 clean-node:
-	rm -rf '$(node_dir)/package-lock.json' '$(node_dir)/node_modules'
+	cd '$(node_dir)' && rm -rf package-lock.json node_modules
 
 .PHONY: clean-java
 clean-java:

--- a/node/package.json
+++ b/node/package.json
@@ -20,7 +20,7 @@
     },
     "scripts": {
         "build": "npm-run-all clean compile copy-non-ts-source",
-        "clean": "rm -rf apidocs dist src/protos",
+        "clean": "rm -rf apidocs dist",
         "compile": "tsc --project tsconfig.build.json",
         "copy-non-ts-source": "rsync -rv --prune-empty-dirs --include='*.d.ts' --exclude='*.ts' src/ dist",
         "format": "prettier '**/*.{ts,js}' --check",


### PR DESCRIPTION
- Use Ubuntu 24.04 as base image.
- Specify latest suitable runtime versions.
- Generate mocks at container creation instead of startup.