### PR TITLE
Fix npm package.json

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -9,7 +9,8 @@
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/hyperledger/fabric-gateway"
+        "url": "git+https://github.com/hyperledger/fabric-gateway.git",
+        "directory": "node"
     },
     "bugs": "https://github.com/hyperledger/fabric-gateway/issues",
     "homepage": "https://hyperledger.github.io/fabric-gateway/",


### PR DESCRIPTION
npm publish flagged (and auto-corrected) errors in the Node package.json file. `npm pkg fix` corrected the offending `repository.url` value. A `repository.directory` value is also added to locate the package.json file within the repository.

See npm [package.json documentation](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#repository).