### PR TITLE
Fix Node API documentation README

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -15,22 +15,22 @@
                 "google-protobuf": "^3.21.0"
             },
             "devDependencies": {
-                "@eslint/eslintrc": "^3.2.0",
-                "@eslint/js": "^9.17.0",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "^9.25.1",
                 "@tsconfig/node20": "^20.1.5",
                 "@types/google-protobuf": "^3.15.12",
                 "@types/jest": "^29.5.14",
                 "@types/node": "^20.17.32",
-                "eslint": "^9.22.0",
-                "eslint-config-prettier": "^10.1.1",
+                "eslint": "^9.25.1",
+                "eslint-config-prettier": "^10.1.2",
                 "eslint-plugin-jest": "^28.11.0",
                 "eslint-plugin-tsdoc": "^0.4.0",
                 "jest": "^29.7.0",
                 "prettier": "^3.5.3",
-                "ts-jest": "^29.3.0",
-                "typedoc": "^0.28.1",
-                "typescript": "~5.8.2",
-                "typescript-eslint": "^8.28.0"
+                "ts-jest": "^29.3.2",
+                "typedoc": "^0.28.3",
+                "typescript": "~5.8.3",
+                "typescript-eslint": "^8.31.1"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -54,24 +54,24 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.26.2",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-            "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.25.9",
+                "@babel/helper-validator-identifier": "^7.27.1",
                 "js-tokens": "^4.0.0",
-                "picocolors": "^1.0.0"
+                "picocolors": "^1.1.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.26.8",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.8.tgz",
-            "integrity": "sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.27.1.tgz",
+            "integrity": "sha512-Q+E+rd/yBzNQhXkG+zQnF58e4zoZfBedaxwzPmicKsiK3nt8iJYrSrDbjwFFDGC4f+rPafqRaPH6TsDoSvMf7A==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -79,22 +79,22 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.26.10",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
-            "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.1.tgz",
+            "integrity": "sha512-IaaGWsQqfsQWVLqMn9OB92MNN7zukfVA4s7KKAI0KfrrDsZ0yhi5uV4baBuLuN7n3vsZpwP8asPPcVwApxvjBQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.26.10",
-                "@babel/helper-compilation-targets": "^7.26.5",
-                "@babel/helper-module-transforms": "^7.26.0",
-                "@babel/helpers": "^7.26.10",
-                "@babel/parser": "^7.26.10",
-                "@babel/template": "^7.26.9",
-                "@babel/traverse": "^7.26.10",
-                "@babel/types": "^7.26.10",
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.27.1",
+                "@babel/helper-compilation-targets": "^7.27.1",
+                "@babel/helper-module-transforms": "^7.27.1",
+                "@babel/helpers": "^7.27.1",
+                "@babel/parser": "^7.27.1",
+                "@babel/template": "^7.27.1",
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -120,14 +120,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.0.tgz",
-            "integrity": "sha512-VybsKvpiN1gU1sdMZIp7FcqphVVKEwcuj02x73uvcHE0PTihx1nlBcowYWhDwjpoAXRv43+gDzyggGnn1XZhVw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.1.tgz",
+            "integrity": "sha512-UnJfnIpc/+JO0/+KRVQNGU+y5taA5vCbwN8+azkX6beii/ZF+enZJSOKo11ZSzGJjlNfJHfQtmQT8H+9TXPG2w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0",
+                "@babel/parser": "^7.27.1",
+                "@babel/types": "^7.27.1",
                 "@jridgewell/gen-mapping": "^0.3.5",
                 "@jridgewell/trace-mapping": "^0.3.25",
                 "jsesc": "^3.0.2"
@@ -137,14 +137,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.0.tgz",
-            "integrity": "sha512-LVk7fbXml0H2xH34dFzKQ7TDZ2G4/rVTOrq9V+icbbadjbVxxeFeDsNHv2SrZeWoA+6ZiTyWYWtScEIW07EAcA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.1.tgz",
+            "integrity": "sha512-2YaDd/Rd9E598B5+WIc8wJPmWETiiJXFYVE60oX8FDohv7rAUU3CQj+A1MgeEmcsk2+dQuEjIe/GDvig0SqL4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.26.8",
-                "@babel/helper-validator-option": "^7.25.9",
+                "@babel/compat-data": "^7.27.1",
+                "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -164,29 +164,29 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
-            "integrity": "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.25.9",
-                "@babel/types": "^7.25.9"
+                "@babel/traverse": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
-            "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.27.1.tgz",
+            "integrity": "sha512-9yHn519/8KvTU5BjTVEEeIM3w9/2yXNKoD82JifINImhpKkARMJKPP59kLo+BafpdN5zgNeIcS4jsGDmd3l58g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9",
-                "@babel/traverse": "^7.25.9"
+                "@babel/helper-module-imports": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/traverse": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -196,9 +196,9 @@
             }
         },
         "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.26.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.26.5.tgz",
