### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,25 @@ updates:
   - package-ecosystem: devcontainers
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
+    groups:
+      actions:
+        patterns:
+          - "*"
   - package-ecosystem: gomod
     directories:
       - "/"
       - "/scenario/fixtures/chaincode/golang/*"
     schedule:
-      interval: weekly
+      interval: daily
+    groups:
+      go:
+        patterns:
+          - "*"
   - package-ecosystem: npm
     versioning-strategy: increase
     ignore:
@@ -32,19 +40,28 @@ updates:
       - "/scenario/node"
       - "/scenario/fixtures/chaincode/node/*"
     schedule:
-      interval: weekly
+      interval: daily
     groups:
       # Group updates to minimise merge conflicts on package-lock.json
-      production-dependencies:
+      production:
         dependency-type: production
-      development-dependencies:
+      development:
         dependency-type: development
   - package-ecosystem: maven
     directory: "/java"
     schedule:
-      interval: weekly
+      interval: daily
+    groups:
+      production:
+        dependency-type: production
+      development:
+        dependency-type: development
   - package-ecosystem: pip
     versioning-strategy: increase
     directory: "/"
     schedule:
-      interval: weekly
+      interval: daily
+    groups:
+      pip:
+        patterns:
+          - "*"

--- a/.github/scripts/npm_publish.sh
+++ b/.github/scripts/npm_publish.sh
@@ -6,11 +6,8 @@ TAG="${1:?}"
 
 if [[ ${TAG} != latest ]]; then
     PACKAGE_VERSION=$(jq --raw-output .version package.json)
-    TODAY=$(date -u '+%Y%m%d')
-    TARGET_VERSION="${PACKAGE_VERSION}-dev.${TODAY}."
-    INCREMENT=$(npm view --json | jq --raw-output '.versions[]' | awk -F . "/^${TARGET_VERSION}/"'{ lastVersion=$NF } \
-        END { sub(/".*/, "", lastVersion); print (lastVersion=="" ? "1" : lastVersion+1) }')
-    PUBLISH_VERSION="${TARGET_VERSION}${INCREMENT}"
+    NOW=$(date -u '+%Y%m%d.%H%M%S')
+    PUBLISH_VERSION="${PACKAGE_VERSION}-dev.${NOW}"
     npm --allow-same-version --no-git-tag-version version "${PUBLISH_VERSION}"
 fi
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,11 @@ on:
 permissions:
   contents: read
 
+# Allow in-progress run to complete but only queue the latest push
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   build:
     uses: ./.github/workflows/test.yml
@@ -56,17 +61,23 @@ jobs:
     needs: build
     name: Publish Node package
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    concurrency:
+      group: npm-pkg
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: "lts/*"
-          registry-url: "https://registry.npmjs.org"
+          registry-url: "https://npm.pkg.github.com"
       - name: Build
         run: make build-node
       - name: Publish
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ${{ github.workspace }}/.github/scripts/npm_publish.sh unstable
         working-directory: node
 


### PR DESCRIPTION
Minimise use of build resources by grouping dependabot updates for each ecosystem into a single pull request. Apply concurrency rules to minimise the number of builds triggered when multiple pull requests are merged in close succession.

Also publish unstable npm packages to GitHub packages instead of the public NPM registry to reduce the burden of dependency updates.