### PR TITLE
Use unique name for dependency-check artifact

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -100,5 +100,5 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: dependency-check-report
+          name: dependency-check-report-${{ inputs.ref || github.event.pull_request.number || github.ref_name }}
           path: reports


### PR DESCRIPTION
The security vulnerability scan failed to upload dependency-check report artifacts since the name was not unique if the scan workflow was run on multiple branches / tags.

This change includes the target reference in the dependency-check artifact name to make it unique for the workflow.