-            "integrity": "sha512-RS+jZcRdZdRFzMyr+wcsaqOmld1/EqTghfaBGQQd/WnRdzdlvSZ//kF7U8VQTxf1ynZ4cjUcYgjVGx13ewNPMg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+            "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -206,9 +206,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-            "integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -216,9 +216,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-            "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -226,9 +226,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
-            "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -236,27 +236,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.0.tgz",
-            "integrity": "sha512-U5eyP/CTFPuNE3qk+WZMxFkp/4zUzdceQlfzf7DdGdhp+Fezd7HD+i8Y24ZuTMKX3wQBld449jijbGq6OdGNQg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.27.1.tgz",
+            "integrity": "sha512-FCvFTm0sWV8Fxhpp2McP5/W53GPllQ9QeQ7SiqGWjMf/LVG07lFa5+pgK05IRhVwtvafT22KF+ZSnM9I545CvQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/template": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-            "integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.1.tgz",
+            "integrity": "sha512-I0dZ3ZpCrJ1c04OqlNsQcKiZlsrXf/kkE4FXzID9rIOYICsAbA8mMDzhW/luRNAHdCNt7os/u8wenklZDlUVUQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.27.0"
+                "@babel/types": "^7.27.1"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -321,13 +321,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.26.0",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-            "integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
+            "integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -363,13 +363,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-jsx": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.25.9.tgz",
-            "integrity": "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
+            "integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -489,13 +489,13 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.25.9",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.25.9.tgz",
-            "integrity": "sha512-hjMgRy5hb8uJJjUcdWunWVcoi9bGpJp8p5Ol1229PoN6aytsLwNMgmdftO23wnCLMfVmTwZDWMPNq/D1SY60JQ==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
+            "integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-plugin-utils": "^7.25.9"
+                "@babel/helper-plugin-utils": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -505,32 +505,32 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.0.tgz",
-            "integrity": "sha512-2ncevenBqXI6qRMukPlXwHKHchC7RyMuu4xv5JBXRfOGVcTy1mXCD12qrp7Jsoxll1EV3+9sE4GugBVRjT2jFA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.1.tgz",
+            "integrity": "sha512-Fyo3ghWMqkHHpHQCoBs2VnYjR4iWFFjguTDEqA5WgZDOrFesVjMhMM2FSqTKSoUSDO1VQtavj8NFpdRBEvJTtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/parser": "^7.27.0",
-                "@babel/types": "^7.27.0"
+                "@babel/code-frame": "^7.27.1",
+                "@babel/parser": "^7.27.1",
+                "@babel/types": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.0.tgz",
-            "integrity": "sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.1.tgz",
+            "integrity": "sha512-ZCYtZciz1IWJB4U61UPu4KEaqyfj+r5T1Q5mqPo+IBpcG9kHv30Z0aD8LXPgC1trYa6rK0orRyAhqUgk4MjmEg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.26.2",
-                "@babel/generator": "^7.27.0",
-                "@babel/parser": "^7.27.0",
-                "@babel/template": "^7.27.0",
-                "@babel/types": "^7.27.0",
+                "@babel/code-frame": "^7.27.1",
+                "@babel/generator": "^7.27.1",
+                "@babel/parser": "^7.27.1",
+                "@babel/template": "^7.27.1",
+                "@babel/types": "^7.27.1",
                 "debug": "^4.3.1",
                 "globals": "^11.1.0"
             },
