### PR TITLE
Update golangci-lint to v2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,8 @@ jobs:
           go-version: stable
       - name: Generate mocks
         run: make generate
-      - name: Staticcheck
-        run: make staticcheck
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6.5.2
+        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
         with:
           version: latest
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,37 +1,57 @@
-# See https://golangci-lint.run/usage/configuration/
-
+version: "2"
 run:
   build-tags:
     - pkcs11
-  timeout: 5m
-
 linters:
-  disable-all: true
+  default: none
   enable:
+    - cyclop
     - errcheck
+    - errname
+    - errorlint
     - gocognit
-    - gocyclo
-    - gofmt
     - goheader
-    - goimports
     - gosec
-    - gosimple
     - govet
     - ineffassign
     - misspell
+    - nolintlint
+    - staticcheck
     - testifylint
-    - typecheck
     - unused
-
-linters-settings:
-  gocognit:
-    min-complexity: 15
-  gocyclo:
-    min-complexity: 10
-  goheader:
-    values:
-      const:
-        COMPANY: IBM Corp.
-    template: |-
-      Copyright {{ COMPANY }} All Rights Reserved.
-      SPDX-License-Identifier: Apache-2.0
+    - usetesting
+  settings:
+    cyclop:
+      max-complexity: 10
+    gocognit:
+      min-complexity: 15
+    goheader:
+      values:
+        const:
+          COMPANY: IBM Corp.
+      template: |-
+        Copyright {{ COMPANY }} All Rights Reserved.
+        SPDX-License-Identifier: Apache-2.0
+    staticcheck:
+      checks:
+        - all
+  exclusions:
+    generated: strict
+    warn-unused: true
+    presets:
+      - std-error-handling
+    rules:
+      - path: pkg/internal/test/
+        text: "^ST1000:"
+        linters:
+          - staticcheck
+      - path: pkg/hash/hash.go
+        text: "^ST1003:.* ALL_CAPS"
+        linters:
+          - staticcheck
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  exclusions:
+    generated: strict

--- a/Makefile
+++ b/Makefile
@@ -87,16 +87,12 @@ unit-test-java:
 		mvn test jacoco:report
 
 .PHONY: lint
-lint: staticcheck golangci-lint
-
-.PHONY: staticcheck
-staticcheck:
-	$(staticcheck) -f stylish -tags=pkcs11 '$(go_dir)/...' '$(scenario_dir)/go'
+lint: golangci-lint
 
 .PHONY: install-golangci-lint
 install-golangci-lint:
 	curl --fail --location --show-error --silent \
-		https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
+		https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
 		| sh -s -- -b '$(go_bin_dir)'
 
 $(go_bin_dir)/golangci-lint:

--- a/pkg/client/blockeventsbuilder.go
+++ b/pkg/client/blockeventsbuilder.go
@@ -58,7 +58,7 @@ func (builder *baseBlockEventsBuilder) channelHeaderBytes() ([]byte, error) {
 	channelHeader := &common.ChannelHeader{
 		Type:        int32(common.HeaderType_DELIVER_SEEK_INFO),
 		Timestamp:   timestamppb.Now(),
-		ChannelId:   builder.eventsBuilder.channelName,
+		ChannelId:   builder.channelName,
 		Epoch:       0,
 		TlsCertHash: builder.tlsCertificateHash,
 	}

--- a/pkg/client/chaincodeevents_test.go
+++ b/pkg/client/chaincodeevents_test.go
@@ -296,7 +296,7 @@ func TestChaincodeEvents(t *testing.T) {
 
 		for _, event := range expected {
 			actual := <-receive
-			require.EqualValues(t, event, actual)
+			require.Equal(t, event, actual)
 		}
 	})
 

--- a/pkg/client/checkpointer_test.go
+++ b/pkg/client/checkpointer_test.go
@@ -37,9 +37,7 @@ func TestCheckpointer(t *testing.T) {
 		require.Equal(t, transactionID, checkpoint.TransactionID(), "TransactionID")
 	}
 
