### PR TITLE
Improve Node undefined signer implementation

### DIFF
--- a/node/src/signingidentity.ts
+++ b/node/src/signingidentity.ts
@@ -14,7 +14,7 @@ import { Signer } from './identity/signer';
 export const undefinedSignerMessage = 'No signing implementation';
 
 const undefinedSigner: Signer = () => {
-    throw new Error(undefinedSignerMessage);
+    return Promise.reject(new Error(undefinedSignerMessage));
 };
 
 type SigningIdentityOptions = Pick<ConnectOptions, 'identity' | 'signer' | 'hash'>;

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -588,7 +588,7 @@
         "node_modules/@hyperledger/fabric-gateway": {
             "version": "1.8.0",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-gH/1vBa4NsRukoFI+euKeKvrdg66IIVnJ38FUTxpZKwr8NXRXvY9M8jgw4pPUmaAZlvWgIjqOMqrFoxIGwMv+A==",
+            "integrity": "sha512-eslblkQhp7oF4331ZJ53vl6CB/nfqpgTD2IQqfNorN2NJVSG7Y4BpNGSq13xhuElvk4pVVLUJNR57GOLSS/5wQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.0",


### PR DESCRIPTION
A signer returns a Promise so an undefined signer implementation that returns a rejected Promise is more consistent with the typing than one that directly throws an Error. This should be functionally equivalent but better match the expectations of the API.