@@ -549,14 +549,14 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-            "integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+            "version": "7.27.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.1.tgz",
+            "integrity": "sha512-+EzkxvLNfiUeKMgy/3luqfsCWFRXLb7U6wNQTk60tovuckwB15B191tJWvpp4HjiQWdJkCxO3Wbvc6jlk3Xb2Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.25.9",
-                "@babel/helper-validator-identifier": "^7.25.9"
+                "@babel/helper-string-parser": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.27.1"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -570,9 +570,9 @@
             "license": "MIT"
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
-            "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
+            "integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -612,9 +612,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-            "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+            "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -627,9 +627,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
-            "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+            "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -637,9 +637,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-            "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+            "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -674,9 +674,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.23.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-            "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+            "version": "9.25.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
+            "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -694,13 +694,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-            "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+            "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.12.0",
+                "@eslint/core": "^0.13.0",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -708,21 +708,23 @@
             }
         },
         "node_modules/@gerrit0/mini-shiki": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.1.tgz",
-            "integrity": "sha512-HbzRC6MKB6U8kQhczz0APKPIzFHTrcqhaC7es2EXInq1SpjPVnpVSIsBe6hNoLWqqCx1n5VKiPXq6PfXnHZKOQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.3.0.tgz",
+            "integrity": "sha512-frvArO0+s5Viq68uSod5SieLPVM2cLpXoQ1e07lURwgADXpL/MOypM7jPz9otks0g2DIe2YedDAeVrDyYJZRxA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/engine-oniguruma": "^3.2.1",
-                "@shikijs/types": "^3.2.1",
+                "@shikijs/engine-oniguruma": "^3.3.0",
+                "@shikijs/langs": "^3.3.0",
+                "@shikijs/themes": "^3.3.0",
+                "@shikijs/types": "^3.3.0",
                 "@shikijs/vscode-textmate": "^10.0.2"
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.13.1",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.1.tgz",
-            "integrity": "sha512-z5nNuIs75S73ZULjPDe5QCNTiCv7FyBZXEVWOyAHtcebnuJf0g1SuueI3U1/z/KK39XyAQRUC+C9ZQJOtgHynA==",
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.13.3.tgz",
+            "integrity": "sha512-FTXHdOoPbZrBjlVLHuKbDZnsTxXv2BlHF57xw6LuThXacXvtkahEPED0CKMk6obZDf65Hv4k3z62eyPNpvinIg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.7.13",
@@ -733,9 +735,9 @@
             }
         },
         "node_modules/@grpc/proto-loader": {
-            "version": "0.7.13",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.13.tgz",
-            "integrity": "sha512-AiXO/bfe9bmxBjxxtYxFAXGZvMaN5s8kO+jBHAJCON8rJoB5YS/D6X7ZNc6XQkuHNmyl4CYaMI1fJ/Gn27RGGw==",
+            "version": "0.7.15",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+            "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash.camelcase": "^4.3.0",
@@ -1346,12 +1348,12 @@
             "license": "MIT"
         },
         "node_modules/@noble/curves": {
-            "version": "1.8.1",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
-            "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
+            "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
             "license": "MIT",
             "dependencies": {
-                "@noble/hashes": "1.7.1"
+                "@noble/hashes": "1.8.0"
             },
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -1361,9 +1363,9 @@
             }
         },
         "node_modules/@noble/hashes": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
-            "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
             "license": "MIT",
             "engines": {
                 "node": "^14.21.3 || >=16"
@@ -1475,20 +1477,40 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@shikijs/engine-oniguruma": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.1.tgz",
-            "integrity": "sha512-wZZAkayEn6qu2+YjenEoFqj0OyQI64EWsNR6/71d1EkG4sxEOFooowKivsWPpaWNBu3sxAG+zPz5kzBL/SsreQ==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.3.0.tgz",
+            "integrity": "sha512-l0vIw+GxeNU7uGnsu6B+Crpeqf+WTQ2Va71cHb5ZYWEVEPdfYwY5kXwYqRJwHrxz9WH+pjSpXQz+TJgAsrkA5A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@shikijs/types": "3.2.1",
+                "@shikijs/types": "3.3.0",
                 "@shikijs/vscode-textmate": "^10.0.2"
             }
         },
+        "node_modules/@shikijs/langs": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.3.0.tgz",
+            "integrity": "sha512-zt6Kf/7XpBQKSI9eqku+arLkAcDQ3NHJO6zFjiChI8w0Oz6Jjjay7pToottjQGjSDCFk++R85643WbyINcuL+g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.3.0"
+            }
+        },
+        "node_modules/@shikijs/themes": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.3.0.tgz",
+            "integrity": "sha512-tXeCvLXBnqq34B0YZUEaAD1lD4lmN6TOHAhnHacj4Owh7Ptb/rf5XCDeROZt2rEOk5yuka3OOW2zLqClV7/SOg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "3.3.0"
+            }
+        },
         "node_modules/@shikijs/types": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.1.tgz",
