### PR TITLE
Pull Docker images from GitHub Container Registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -205,10 +205,13 @@ scenario-test-no-hsm: scenario-test-go-no-hsm scenario-test-node-no-hsm scenario
 .PHONY: pull-docker-images
 pull-docker-images:
 	for IMAGE in peer orderer baseos ccenv tools; do \
-		docker pull --quiet "hyperledger/fabric-$${IMAGE}:$(FABRIC_VERSION)"; \
+		docker pull --quiet "ghcr.io/hyperledger/fabric-$${IMAGE}:$(FABRIC_VERSION)"; \
+		docker tag "ghcr.io/hyperledger/fabric-$${IMAGE}:$(FABRIC_VERSION)" "hyperledger/fabric-$${IMAGE}:$(FABRIC_VERSION)"; \
 	done
-	docker pull --quiet 'hyperledger/fabric-nodeenv:$(NODEENV_VERSION)'
-	docker pull --quiet 'hyperledger/fabric-ca:$(CA_VERSION)'
+	docker pull --quiet 'ghcr.io/hyperledger/fabric-nodeenv:$(NODEENV_VERSION)'
+	docker tag 'ghcr.io/hyperledger/fabric-nodeenv:$(NODEENV_VERSION)' 'hyperledger/fabric-nodeenv:$(NODEENV_VERSION)'
+	docker pull --quiet 'ghcr.io/hyperledger/fabric-ca:$(CA_VERSION)'
+	docker tag 'ghcr.io/hyperledger/fabric-ca:$(CA_VERSION)' 'hyperledger/fabric-ca:$(CA_VERSION)'
 
 .PHONY: fabric-ca-client
 fabric-ca-client:


### PR DESCRIPTION
Docker Hub has applied rate limiting that can potentially cause build issues. Current Fabric v2.5 and chaincode container images are also published to GitHub Container Registry (GHCR), which does not impose rate limits and is located closer to the build runners.