### PR TITLE
Reduce frequency of scheduled builds

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -2,7 +2,7 @@ name: Scheduled build
 
 on:
   schedule:
-    - cron: "32 23 * * *"
+    - cron: "32 23 * * 6"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The rate of change in this repository is low. Run scheduled builds weekly instead of daily to save build resources.