-            "integrity": "sha512-/NTWAk4KE2M8uac0RhOsIhYQf4pdU0OywQuYDGIGAJ6Mjunxl2cGiuLkvu4HLCMn+OTTLRWkjZITp+aYJv60yA==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.3.0.tgz",
+            "integrity": "sha512-KPCGnHG6k06QG/2pnYGbFtFvpVJmC3uIpXrAiPrawETifujPBv0Se2oUxm5qYgjCvGJS9InKvjytOdN+bGuX+Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1552,9 +1574,9 @@
             }
         },
         "node_modules/@types/babel__generator": {
-            "version": "7.6.8",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-            "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+            "version": "7.27.0",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1702,17 +1724,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
-            "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
+            "integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/type-utils": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/scope-manager": "8.31.1",
+                "@typescript-eslint/type-utils": "8.31.1",
+                "@typescript-eslint/utils": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -1732,16 +1754,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
-            "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
+            "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/typescript-estree": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/scope-manager": "8.31.1",
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/typescript-estree": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1757,14 +1779,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
-            "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
+            "integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0"
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1775,14 +1797,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz",
-            "integrity": "sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
+            "integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0",
+                "@typescript-eslint/typescript-estree": "8.31.1",
+                "@typescript-eslint/utils": "8.31.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -1799,9 +1821,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
-            "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
+            "integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1813,14 +1835,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
-            "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
+            "integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1866,16 +1888,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
-            "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
+            "integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/typescript-estree": "8.28.0"
+                "@typescript-eslint/scope-manager": "8.31.1",
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/typescript-estree": "8.31.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1890,13 +1912,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
-            "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
+            "integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
+                "@typescript-eslint/types": "8.31.1",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -2256,9 +2278,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001707",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-            "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+            "version": "1.0.30001716",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001716.tgz",
+            "integrity": "sha512-49/c1+x3Kwz7ZIWt+4DvK3aMJy9oYXXG6/97JKsnjdCk/6n9vVyWL8NAwVt95Lwt9eigI10Hl782kDfZUUlRXw==",
             "dev": true,
             "funding": [
                 {
@@ -2446,9 +2468,9 @@
             }
         },
         "node_modules/dedent": {
-            "version": "1.5.3",
-            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
-            "integrity": "sha512-NHQtfOOW68WD8lgypbLA5oT+Bt0xXJhiYvoR6SmmNXZfpzOGXwdKWmcwG8N7PwVVWV3eF/68nmD9BaJSsTBhyQ==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.6.0.tgz",
+            "integrity": "sha512-F1Z+5UCFpmQUzJa11agbyPVMbpgT/qA3/SKyJ1jyBgm7dUcUEa8v9JwDkerSQXfakBwFljIxhOJqGkjUwZ9FSA==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
@@ -2514,9 +2536,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.124",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.124.tgz",
-            "integrity": "sha512-riELkpDUqBi00gqreV3RIGoowxGrfueEKBd6zPdOk/I8lvuFpBGNkYoHof3zUHbiTBsIU8oxdIIL/WNrAG1/7A==",
+            "version": "1.5.148",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.148.tgz",
+            "integrity": "sha512-8uc1QXwwqayD4mblcsQYZqoi+cOc97A2XmKSBOIRbEAvbp6vrqmSYs4dHD2qVygUgn7Mi0qdKgPaJ9WC8cv63A==",
             "dev": true,
             "license": "ISC"
         },
@@ -2585,20 +2607,20 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.23.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-            "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+            "version": "9.25.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
+            "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.19.2",
-                "@eslint/config-helpers": "^0.2.0",
-                "@eslint/core": "^0.12.0",
+                "@eslint/config-array": "^0.20.0",
+                "@eslint/config-helpers": "^0.2.1",
+                "@eslint/core": "^0.13.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.23.0",
-                "@eslint/plugin-kit": "^0.2.7",
+                "@eslint/js": "9.25.1",
+                "@eslint/plugin-kit": "^0.2.8",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -2646,9 +2668,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
-            "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
+            "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -4226,9 +4248,9 @@
             "license": "MIT"
         },
         "node_modules/long": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.3.1.tgz",
