### PR TITLE
Change surefire naming strategy

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -39,13 +39,19 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javaReleaseVersion>8</javaReleaseVersion>
         <requireJavaVersion>17</requireJavaVersion>
-        <bouncyCastleVersion>1.82</bouncyCastleVersion>
         <skipUnitTests>${skipTests}</skipUnitTests>
         <pmdVersion>7.17.0</pmdVersion>
     </properties>
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bc-jdk18on-bom</artifactId>
+                <type>pom</type>
+                <version>1.82</version>
+                <scope>import</scope>
+            </dependency>
             <dependency>
                 <groupId>io.cucumber</groupId>
                 <artifactId>cucumber-bom</artifactId>
@@ -65,6 +71,13 @@
                 <artifactId>assertj-bom</artifactId>
                 <version>3.27.6</version>
                 <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <type>pom</type>
+                <version>5.20.0</version>
                 <scope>import</scope>
             </dependency>
             <dependency>
@@ -104,7 +117,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>5.20.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -120,12 +132,10 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk18on</artifactId>
-            <version>${bouncyCastleVersion}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk18on</artifactId>
-            <version>${bouncyCastleVersion}</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
@@ -230,7 +240,7 @@
                 <configuration>
                     <properties>
                         <configurationParameters>
-                            cucumber.junit-platform.naming-strategy=surefire
+                            cucumber.junit-platform.naming-strategy=long
                         </configurationParameters>
                     </properties>
                 </configuration>

--- a/java/src/test/java/scenario/RunScenarioTest.java
+++ b/java/src/test/java/scenario/RunScenarioTest.java
@@ -26,7 +26,7 @@ import org.junit.platform.suite.api.Suite;
 public class RunScenarioTest {
     @BeforeAll
     public static void startFabric() throws Exception {
-        System.err.println("Starting Fabric");
+        System.out.println("Starting Fabric");
         ScenarioSteps.startFabric();
     }
 

--- a/java/src/test/java/scenario/ScenarioSteps.java
+++ b/java/src/test/java/scenario/ScenarioSteps.java
@@ -914,7 +914,7 @@ public class ScenarioSteps {
 
     private static String exec(Path dir, String... commandArgs) throws IOException, InterruptedException {
         String commandString = String.join(" ", commandArgs);
-        System.err.println(commandString);
+        System.out.println(commandString);
         StringBuilder sb = new StringBuilder();
 
         File dirFile = dir != null ? dir.toFile() : null;

--- a/scenario/fixtures/docker-compose/docker-compose-base.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-base.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: "3.8"
 
 services:
   ca0:

--- a/scenario/fixtures/docker-compose/docker-compose-cli.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-cli.yaml
@@ -12,8 +12,6 @@
 # limitations under the License.
 #
 
-version: "3.8"
-
 services:
   clinopeer:
     container_name: cli

--- a/scenario/fixtures/docker-compose/docker-compose-tls.yaml
+++ b/scenario/fixtures/docker-compose/docker-compose-tls.yaml
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-version: "3.8"
 
 services:
   ca0.example.com:


### PR DESCRIPTION
The `surefire` naming strategy for the Java surefire test runner plugin does not work as expected for surefire plugin 3.5.4 and above. This causes warning messages to appear in the test logs, and can compromise the usability of the output.

This change use the currently recommended `long` naming strategy. There are some additional minor changes to dependency declarations and docker-compose files to streamline version management and avoid warning messages during test execution.