### PR TITLE
Publish Java using Maven Central Publisher API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
         run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh github
         working-directory: java
 
-  publish-java-ossrh:
+  publish-java-central:
     needs: verify-versions
     name: Publish Java artifact to Maven Central
     runs-on: ubuntu-24.04
@@ -64,15 +64,15 @@ jobs:
           java-version: 21
           distribution: temurin
           cache: maven
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
-        run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh ossrh
+        run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh central
         working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -404,7 +404,7 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <uniqueVersion>true</uniqueVersion>
+            <uniqueVersion>false</uniqueVersion>
             <id>github</id>
             <name>GitHub Packages</name>
             <url>https://maven.pkg.github.com/hyperledger/fabric-gateway</url>
@@ -553,25 +553,17 @@
             </distributionManagement>
         </profile>
         <profile>
-            <id>ossrh</id>
-            <distributionManagement>
-                <repository>
-                    <id>ossrh</id>
-                    <name>Central Repository OSSRH</name>
-                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-                </repository>
-            </distributionManagement>
+            <id>central</id>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.7.0</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.7.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Publishing to Maven Central using OSSRH is deprecated and is sunset on 2025-06-30. The build needs to be migrated to use the Central Publishing Portal.

Also allow non-unique snapshot publications since there is no need to retain multiple snapshot versions. Just the latest is sufficient.