-	tempDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	for testName, testCase := range map[string]struct {
 		newCheckpointer func(*testing.T) Checkpointer
@@ -74,7 +72,7 @@ func TestCheckpointer(t *testing.T) {
 				checkpointer := testCase.newCheckpointer(t)
 				defer checkpointer.Close()
 
-				err = checkpointer.CheckpointBlock(blockNumber)
+				err := checkpointer.CheckpointBlock(blockNumber)
 				require.NoError(t, err)
 
 				assertState(t, checkpointer, blockNumber+1, "")
@@ -85,7 +83,7 @@ func TestCheckpointer(t *testing.T) {
 				checkpointer := testCase.newCheckpointer(t)
 				defer checkpointer.Close()
 
-				err = checkpointer.CheckpointTransaction(blockNumber, "txn1")
+				err := checkpointer.CheckpointTransaction(blockNumber, "txn1")
 				require.NoError(t, err)
 
 				assertState(t, checkpointer, blockNumber, "txn1")
@@ -99,7 +97,7 @@ func TestCheckpointer(t *testing.T) {
 				checkpointer := testCase.newCheckpointer(t)
 				defer checkpointer.Close()
 
-				err = checkpointer.CheckpointChaincodeEvent(event)
+				err := checkpointer.CheckpointChaincodeEvent(event)
 				require.NoError(t, err)
 
 				assertState(t, checkpointer, event.BlockNumber, event.TransactionID)

--- a/pkg/client/evaluate_test.go
+++ b/pkg/client/evaluate_test.go
@@ -53,7 +53,7 @@ func TestEvaluateTransaction(t *testing.T) {
 			actual, err := testCase.run(t, contract)
 			require.NoError(t, err)
 
-			require.EqualValues(t, expected, actual)
+			require.Equal(t, expected, actual)
 		})
 	}
 
@@ -133,7 +133,7 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		args := AssertUnmarshalInvocationSpec(t, (<-requests).ProposedTransaction).ChaincodeSpec.Input.Args
 		actual := bytesAsStrings(args[1:])
-		require.EqualValues(t, expected, actual, "got Args: %s", args)
+		require.Equal(t, expected, actual, "got Args: %s", args)
 	})
 
 	t.Run("Includes channel name in proposed transaction", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestEvaluateTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := (<-requests).ProposedTransaction.Signature
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Uses hash", func(t *testing.T) {
@@ -222,7 +222,7 @@ func TestEvaluateTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := <-digests
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Sends private data with evaluate", func(t *testing.T) {
@@ -242,11 +242,11 @@ func TestEvaluateTransaction(t *testing.T) {
 
 		request := <-requests
 		actualOrgs := request.TargetOrganizations
-		require.EqualValues(t, expectedOrgs, actualOrgs)
+		require.Equal(t, expectedOrgs, actualOrgs)
 
 		transient := AssertUnmarshalProposalPayload(t, request.ProposedTransaction).TransientMap
 		actualPrice := transient["price"]
-		require.EqualValues(t, expectedPrice, actualPrice)
+		require.Equal(t, expectedPrice, actualPrice)
 	})
 
 	for name, testCase := range map[string]struct {

--- a/pkg/client/filecheckpointer_test.go
+++ b/pkg/client/filecheckpointer_test.go
@@ -13,9 +13,7 @@ import (
 )
 
 func TestFileCheckpointer(t *testing.T) {
-	tempDir, err := os.MkdirTemp("", "test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	newCheckpointer := func(t *testing.T) (*FileCheckpointer, string) {
 		fileName := NonExistentFileName(t, tempDir)
@@ -29,7 +27,7 @@ func TestFileCheckpointer(t *testing.T) {
 		expected, fileName := newCheckpointer(t)
 		defer expected.Close()
 
-		err = expected.CheckpointTransaction(uint64(1), "TRANSACTION_ID")
+		err := expected.CheckpointTransaction(uint64(1), "TRANSACTION_ID")
 		require.NoError(t, err)
 
 		actual, err := NewFileCheckpointer(fileName)
@@ -49,7 +47,7 @@ func TestFileCheckpointer(t *testing.T) {
 		defer actual.Close()
 
 		require.Equal(t, uint64(0), actual.BlockNumber())
-		require.Equal(t, "", actual.TransactionID())
+		require.Empty(t, actual.TransactionID())
 	})
 
 	t.Run("error reading invalid checkpoint JSON from file", func(t *testing.T) {
@@ -84,7 +82,7 @@ func TestFileCheckpointer(t *testing.T) {
 	})
 
 	t.Run("error checkpointing to non-writable file location", func(t *testing.T) {
-		_, err = NewFileCheckpointer(path.Join(tempDir, "NON_EXISTENT_DIR", "FILE"))
+		_, err := NewFileCheckpointer(path.Join(tempDir, "NON_EXISTENT_DIR", "FILE"))
 
 		require.Error(t, err)
 	})

--- a/pkg/client/identity_test.go
+++ b/pkg/client/identity_test.go
@@ -43,7 +43,7 @@ func TestIdentity(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := AssertUnmarshalSignatureHeader(t, (<-requests).ProposedTransaction).Creator
-		require.EqualValues(t, creator, actual)
+		require.Equal(t, creator, actual)
 	})
 
 	t.Run("Submit uses client identity for proposals", func(t *testing.T) {
@@ -60,6 +60,6 @@ func TestIdentity(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := AssertUnmarshalSignatureHeader(t, (<-requests).ProposedTransaction).Creator
-		require.EqualValues(t, creator, actual)
+		require.Equal(t, creator, actual)
 	})
 }

--- a/pkg/client/network_test.go
+++ b/pkg/client/network_test.go
@@ -23,7 +23,7 @@ func TestNetwork(t *testing.T) {
 
 		require.NotNil(t, contract)
 		require.Equal(t, chaincodeName, contract.ChaincodeName(), "chaincode name")
-		require.Equal(t, "", contract.ContractName(), "contract name")
+		require.Empty(t, contract.ContractName(), "contract name")
 	})
 
 	t.Run("GetContractWithName returns correctly named Contract", func(t *testing.T) {

--- a/pkg/client/sign_test.go
+++ b/pkg/client/sign_test.go
@@ -30,7 +30,7 @@ func TestSign(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := (<-requests).ProposedTransaction.Signature
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Submit signs proposal using client signing implementation", func(t *testing.T) {
@@ -51,7 +51,7 @@ func TestSign(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := (<-requests).ProposedTransaction.Signature
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Submit signs transaction using client signing implementation", func(t *testing.T) {
@@ -72,7 +72,7 @@ func TestSign(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := (<-requests).PreparedTransaction.Signature
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Default error implementation is used if no signing implementation supplied", func(t *testing.T) {

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -254,7 +254,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 		args := AssertUnmarshalInvocationSpec(t, (<-requests).ProposedTransaction).ChaincodeSpec.Input.Args
 		actual := bytesAsStrings(args[1:])
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Includes channel name in endorse request", func(t *testing.T) {
@@ -369,7 +369,7 @@ func TestSubmitTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := (<-requests).ProposedTransaction.Signature
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Uses signer for submit", func(t *testing.T) {
@@ -390,7 +390,7 @@ func TestSubmitTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := (<-requests).PreparedTransaction.Signature
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Sends private data with submit", func(t *testing.T) {
@@ -415,7 +415,7 @@ func TestSubmitTransaction(t *testing.T) {
 		require.ElementsMatch(t, []string{expectedOrg}, request.EndorsingOrganizations)
 
 		transient := AssertUnmarshalProposalPayload(t, request.ProposedTransaction).TransientMap
-		require.EqualValues(t, expectedPrice, transient["price"])
+		require.Equal(t, expectedPrice, transient["price"])
 	})
 
 	t.Run("Uses signer for commit status", func(t *testing.T) {
@@ -436,7 +436,7 @@ func TestSubmitTransaction(t *testing.T) {
 		require.NoError(t, err)
 
 		actual := (<-requests).Signature
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Uses hash", func(t *testing.T) {
@@ -461,7 +461,7 @@ func TestSubmitTransaction(t *testing.T) {
 
 		expected := [][]byte{digest, digest, digest}
 		actual := ReceiveAll(digests)
-		require.EqualValues(t, expected, actual)
+		require.Equal(t, expected, actual)
 	})
 
 	t.Run("Commit returns transaction status", func(t *testing.T) {

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -32,15 +32,11 @@ func SHA384(message []byte) []byte {
 }
 
 // SHA3_256 hash the supplied message bytes to create a digest for signing.
-//
-//lint:ignore ST1003 This naming is consistent with Go crypto package hash function constants.
 func SHA3_256(message []byte) []byte {
 	return digest(sha3.New256(), message)
 }
 
 // SHA3_384 hash the supplied message bytes to create a digest for signing.
-//
-//lint:ignore ST1003 This naming is consistent with Go crypto package hash function constants.
 func SHA3_384(message []byte) []byte {
 	return digest(sha3.New384(), message)
 }

--- a/pkg/hash/hash_test.go
+++ b/pkg/hash/hash_test.go
@@ -26,7 +26,7 @@ func TestHash(t *testing.T) {
 				hash1 := testCase.hash(message)
 				hash2 := testCase.hash(message)
 
-				require.EqualValues(t, hash1, hash2)
+				require.Equal(t, hash1, hash2)
 			})
 
 			t.Run("Hashes of different data are not identical", func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestHash(t *testing.T) {
 				fooHash := testCase.hash(foo)
 				barHash := testCase.hash(bar)
 
-				require.NotEqualValues(t, fooHash, barHash)
+				require.NotEqual(t, fooHash, barHash)
 			})
 		})
 	}
@@ -44,6 +44,6 @@ func TestHash(t *testing.T) {
 	t.Run("NONE returns input", func(t *testing.T) {
 		message := []byte("foobar")
 		result := NONE(message)
-		require.EqualValues(t, message, result)
+		require.Equal(t, message, result)
 	})
 }

--- a/pkg/identity/hsmsign.go
+++ b/pkg/identity/hsmsign.go
@@ -144,6 +144,7 @@ func (factory *HSMSignerFactory) createSession(slot uint, pin string) (pkcs11.Se
 		return 0, fmt.Errorf("open session failed: %w", err)
 	}
 
+	//nolint:errorlint
 	if err := factory.ctx.Login(session, pkcs11.CKU_USER, pin); err != nil && err != pkcs11.Error(pkcs11.CKR_USER_ALREADY_LOGGED_IN) {
 		_ = factory.ctx.CloseSession(session)
 		return 0, fmt.Errorf("login failed: %w", err)

--- a/scenario/go/connection_test.go
+++ b/scenario/go/connection_test.go
@@ -117,7 +117,7 @@ func NewGatewayConnectionWithHSMSigner(user string, mspID string) (*GatewayConne
 }
 
 func newIdentity(mspID string, certPath string) (*identity.X509Identity, error) {
-	certificatePEM, err := os.ReadFile(certPath)
+	certificatePEM, err := os.ReadFile(certPath) // #nosec G304
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,7 @@ func newIdentity(mspID string, certPath string) (*identity.X509Identity, error) 
 }
 
 func NewSign(keyPath string) (identity.Sign, error) {
-	privateKeyPEM, err := os.ReadFile(keyPath)
+	privateKeyPEM, err := os.ReadFile(keyPath) // #nosec G304
 	if err != nil {
 		return nil, err
 	}
@@ -240,7 +240,7 @@ func (connection *GatewayConnection) Connect(grpcClient *grpc.ClientConn) error 
 
 	gateway, err := client.Connect(connection.id, options...)
 	if err != nil {
-		grpcClient.Close()
+		_ = grpcClient.Close()
 		return err
 	}
 
@@ -507,10 +507,10 @@ func (connection *GatewayConnection) Close() {
 	connection.cancel() // Closes all listener contexts
 
 	if connection.gateway != nil {
-		connection.gateway.Close()
+		_ = connection.gateway.Close()
 	}
 	if connection.grpcClient != nil {
-		connection.grpcClient.Close()
+		_ = connection.grpcClient.Close()
 	}
 }
 

--- a/scenario/go/scenario_test.go
+++ b/scenario/go/scenario_test.go
@@ -196,7 +196,7 @@ func useGateway(name string) error {
 }
 
 func loadX509Cert(certFile string) (*x509.Certificate, error) {
-	cf, e := os.ReadFile(certFile)
+	cf, e := os.ReadFile(certFile) // #nosec G304
 	if e != nil {
 		return nil, e
 	}

--- a/staticcheck.conf
+++ b/staticcheck.conf
@@ -1,1 +1,0 @@
-checks = ["all"]


### PR DESCRIPTION
Also update actions/golangci-lint to v7.0.0, which requires golangci-lint v2.