### PR TITLE
Group Node dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,13 +26,19 @@ updates:
       # Avoid incrementing patch level to keep version ranges more compatible.
       - dependency-name: "*"
         update-types:
-        - "version-update:semver-patch"
+          - "version-update:semver-patch"
     directories:
       - "/node"
       - "/scenario/node"
       - "/scenario/fixtures/chaincode/node/*"
     schedule:
       interval: weekly
+    groups:
+      # Group updates to minimise merge conflicts on package-lock.json
+      production-dependencies:
+        dependency-type: production
+      development-dependencies:
+        dependency-type: development
   - package-ecosystem: maven
     directory: "/java"
     schedule:


### PR DESCRIPTION
Each dependency update modifies the package-lock.json, which means any dependency updates open in parallel result in a merge conflict and must be rebased when a change is merged. This change groups dependabot updates to Node packages in single pull requests to minimise merge conflicts and build churn.