### PR TITLE
Use Python virtualenv for generate-docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "Ubuntu",
-    "image": "mcr.microsoft.com/devcontainers/base:ubuntu-24.04",
+    "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
     "features": {
         "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
         "ghcr.io/devcontainers/features/go:1": {
@@ -18,12 +18,8 @@
             "version": "latest",
             "installTools": false
         },
-        "ghcr.io/devcontainers-contrib/features/apt-get-packages:1": {
-            "packages": "softhsm2"
-        },
-        "ghcr.io/devcontainers-contrib/features/gh-release:1": {
-            "repo": "koalaman/shellcheck",
-            "binaryNames": "shellcheck"
+        "ghcr.io/devcontainers-extra/features/apt-get-packages:1": {
+            "packages": "shellcheck,softhsm2"
         }
     },
     "customizations": {
@@ -35,6 +31,9 @@
             "extensions": [
                 "esbenp.prettier-vscode",
                 "github.vscode-github-actions",
+                "-ms-python.python",
+                "-ms-python.vscode-pylance",
+                "-ms-python.autopep8",
                 "ms-vscode.makefile-tools",
                 "timonwong.shellcheck"
             ]

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ vendor/
 *.iml
 softhsm2.conf
 .python-version
+.venv/
 site/
 osv-scanner.toml

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ java_dir := $(base_dir)/java
 scenario_dir := $(base_dir)/scenario
 
 go_bin_dir := $(shell go env GOPATH)/bin
+python_venv_dir := $(base_dir)/.venv
+python_venv_activate := $(python_venv_dir)/bin/activate
 
 mockery_version := 2.52.2
 kernel_name := $(shell uname -s)
@@ -224,9 +226,14 @@ setup-softhsm:
 	softhsm2-util --init-token --slot 0 --label 'ForFabric' --pin 98765432 --so-pin 1234 || true
 
 .PHONY: generate-docs
-generate-docs:
-	pip install --quiet --upgrade --requirement '$(base_dir)/requirements.txt'
-	cd '$(base_dir)' && TZ=UTC mkdocs build --strict
+generate-docs: $(python_venv_activate)
+	. '$(python_venv_activate)' && \
+		cd '$(base_dir)' && \
+		python -m pip install --quiet --upgrade --require-virtualenv --disable-pip-version-check --requirement requirements.txt && \
+		TZ=UTC mkdocs build --strict
+
+$(python_venv_activate):
+	python -m venv '$(python_venv_dir)'
 
 .PHONY: generate-docs-node
 generate-docs-node:

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ build these components, the following need to be installed and available in the 
 - [Make](https://www.gnu.org/software/make/)
 - [Maven](https://maven.apache.org/)
 - [ShellCheck](https://github.com/koalaman/shellcheck#readme) (for linting shell scripts)
+- [Python 3](https://www.python.org/) (for building documentation site content)
 
 In order to run any of the Hardware Security Module (HSM) tests, [SoftHSM v2](https://www.opendnssec.org/softhsm/) is required. This can either be:
 
@@ -71,6 +72,10 @@ The following Makefile targets are available:
 - `make shellcheck` - check for script errors
 - `make test` - run all tests
 - `make format` - fix all code formatting
+- `make generate-docs` - generate documentation site content
+- `make generate-docs-node` - generate Node API documentation
+- `make generate-docs-java` - generate Java API documentation
+- `make clean` - remove all generated content
 
 ### Scenario tests
 


### PR DESCRIPTION
Avoid requiring contributors to set up their own Python virtualenv or risk polluting their global package install by explicitly creating a Python virtualenv to build the documentation site.

This change also documents the doc generation command in the README and fixes some minor issues with the Dev Container image definition that could prevent shellcheck from running in the container.