-            "integrity": "sha512-ka87Jz3gcx/I7Hal94xaN2tZEOPoUOEVftkQqZx2EeQRN7LGdfLlI3FvZ+7WDplm+vK2Urx9ULrvSowtdCieng==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
             "license": "Apache-2.0"
         },
         "node_modules/lru-cache": {
@@ -4587,9 +4609,9 @@
             }
         },
         "node_modules/pirates": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
-            "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4749,9 +4771,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.4.0.tgz",
-            "integrity": "sha512-mRUWCc3KUU4w1jU8sGxICXH/gNS94DvI1gxqDvBzhj1JpcsimQkYiOJfwsPUykUI5ZaspFbSgmBLER8IrQ3tqw==",
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.0.tgz",
+            "integrity": "sha512-Z2E/kOY1QjoMlCytmexzYfDm/w5fKAiRwpSzGtdnXW1zC88Z2yXazHHrOtwCzn+7wSxyE8PYM4rvVcMphF9sOA==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -5214,9 +5236,9 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.3.0",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.0.tgz",
-            "integrity": "sha512-4bfGBX7Gd1Aqz3SyeDS9O276wEU/BInZxskPrbhZLyv+c1wskDCqDFMJQJLWrIr/fKoAH4GE5dKUlrdyvo+39A==",
+            "version": "29.3.2",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
+            "integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5228,7 +5250,7 @@
                 "lodash.memoize": "^4.1.2",
                 "make-error": "^1.3.6",
                 "semver": "^7.7.1",
-                "type-fest": "^4.37.0",
+                "type-fest": "^4.39.1",
                 "yargs-parser": "^21.1.1"
             },
             "bin": {
@@ -5264,9 +5286,9 @@
             }
         },
         "node_modules/ts-jest/node_modules/type-fest": {
-            "version": "4.38.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.38.0.tgz",
-            "integrity": "sha512-2dBz5D5ycHIoliLYLi0Q2V7KRaDlH0uWIvmk7TYlAg5slqwiPv1ezJdZm1QEM0xgk29oYWMCbIG7E6gHpvChlg==",
+            "version": "4.40.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.1.tgz",
+            "integrity": "sha512-9YvLNnORDpI+vghLU/Nf+zSv0kL47KbVJ1o3sKgoTefl6i+zebxbiDQWoe/oWWqPhIgQdRZRT1KA9sCPL810SA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "engines": {
@@ -5313,17 +5335,17 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.1.tgz",
-            "integrity": "sha512-Mn2VPNMaxoe/hlBiLriG4U55oyAa3Xo+8HbtEwV7F5WEOPXqtxzGuMZhJYHaqFJpajeQ6ZDUC2c990NAtTbdgw==",
+            "version": "0.28.3",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.3.tgz",
+            "integrity": "sha512-5svOCTfXvVSh6zbZKSQluZhR8yN2tKpTeHZxlmWpE6N5vc3R8k/jhg9nnD6n5tN9/ObuQTojkONrOxFdUFUG9w==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@gerrit0/mini-shiki": "^3.2.1",
+                "@gerrit0/mini-shiki": "^3.2.2",
                 "lunr": "^2.3.9",
                 "markdown-it": "^14.1.0",
                 "minimatch": "^9.0.5",
-                "yaml": "^2.7.0 "
+                "yaml": "^2.7.1"
             },
             "bin": {
                 "typedoc": "bin/typedoc"
@@ -5363,9 +5385,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -5377,15 +5399,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.28.0.tgz",
-            "integrity": "sha512-jfZtxJoHm59bvoCMYCe2BM0/baMswRhMmYhy+w6VfcyHrjxZ0OJe0tGasydCpIpA+A/WIJhTyZfb3EtwNC/kHQ==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.1.tgz",
+            "integrity": "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.28.0",
-                "@typescript-eslint/parser": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0"
+                "@typescript-eslint/eslint-plugin": "8.31.1",
+                "@typescript-eslint/parser": "8.31.1",
+                "@typescript-eslint/utils": "8.31.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5559,9 +5581,9 @@
             "license": "ISC"
         },
         "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+            "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
             "dev": true,
             "license": "ISC",
             "bin": {

--- a/node/package.json
+++ b/node/package.json
@@ -41,21 +41,21 @@
         "pkcs11js": "^2.1.0"
     },
     "devDependencies": {
-        "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "^9.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "^9.25.1",
         "@tsconfig/node20": "^20.1.5",
         "@types/google-protobuf": "^3.15.12",
         "@types/jest": "^29.5.14",
         "@types/node": "^20.17.32",
-        "eslint": "^9.22.0",
-        "eslint-config-prettier": "^10.1.1",
+        "eslint": "^9.25.1",
+        "eslint-config-prettier": "^10.1.2",
         "eslint-plugin-jest": "^28.11.0",
         "eslint-plugin-tsdoc": "^0.4.0",
         "jest": "^29.7.0",
         "prettier": "^3.5.3",
-        "ts-jest": "^29.3.0",
-        "typedoc": "^0.28.1",
-        "typescript": "~5.8.2",
-        "typescript-eslint": "^8.28.0"
+        "ts-jest": "^29.3.2",
+        "typedoc": "^0.28.3",
+        "typescript": "~5.8.3",
+        "typescript-eslint": "^8.31.1"
     }
 }

