### PR TITLE
Support Go 1.25

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,10 +48,10 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.23"
           - "1.24"
+          - "1.25"
         include:
-          - go-version: "1.24"
+          - go-version: "1.25"
             coverage: true
     env:
       SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf
@@ -82,8 +82,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.23"
           - "1.24"
+          - "1.25"
     env:
       SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf
     steps:

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GATEWAY_VERSION: 1.8.1
+  GATEWAY_VERSION: 1.9.0
 
 jobs:
   go:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ go_bin_dir := $(shell go env GOPATH)/bin
 python_venv_dir := $(base_dir)/.venv
 python_venv_activate := $(python_venv_dir)/bin/activate
 
-mockery_version := 3.5.3
+mockery_version := 3.5.4
 kernel_name := $(shell uname -s)
 machine_hardware := $(shell uname -m)
 ifeq ($(machine_hardware), aarch64)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ See the [proto definitions](https://github.com/hyperledger/fabric-protos/blob/ma
 This repository comprises three functionally equivalent client APIs, written in Go, TypeScript, and Java. In order to
 build these components, the following need to be installed and available in the PATH:
 
-- [Go 1.23+](https://go.dev/)
+- [Go 1.24+](https://go.dev/)
 - [Node 18+](https://nodejs.org/)
 - [Java 11+](https://adoptium.net/)
 - [Docker](https://www.docker.com/)

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -4,10 +4,10 @@ Each minor release version of Fabric Gateway client API targets the current supp
 
 The following table shows versions of Fabric, programming language runtimes, and other dependencies that are explicitly tested and that are supported for use with the latest version of the Fabric Gateway client API.
 
-|              | Tested       | Supported     |
-| ------------ | ------------ | ------------- |
-| **Fabric**   | 2.5          | 2.4.4+        |
-| **Go**       | 1.23, 1.24   | 1.23, 1.24    |
-| **Node**     | 20, 22       | 20, 22        |
-| **Java**     | 11, 17, 21   | 8, 11, 17, 21 |
-| **Platform** | Ubuntu 24.04 |               |
+|              | Tested       | Supported        |
+| ------------ | ------------ | ---------------- |
+| **Fabric**   | 2.5          | 2.4.4+           |
+| **Go**       | 1.23, 1.24   | 1.23, 1.24, 1.25 |
+| **Node**     | 20, 22       | 20, 22           |
+| **Java**     | 11, 17, 21   | 8, 11, 17, 21    |
+| **Platform** | Ubuntu 24.04 |                  |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/cucumber/godog v0.15.1
@@ -9,7 +9,6 @@ require (
 	github.com/miekg/pkcs11 v1.1.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	golang.org/x/crypto v0.41.0
 	google.golang.org/grpc v1.75.1
 	google.golang.org/protobuf v1.36.9
 )

--- a/go.sum
+++ b/go.sum
@@ -76,8 +76,6 @@ go.opentelemetry.io/otel/sdk/metric v1.37.0 h1:90lI228XrB9jCMuSdA0673aubgRobVZFh
 go.opentelemetry.io/otel/sdk/metric v1.37.0/go.mod h1:cNen4ZWfiD37l5NhS+Keb5RXVWZWpRE+9WyVCpbo5ps=
 go.opentelemetry.io/otel/trace v1.37.0 h1:HLdcFNbRQBE2imdSEgm/kwqmQj1Or1l/7bW6mxVK7z4=
 go.opentelemetry.io/otel/trace v1.37.0/go.mod h1:TlgrlQ+PtQO5XFerSPUYG0JSgGyryXewPGyayAWSBS0=
-golang.org/x/crypto v0.41.0 h1:WKYxWedPGCTVVl5+WHSSrOBT0O8lx32+zxmHxijgXp4=
-golang.org/x/crypto v0.41.0/go.mod h1:pO5AFd7FA68rFak7rOAGVuygIISepHftHnr8dr6+sUc=
 golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
 golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
 golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hyperledger.fabric</groupId>
     <artifactId>fabric-gateway</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>fabric-gateway</name>

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hyperledger/fabric-gateway",
-            "version": "1.8.1",
+            "version": "1.9.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.8.1",
+    "version": "1.9.0",
     "description": "Hyperledger Fabric Gateway client API for Node",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/pkg/hash/hash.go
+++ b/pkg/hash/hash.go
@@ -6,10 +6,9 @@ package hash
 
 import (
 	"crypto/sha256"
+	"crypto/sha3"
 	"crypto/sha512"
 	gohash "hash"
-
-	"golang.org/x/crypto/sha3"
 )
 
 // Hash function generates a digest for the supplied message.

--- a/scenario/fixtures/chaincode/golang/basic/go.mod
+++ b/scenario/fixtures/chaincode/golang/basic/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway/scenario/fixtures/chaincode/golang/basic
 
-go 1.23.0
+go 1.24.0
 
 require github.com/hyperledger/fabric-contract-api-go/v2 v2.2.0
 

--- a/scenario/fixtures/chaincode/golang/private/go.mod
+++ b/scenario/fixtures/chaincode/golang/private/go.mod
@@ -1,6 +1,6 @@
 module github.com/hyperledger/fabric-gateway/scenario/fixtures/chaincode/golang/private
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/hyperledger/fabric-chaincode-go/v2 v2.3.0

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -597,9 +597,9 @@
             }
         },
         "node_modules/@hyperledger/fabric-gateway": {
-            "version": "1.8.1",
+            "version": "1.9.0",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-YLLEDYc7udO7aNcDCrEy72j9ksKYOy/4VhD4z9R1t/D33lRDnkbxgeMecLLi/pFa+FVi/A4fk6WvKOsXGTas2A==",
+            "integrity": "sha512-dRM5x/ZcbjFkviGTtu+BjLI+uGJ2bLI00cweQU+G8NEsEmuyS9i2R16MQSSiZKlrxbrWgHkd8PzQgNKUOY4SUw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.12.0",


### PR DESCRIPTION
- Remove support for Go 1.23 since this is no longer a supported Go version.
- Use standard library crypto/sha3 instead of golang.org/x/crypto.

Closes #915