### PR TITLE
Fix Java snapshot publishing

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -84,11 +84,10 @@ jobs:
           java-version: 21
           distribution: temurin
           cache: maven
-          gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
-          gpg-passphrase: MAVEN_GPG_PASSPHRASE
       - name: Publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MAVEN_GPG_KEY: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
         run: ${{ github.workspace }}/.github/scripts/maven_publish_snapshot.sh
         working-directory: java


### PR DESCRIPTION
Changes to use the bc signing implementation were not reflected in the push workflow. This change matches the configuration from the release workflow.