### PR TITLE
Use Maven Daemon for Java builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ osv_scanner := go run github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
 govulncheck := go run golang.org/x/vuln/cmd/govulncheck@latest
 nancy := go run github.com/sonatype-nexus-community/nancy@latest
 
+maven := mvn
+ifneq (, $(shell command -v mvnd 2>/dev/null))
+	maven := mvnd
+endif
+
 # These should match names in Docker .env file
 export FABRIC_VERSION ?= 2.5
 export NODEENV_VERSION ?= 2.5
@@ -60,7 +65,7 @@ build-scenario-node: build-node
 .PHONY: build-java
 build-java:
 	cd '$(java_dir)' && \
-		mvn -DskipTests install
+		$(maven) -DskipTests install
 
 .PHONY: unit-test
 unit-test: generate lint unit-test-go unit-test-node unit-test-java
@@ -83,7 +88,7 @@ unit-test-node: build-node
 .PHONY: unit-test-java
 unit-test-java:
 	cd '$(java_dir)' && \
-		mvn test jacoco:report
+		$(maven) test jacoco:report
 
 .PHONY: lint
 lint: golangci-lint
@@ -142,7 +147,7 @@ scan-java: scan-java-dependency-check scan-java-osv-scanner
 .PHONY: scan-java-dependency-check
 scan-java-dependency-check:
 	cd '$(java_dir)' && \
-		mvn dependency-check:check -P owasp
+		$(maven) dependency-check:check -P owasp
 
 .PHONY: scan-java-osv-scanner
 scan-java-osv-scanner:
@@ -191,7 +196,7 @@ scenario-test-node-no-hsm: vendor-chaincode build-scenario-node install-fabric-c
 .PHONY: scenario-test-java
 scenario-test-java: vendor-chaincode
 	cd '$(java_dir)' && \
-		mvn -Dmaven.javadoc.skip=true -DskipUnitTests verify
+		$(maven) -Dmaven.javadoc.skip=true -DskipUnitTests verify
 
 .PHONY: scenario-test
 scenario-test: scenario-test-go scenario-test-node scenario-test-java
@@ -239,7 +244,7 @@ generate-docs-node:
 .PHONY: generate-docs-java
 generate-docs-java:
 	cd '$(java_dir)' && \
-		mvn javadoc:javadoc
+		$(maven) javadoc:javadoc
 
 .PHONY: test
 test: shellcheck unit-test scenario-test
@@ -256,7 +261,7 @@ clean-node:
 
 .PHONY: clean-java
 clean-java:
-	cd '$(java_dir)' && mvn clean
+	cd '$(java_dir)' && $(maven) clean
 
 .PHONY: clean-generated
 clean-generated:
@@ -285,4 +290,4 @@ format-node:
 
 .PHONY: format-java
 format-java:
-	cd '$(java_dir)' && mvn spotless:apply
+	cd '$(java_dir)' && $(maven) spotless:apply


### PR DESCRIPTION
If the Maven Daemon (mvnd) is available on the path, use that for Java builds instead of the default Maven (mvn) command. This improves build performance during development.