### PR TITLE
Use bc signer for Java publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,10 @@ jobs:
           java-version: 21
           distribution: temurin
           cache: maven
-          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh github
         working-directory: java
@@ -65,14 +64,13 @@ jobs:
           distribution: temurin
           cache: maven
           server-id: central
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
+          server-username: MAVENCENTRAL_USERNAME
+          server-password: MAVENCENTRAL_PASSWORD
       - name: Publish
         env:
-          MAVEN_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
+          MAVENCENTRAL_USERNAME: ${{ secrets.MAVENCENTRAL_USERNAME }}
+          MAVENCENTRAL_PASSWORD: ${{ secrets.MAVENCENTRAL_PASSWORD }}
+          MAVEN_GPG_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         run: ${{ github.workspace }}/.github/scripts/maven_publish_release.sh central
         working-directory: java

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -536,10 +536,9 @@
                                     <goal>sign</goal>
                                 </goals>
                                 <configuration>
-                                    <gpgArguments>
-                                        <arg>--pinentry-mode</arg>
-                                        <arg>loopback</arg>
-                                    </gpgArguments>
+                                    <keyEnvName>MAVEN_GPG_KEY</keyEnvName>
+                                    <passphraseEnvName>MAVEN_GPG_PASSPHRASE</passphraseEnvName>
+                                    <signer>bc</signer>
                                 </configuration>
                             </execution>
                         </executions>
@@ -564,7 +563,7 @@
                     <plugin>
                         <groupId>org.sonatype.central</groupId>
                         <artifactId>central-publishing-maven-plugin</artifactId>
-                        <version>0.7.0</version>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
                             <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
This simplifies the signing process by avoiding the need for GPG to be installed and configured, since the signing is done in Java using environment variables to supply secrets.