--- a/node/typedoc.json
+++ b/node/typedoc.json
@@ -1,8 +1,7 @@
 {
     "cleanOutputDir": true,
-    "entryPoints": [
-        "src/index.ts"
-    ],
+    "entryPoints": ["src/index.ts"],
     "out": "apidocs",
+    "readme": "src/README.md",
     "treatWarningsAsErrors": true
 }

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -17,12 +17,12 @@
                 "@tsconfig/node20": "^20.1.5",
                 "@types/node": "^20.17.32",
                 "cucumber-console-formatter": "^1.0.0",
-                "eslint": "^9.22.0",
-                "eslint-config-prettier": "^10.1.1",
+                "eslint": "^9.25.1",
+                "eslint-config-prettier": "^10.1.2",
                 "expect": "^29.7.0",
                 "prettier": "^3.5.3",
-                "typescript": "~5.8.2",
-                "typescript-eslint": "^8.28.0"
+                "typescript": "~5.8.3",
+                "typescript-eslint": "^8.31.1"
             },
             "engines": {
                 "node": ">=20.9.0"
@@ -393,9 +393,9 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.2",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-            "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+            "version": "0.20.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+            "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -408,9 +408,9 @@
             }
         },
         "node_modules/@eslint/config-helpers": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.0.tgz",
-            "integrity": "sha512-yJLLmLexii32mGrhW29qvU3QBVTu0GUmEf/J4XsBtVhp4JkIUFN/BjWqTF63yRvGApIDpZm5fa97LtYtINmfeQ==",
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
+            "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -418,9 +418,9 @@
             }
         },
         "node_modules/@eslint/core": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.12.0.tgz",
