### PR TITLE
Fix mockery install to work on Apple Silicon Macs

### DIFF
--- a/.mockery.yaml
+++ b/.mockery.yaml
@@ -1,3 +1,4 @@
+issue-845-fix: true
 with-expecter: true
 exported: true
 filename: "{{.InterfaceName | lower}}_mock_test.go"

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,12 @@ scenario_dir := $(base_dir)/scenario
 
 go_bin_dir := $(shell go env GOPATH)/bin
 
-mockery_version := 2.46.2
+mockery_version := 2.48.0
 kernel_name := $(shell uname -s)
 machine_hardware := $(shell uname -m)
+ifeq ($(machine_hardware), aarch64)
+	machine_hardware := arm64
+endif
 
 export SOFTHSM2_CONF ?= $(base_dir)/softhsm2.conf
 TMPDIR ?= /tmp


### PR DESCRIPTION
The URL used to download the Mockery binary is composed using the current hardware platform string. For Apple Silicon Macs, this is `aarch64`, whereas the Mockery binary uses `arm64`.

This change uses `arm64` in place of `aarch64` as the hardware platform to build the Mockery download URL.

The version of Mockery is also updated.