### PR TITLE
Fix Node HSM signer failure

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.0",
                 "@hyperledger/fabric-protos": "^0.3.0",
-                "@noble/curves": "^1.7.0",
+                "@noble/curves": "^1.9.4",
                 "google-protobuf": "^3.21.0"
             },
             "devDependencies": {
@@ -1491,9 +1491,9 @@
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.0.tgz",
-            "integrity": "sha512-7YDlXiNMdO1YZeH6t/kvopHHbIZzlxrCV9WLqCY6QhcXOoXiNCMDqJIglZ9Yjx5+w7Dz30TITFrlTjnRg7sKEg==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
+            "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
             "license": "MIT",
             "dependencies": {
                 "@noble/hashes": "1.8.0"

--- a/node/package.json
+++ b/node/package.json
@@ -35,7 +35,7 @@
     "dependencies": {
         "@grpc/grpc-js": "^1.12.0",
         "@hyperledger/fabric-protos": "^0.3.0",
-        "@noble/curves": "^1.7.0",
+        "@noble/curves": "^1.9.4",
         "google-protobuf": "^3.21.0"
     },
     "optionalDependencies": {

--- a/node/src/identity/ecdsa.ts
+++ b/node/src/identity/ecdsa.ts
@@ -5,8 +5,8 @@
  */
 
 import { CurveFn } from '@noble/curves/abstract/weierstrass';
-import { p256 } from '@noble/curves/p256';
-import { p384 } from '@noble/curves/p384';
+import { p256 } from '@noble/curves/nist';
+import { p384 } from '@noble/curves/nist';
 import { KeyObject } from 'node:crypto';
 import { Signer } from './signer';
 
@@ -29,7 +29,7 @@ export function newECPrivateKeySigner(key: KeyObject): Signer {
 
     return (digest) => {
         const signature = curve.sign(digest, privateKey, { lowS: true });
-        return Promise.resolve(signature.toDERRawBytes());
+        return Promise.resolve(signature.toBytes('der'));
     };
 }
 

--- a/node/src/identity/hsmsigner.test.ts
+++ b/node/src/identity/hsmsigner.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { p256 } from '@noble/curves/p256';
+import { p256 } from '@noble/curves/nist';
 import { createHash } from 'node:crypto';
 import { Mechanism, Pkcs11Error, SessionInfo, SlotInfo, Template, TokenInfo } from 'pkcs11js';
 import { HSMSignerOptions } from './hsmsigner';
@@ -195,7 +195,7 @@ describe('When using an HSM Signer', () => {
 
     const hsmSignerFactory = newHSMSignerFactory('somelibrary');
 
-    const privateKey = p256.utils.randomPrivateKey();
+    const privateKey = p256.utils.randomSecretKey();
     const publicKey = p256.getPublicKey(privateKey);
 
     beforeEach(() => {
@@ -212,7 +212,7 @@ describe('When using an HSM Signer', () => {
         });
         pkcs11Stub.C_SignInit = jest.fn();
         pkcs11Stub.C_Sign = jest.fn((session, digest, buffer) => {
-            const signature = p256.sign(digest, privateKey).toCompactRawBytes();
+            const signature = p256.sign(digest, privateKey).toBytes('compact');
             signature.forEach((b, i) => buffer.writeUInt8(b, i));
             // Return buffer of exactly signature length regardless of supplied buffer size
             return buffer.subarray(0, signature.length);

--- a/node/src/identity/hsmsigner.ts
+++ b/node/src/identity/hsmsigner.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { p256 } from '@noble/curves/p256';
+import { p256 } from '@noble/curves/nist';
 import * as pkcs11js from 'pkcs11js';
 import { Signer } from './signer';
 
@@ -101,9 +101,9 @@ export class HSMSignerFactoryImpl implements HSMSignerFactory {
                     Buffer.from(digest),
                     // EC signatures have length of 2n according to the PKCS11 spec:
                     // https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.1/pkcs11-spec-v3.1.html
-                    Buffer.alloc(p256.CURVE.nByteLength * 2),
+                    Buffer.alloc(p256.Point.Fn.BYTES * 2),
                 );
-                const signature = p256.Signature.fromCompact(compactSignature).normalizeS().toDERRawBytes();
+                const signature = p256.Signature.fromBytes(compactSignature, 'compact').normalizeS().toBytes('der');
                 return Promise.resolve(signature);
             },
             close: () => {

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -537,12 +537,12 @@
         "node_modules/@hyperledger/fabric-gateway": {
             "version": "1.8.0",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-8cpIdTXalWHBQa/ck+oWvvq5GMEauBkqddZxoyxlYd8Wm812wCxjapeFpKHW2+BITtcTSvQXlKdY2RwEg7DTkw==",
+            "integrity": "sha512-rvERMtORv/cHj9TwKANZmlF1j8RvqqdeS4GO5ZC9O6Is7SSCR3rs7VQ79CluKnvCzurW/v5CcYRdH/mZqwKY8A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.0",
                 "@hyperledger/fabric-protos": "^0.3.0",
-                "@noble/curves": "^1.7.0",
+                "@noble/curves": "^1.9.4",
                 "google-protobuf": "^3.21.0"
             },
             "engines": {
@@ -715,9 +715,9 @@
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.2.tgz",
-            "integrity": "sha512-HxngEd2XUcg9xi20JkwlLCtYwfoFw4JGkuZpT+WlsPD4gB/cxkvTD8fSsoAnphGZhFdZYKeQIPCuFlWPm1uE0g==",
+            "version": "1.9.4",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
+            "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
             "license": "MIT",
             "dependencies": {
                 "@noble/hashes": "1.8.0"


### PR DESCRIPTION
A regression in the `@noble/curves` dependency causes the following error in the Node HSM signer if npm install resolves version 1.9.2 to 1.9.4.

This change uses new `@noble/curves` APIs (introduced in v1.9.2) and avoids newly deprecated API usage, including the one where the regression is introduced.

Closes #865