-            "integrity": "sha512-cmrR6pytBuSMTaBweKoGMwu3EiHiEC+DoyupPmlZ0HxBJBtIxwe+j/E4XPIKNx+Q74c8lXKPwYawBf5glsTkHg==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.13.0.tgz",
+            "integrity": "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -455,9 +455,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.23.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-            "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+            "version": "9.25.1",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.25.1.tgz",
+            "integrity": "sha512-dEIwmjntEx8u3Uvv+kr3PDeeArL8Hw07H9kyYxCjnM9pBjfEhk6uLXSchxxzgiwtRhhzVzqmUSDFBOi1TuZ7qg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -475,13 +475,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.7.tgz",
-            "integrity": "sha512-JubJ5B2pJ4k4yGxaNLdbjrnk9d/iDz6/q8wOilpIowd6PJPgaxCuHBnBszq7Ce2TyMrywm5r4PnKm6V3iiZF+g==",
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
+            "integrity": "sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/core": "^0.12.0",
+                "@eslint/core": "^0.13.0",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -588,7 +588,7 @@
         "node_modules/@hyperledger/fabric-gateway": {
             "version": "1.8.0",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-eslblkQhp7oF4331ZJ53vl6CB/nfqpgTD2IQqfNorN2NJVSG7Y4BpNGSq13xhuElvk4pVVLUJNR57GOLSS/5wQ==",
+            "integrity": "sha512-8cpIdTXalWHBQa/ck+oWvvq5GMEauBkqddZxoyxlYd8Wm812wCxjapeFpKHW2+BITtcTSvQXlKdY2RwEg7DTkw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.0",
@@ -597,7 +597,7 @@
                 "google-protobuf": "^3.21.0"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20.9.0"
             },
             "optionalDependencies": {
                 "pkcs11js": "^2.1.0"
@@ -973,17 +973,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.28.0.tgz",
-            "integrity": "sha512-lvFK3TCGAHsItNdWZ/1FkvpzCxTHUVuFrdnOGLMa0GGCFIbCgQWVk3CzCGdA7kM3qGVc+dfW9tr0Z/sHnGDFyg==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.31.1.tgz",
+            "integrity": "sha512-oUlH4h1ABavI4F0Xnl8/fOtML/eu8nI2A1nYd+f+55XI0BLu+RIqKoCiZKNo6DtqZBEQm5aNKA20G3Z5w3R6GQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/type-utils": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/scope-manager": "8.31.1",
+                "@typescript-eslint/type-utils": "8.31.1",
+                "@typescript-eslint/utils": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1",
                 "graphemer": "^1.4.0",
                 "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
@@ -1003,16 +1003,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.28.0.tgz",
-            "integrity": "sha512-LPcw1yHD3ToaDEoljFEfQ9j2xShY367h7FZ1sq5NJT9I3yj4LHer1Xd1yRSOdYy9BpsrxU7R+eoDokChYM53lQ==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.31.1.tgz",
+            "integrity": "sha512-oU/OtYVydhXnumd0BobL9rkJg7wFJ9bFFPmSmB/bf/XWN85hlViji59ko6bSKBXyseT9V8l+CN1nwmlbiN0G7Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/typescript-estree": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/scope-manager": "8.31.1",
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/typescript-estree": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -1028,14 +1028,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.28.0.tgz",
-            "integrity": "sha512-u2oITX3BJwzWCapoZ/pXw6BCOl8rJP4Ij/3wPoGvY8XwvXflOzd1kLrDUUUAIEdJSFh+ASwdTHqtan9xSg8buw==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.31.1.tgz",
+            "integrity": "sha512-BMNLOElPxrtNQMIsFHE+3P0Yf1z0dJqV9zLdDxN/xLlWMlXK/ApEsVEKzpizg9oal8bAT5Sc7+ocal7AC1HCVw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0"
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1046,14 +1046,14 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.28.0.tgz",
-            "integrity": "sha512-oRoXu2v0Rsy/VoOGhtWrOKDiIehvI+YNrDk5Oqj40Mwm0Yt01FC/Q7nFqg088d3yAsR1ZcZFVfPCTTFCe/KPwg==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.31.1.tgz",
+            "integrity": "sha512-fNaT/m9n0+dpSp8G/iOQ05GoHYXbxw81x+yvr7TArTuZuCA6VVKbqWYVZrV5dVagpDTtj/O8k5HBEE/p/HM5LA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0",
+                "@typescript-eslint/typescript-estree": "8.31.1",
+                "@typescript-eslint/utils": "8.31.1",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.0.1"
             },
@@ -1070,9 +1070,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.28.0.tgz",
-            "integrity": "sha512-bn4WS1bkKEjx7HqiwG2JNB3YJdC1q6Ue7GyGlwPHyt0TnVq6TtD/hiOdTZt71sq0s7UzqBFXD8t8o2e63tXgwA==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.31.1.tgz",
+            "integrity": "sha512-SfepaEFUDQYRoA70DD9GtytljBePSj17qPxFHA/h3eg6lPTqGJ5mWOtbXCk1YrVU1cTJRd14nhaXWFu0l2troQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1084,14 +1084,14 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.28.0.tgz",
-            "integrity": "sha512-H74nHEeBGeklctAVUvmDkxB1mk+PAZ9FiOMPFncdqeRBXxk1lWSYraHw8V12b7aa6Sg9HOBNbGdSHobBPuQSuA==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.31.1.tgz",
+            "integrity": "sha512-kaA0ueLe2v7KunYOyWYtlf/QhhZb7+qh4Yw6Ni5kgukMIG+iP773tjgBiLWIXYumWCwEq3nLW+TUywEp8uEeag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/visitor-keys": "8.28.0",
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/visitor-keys": "8.31.1",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
@@ -1150,16 +1150,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.28.0.tgz",
-            "integrity": "sha512-OELa9hbTYciYITqgurT1u/SzpQVtDLmQMFzy/N8pQE+tefOyCWT79jHsav294aTqV1q1u+VzqDGbuujvRYaeSQ==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.31.1.tgz",
+            "integrity": "sha512-2DSI4SNfF5T4oRveQ4nUrSjUqjMND0nLq9rEkz0gfGr3tg0S5KB6DhwR+WZPCjzkZl3cH+4x2ce3EsL50FubjQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.28.0",
-                "@typescript-eslint/types": "8.28.0",
-                "@typescript-eslint/typescript-estree": "8.28.0"
+                "@typescript-eslint/scope-manager": "8.31.1",
+                "@typescript-eslint/types": "8.31.1",
+                "@typescript-eslint/typescript-estree": "8.31.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1174,13 +1174,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.28.0.tgz",
-            "integrity": "sha512-hbn8SZ8w4u2pRwgQ1GlUrPKE+t2XvcCW5tTRF7j6SMYIuYG37XuzIW44JCZPa36evi0Oy2SnM664BlIaAuQcvg==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.31.1.tgz",
+            "integrity": "sha512-I+/rgqOVBn6f0o7NDTmAPWWC6NuqhV174lfYvAm9fUaWeiefLdux9/YI3/nLugEn9L8fcSi0XmpKi/r5u0nmpw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.28.0",
+                "@typescript-eslint/types": "8.31.1",
                 "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
