### PR TITLE
Avoid deprecated OSV-Scanner option

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -56,7 +56,6 @@ jobs:
       - name: Create BOM
         working-directory: node
         run: |
-          npm install --omit=dev --package-lock-only --no-audit
           npm sbom --omit=dev --package-lock-only --sbom-format cyclonedx > bom.cdx.json
       - name: Scan
         id: scan-node
@@ -65,7 +64,7 @@ jobs:
             --volume './:/src' \
             ghcr.io/google/osv-scanner:latest \
             scan \
-            --sbom=/src/node/bom.cdx.json \
+            --lockfile=/src/node/bom.cdx.json \
             --format=markdown > osv-scanner.md
       - name: Report failure
         if: ${{ failure() && steps.scan-node.conclusion == 'failure' }}

--- a/Makefile
+++ b/Makefile
@@ -133,15 +133,13 @@ scan-node: scan-node-osv-scanner
 .PHONY: scan-node-npm-audit
 scan-node-npm-audit:
 	cd '$(node_dir)' && \
-		npm install --omit=dev --package-lock-only --no-audit && \
 		npm audit --omit=dev
 
 .PHONY: scan-node-osv-scanner
 scan-node-osv-scanner: install-osv-scanner
 	cd '$(node_dir)' && \
-		npm install --omit=dev --package-lock-only --no-audit && \
 		npm sbom --omit=dev --package-lock-only --sbom-format cyclonedx > bom.cdx.json && \
-		osv-scanner scan --sbom=bom.cdx.json
+		osv-scanner scan --lockfile=bom.cdx.json
 
 .PHONY: scan-java
 scan-java: scan-java-osv-scanner


### PR DESCRIPTION
Avoid the recently deprecated `--sbom` option to OSV-Scanner. The existing `--lockfile` option now handles SBOMs in addition to other lockfile formats.

Also avoid regenerating the the package-lock.json file before generating the SBOM, since package-lock.json files are checked into the repository.