### PR TITLE
Use only OSV-Scanner to scan Go code

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -14,14 +14,8 @@ permissions:
 
 jobs:
   go:
+    name: "go (osv-scanner)"
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        target:
-          - govulncheck
-          - nancy
-          - osv-scanner
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,7 +26,7 @@ jobs:
           go-version: stable
           check-latest: true
       - name: Scan
-        run: make scan-go-${{ matrix.target }}
+        run: make scan-go-osv-scanner
 
   node:
     runs-on: ubuntu-latest

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -9,6 +9,10 @@ permissions:
   contents: read
 
 jobs:
+  latest:
+    name: Scan ${{ github.ref_name }}
+    uses: ./.github/workflows/scan.yml
+
   latest-release-version:
     name: Get latest release tag
     runs-on: ubuntu-latest
@@ -18,7 +22,7 @@ jobs:
       - id: tag-name
         run: echo "value=$(curl --location --silent --fail "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq --raw-output '.tag_name')" >> "${GITHUB_OUTPUT}"
 
-  scan:
+  release:
     name: Scan ${{ needs.latest-release-version.outputs.tag_name }}
     needs: latest-release-version
     uses: ./.github/workflows/scan.yml


### PR DESCRIPTION
OSV-Scanner uses Govulncheck internally so there is little benefit to running both. Nancy does not perform call analysis when scanning so is prone to false positives compared to OSV-Scanner (and Govulncheck).

This change removes scheduled scans of Go code using Govulncheck and Nancy. Only OSV-Scanner is used for Go code. Scheduled scanning of the latest code is added, in addition to scanning of the latest release.