### PR TITLE
Remove support for Node 18

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 18
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
       - name: Build
         run: make build-node

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:
-          node-version: 18
+          node-version: "lts/*"
           registry-url: "https://registry.npmjs.org"
       - name: Build
         run: make build-node

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18
           - 20
           - 22
     env:
@@ -131,7 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 18
+          - 20
           - 22
     env:
       SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -17,10 +17,10 @@
             "devDependencies": {
                 "@eslint/eslintrc": "^3.2.0",
                 "@eslint/js": "^9.17.0",
-                "@tsconfig/node18": "^18.2.4",
+                "@tsconfig/node20": "^20.1.5",
                 "@types/google-protobuf": "^3.15.12",
                 "@types/jest": "^29.5.14",
-                "@types/node": "^18.19.83",
+                "@types/node": "^20.17.32",
                 "eslint": "^9.22.0",
                 "eslint-config-prettier": "^10.1.1",
                 "eslint-plugin-jest": "^28.11.0",
@@ -33,7 +33,7 @@
                 "typescript-eslint": "^8.28.0"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20.9.0"
             },
             "optionalDependencies": {
                 "pkcs11js": "^2.1.0"
@@ -1530,10 +1530,10 @@
                 "@sinonjs/commons": "^3.0.0"
             }
         },
-        "node_modules/@tsconfig/node18": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-            "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+        "node_modules/@tsconfig/node20": {
+            "version": "20.1.5",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.5.tgz",
+            "integrity": "sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==",
             "dev": true,
             "license": "MIT"
         },
@@ -1662,12 +1662,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "18.19.83",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.83.tgz",
-            "integrity": "sha512-D69JeR5SfFS5H6FLbUaS0vE4r1dGhmMBbG4Ed6BNS4wkDK8GZjsdCShT5LCN59vOHEUHnFCY9J4aclXlIphMkA==",
+            "version": "20.17.32",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.32.tgz",
+            "integrity": "sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.19.2"
             }
         },
         "node_modules/@types/stack-utils": {
@@ -5407,9 +5407,9 @@
             "license": "MIT"
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
             "license": "MIT"
         },
         "node_modules/update-browserslist-db": {

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
     },
     "repository": {
         "type": "git",
@@ -43,10 +43,10 @@
     "devDependencies": {
         "@eslint/eslintrc": "^3.2.0",
         "@eslint/js": "^9.17.0",
-        "@tsconfig/node18": "^18.2.4",
+        "@tsconfig/node20": "^20.1.5",
         "@types/google-protobuf": "^3.15.12",
         "@types/jest": "^29.5.14",
-        "@types/node": "^18.19.83",
+        "@types/node": "^20.17.32",
         "eslint": "^9.22.0",
         "eslint-config-prettier": "^10.1.1",
         "eslint-plugin-jest": "^28.11.0",

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -1,13 +1,11 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node18/tsconfig.json",
+    "extends": "@tsconfig/node20/tsconfig.json",
     "compilerOptions": {
         "declaration": true,
         "declarationMap": true,
         "erasableSyntaxOnly": true,
         "isolatedModules": true,
-        "lib": ["es2023", "esnext.disposable"],
-        "module": "node18",
         "sourceMap": true,
         "outDir": "dist",
         "strict": true,

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -14,8 +14,8 @@
             },
             "devDependencies": {
                 "@cucumber/cucumber": "^11.2.0",
-                "@tsconfig/node18": "^18.2.4",
-                "@types/node": "^18.19.83",
+                "@tsconfig/node20": "^20.1.5",
+                "@types/node": "^20.17.32",
                 "cucumber-console-formatter": "^1.0.0",
                 "eslint": "^9.22.0",
                 "eslint-config-prettier": "^10.1.1",
@@ -25,7 +25,7 @@
                 "typescript-eslint": "^8.28.0"
             },
             "engines": {
-                "node": ">=18.12.0"
+                "node": ">=20.9.0"
             }
         },
         "node_modules/@babel/code-frame": {
@@ -870,10 +870,10 @@
                 "node": ">=14"
             }
         },
-        "node_modules/@tsconfig/node18": {
-            "version": "18.2.4",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node18/-/node18-18.2.4.tgz",
-            "integrity": "sha512-5xxU8vVs9/FNcvm3gE07fPbn9tl6tqGGWA9tSlwsUEkBxtRnTsNmwrV8gasZ9F/EobaSv9+nu8AxUKccw77JpQ==",
+        "node_modules/@tsconfig/node20": {
+            "version": "20.1.5",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.5.tgz",
+            "integrity": "sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==",
             "dev": true,
             "license": "MIT"
         },
@@ -926,12 +926,12 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "18.19.83",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.83.tgz",
-            "integrity": "sha512-D69JeR5SfFS5H6FLbUaS0vE4r1dGhmMBbG4Ed6BNS4wkDK8GZjsdCShT5LCN59vOHEUHnFCY9J4aclXlIphMkA==",
+            "version": "20.17.32",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.32.tgz",
+            "integrity": "sha512-zeMXFn8zQ+UkjK4ws0RiOC9EWByyW1CcVmLe+2rQocXRsGEDxUCwPEIVgpsGcLHS/P8JkT0oa3839BRABS0oPw==",
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.19.2"
             }
         },
         "node_modules/@types/normalize-package-data": {
@@ -3614,9 +3614,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
             "license": "MIT"
         },
         "node_modules/unicorn-magic": {

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "description": "Scenario test for Fabric Gateway",
     "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.9.0"
     },
     "scripts": {
         "build": "npm run clean && npm run compile && npm run lint && npm run format",
@@ -26,8 +26,8 @@
     },
     "devDependencies": {
         "@cucumber/cucumber": "^11.2.0",
-        "@tsconfig/node18": "^18.2.4",
-        "@types/node": "^18.19.83",
+        "@tsconfig/node20": "^20.1.5",
+        "@types/node": "^20.17.32",
         "cucumber-console-formatter": "^1.0.0",
         "eslint": "^9.22.0",
         "eslint-config-prettier": "^10.1.1",

--- a/scenario/node/tsconfig.json
+++ b/scenario/node/tsconfig.json
@@ -1,10 +1,10 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node18/tsconfig.json",
+    "extends": "@tsconfig/node20/tsconfig.json",
     "compilerOptions": {
         "declaration": false,
         "erasableSyntaxOnly": true,
-        "module": "node18",
+        "isolatedModules": true,
         "sourceMap": true,
         "outDir": "dist",
         "rootDir": "src",


### PR DESCRIPTION
Node 18 reached end-of-life at 2025-04-30, and is no longer supported.