@@ -1620,20 +1620,20 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.23.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-            "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+            "version": "9.25.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.25.1.tgz",
+            "integrity": "sha512-E6Mtz9oGQWDCpV12319d59n4tx9zOTXSTmc8BLVxBx+G/0RdM5MvEEJLU9c0+aleoePYYgVTOsRblx433qmhWQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.19.2",
-                "@eslint/config-helpers": "^0.2.0",
-                "@eslint/core": "^0.12.0",
+                "@eslint/config-array": "^0.20.0",
+                "@eslint/config-helpers": "^0.2.1",
+                "@eslint/core": "^0.13.0",
                 "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "9.23.0",
-                "@eslint/plugin-kit": "^0.2.7",
+                "@eslint/js": "9.25.1",
+                "@eslint/plugin-kit": "^0.2.8",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@humanwhocodes/retry": "^0.4.2",
@@ -1681,9 +1681,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "10.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.1.tgz",
-            "integrity": "sha512-4EQQr6wXwS+ZJSzaR5ZCrYgLxqvUjdXctaEtBqHcbkW944B1NQyO4qpdHQbXBONfwxXdkAY81HH4+LUfrg+zPw==",
+            "version": "10.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
+            "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3577,9 +3577,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.8.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-            "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+            "version": "5.8.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -3591,15 +3591,15 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.28.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.28.0.tgz",
-            "integrity": "sha512-jfZtxJoHm59bvoCMYCe2BM0/baMswRhMmYhy+w6VfcyHrjxZ0OJe0tGasydCpIpA+A/WIJhTyZfb3EtwNC/kHQ==",
+            "version": "8.31.1",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.31.1.tgz",
+            "integrity": "sha512-j6DsEotD/fH39qKzXTQRwYYWlt7D+0HmfpOK+DVhwJOFLcdmn92hq3mBb7HlKJHbjjI/gTOqEcc9d6JfpFf/VA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.28.0",
-                "@typescript-eslint/parser": "8.28.0",
-                "@typescript-eslint/utils": "8.28.0"
+                "@typescript-eslint/eslint-plugin": "8.31.1",
+                "@typescript-eslint/parser": "8.31.1",
+                "@typescript-eslint/utils": "8.31.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -29,11 +29,11 @@
         "@tsconfig/node20": "^20.1.5",
         "@types/node": "^20.17.32",
         "cucumber-console-formatter": "^1.0.0",
-        "eslint": "^9.22.0",
-        "eslint-config-prettier": "^10.1.1",
+        "eslint": "^9.25.1",
+        "eslint-config-prettier": "^10.1.2",
         "expect": "^29.7.0",
         "prettier": "^3.5.3",
-        "typescript": "~5.8.2",
-        "typescript-eslint": "^8.28.0"
+        "typescript": "~5.8.3",
+        "typescript-eslint": "^8.31.1"
     }
 }


### PR DESCRIPTION
An update to TypeDoc resulted in the wrong README file being selected for the API documentation. This change explicitly specifies the README file to be used.