### PR TITLE
Make Go error details more accessible

### DIFF
--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GATEWAY_VERSION: 1.9.1
+  GATEWAY_VERSION: 1.10.0
 
 jobs:
   go:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hyperledger.fabric</groupId>
     <artifactId>fabric-gateway</artifactId>
-    <version>1.9.1-SNAPSHOT</version>
+    <version>1.10.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>fabric-gateway</name>

--- a/java/src/main/java/org/hyperledger/fabric/client/GrpcStackTracePrinter.java
+++ b/java/src/main/java/org/hyperledger/fabric/client/GrpcStackTracePrinter.java
@@ -38,16 +38,16 @@ class GrpcStackTracePrinter {
 
         List<ErrorDetail> details = grpcStatus.getDetails();
         if (!details.isEmpty()) {
-            message.append("Error details:\n");
+            message.append("Error details:");
             for (ErrorDetail detail : details) {
-                message.append("    address: ")
+                message.append("\n  - address: ")
                         .append(detail.getAddress())
-                        .append("; mspId: ")
+                        .append("\n    mspId: ")
                         .append(detail.getMspId())
-                        .append("; message: ")
-                        .append(detail.getMessage())
-                        .append('\n');
+                        .append("\n    message: ")
+                        .append(detail.getMessage());
             }
+            message.append('\n');
         }
 
         out.print(message);

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.9.1",
+    "version": "1.10.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hyperledger/fabric-gateway",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.9.1",
+    "version": "1.10.0",
     "description": "Hyperledger Fabric Gateway client API for Node",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/pkg/client/errors_test.go
+++ b/pkg/client/errors_test.go
@@ -1,0 +1,153 @@
+// Copyright IBM Corp. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/gateway"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/protoadapt"
+)
+
+func newGrpcStatus(code codes.Code, message string, details ...*gateway.ErrorDetail) (*status.Status, error) {
+	result := status.New(code, message)
+	if len(details) == 0 {
+		return result, nil
+	}
+
+	var v1Details []protoadapt.MessageV1
+	for _, detail := range details {
+		v1Details = append(v1Details, protoadapt.MessageV1Of(detail))
+	}
+
+	resultWithDetails, err := result.WithDetails(v1Details...)
+	if err != nil {
+		return nil, err
+	}
+
+	return resultWithDetails, nil
+}
+
+func TestErrors(t *testing.T) {
+	for typeName, newInstance := range map[string](func(*TransactionError) error){
+		"endorse error": func(txErr *TransactionError) error {
+			return &EndorseError{txErr}
+		},
+		"submit error": func(txErr *TransactionError) error {
+			return &SubmitError{txErr}
+		},
+		"commit status error": func(txErr *TransactionError) error {
+			return &CommitStatusError{txErr}
+		},
+	} {
+		t.Run(typeName+" with details", func(t *testing.T) {
+			details := []*gateway.ErrorDetail{
+				{
+					Address: "ADDRESS_1",
+					MspId:   "MSP_ID_1",
+					Message: "MESSAGE_1",
+				},
+				{
+					Address: "ADDRESS_2",
+					MspId:   "MSP_ID_2",
+					Message: "MESSAGE_2",
+				},
+			}
+			grpcStatus, err := newGrpcStatus(codes.Aborted, "STATUS_MESSAGE", details...)
+			require.NoError(t, err)
+
+			transactionErr := newTransactionError(grpcStatus.Err(), "TRANSACTION_ID")
+			actualErr := newInstance(transactionErr)
+
+			t.Run("Error", func(t *testing.T) {
+				require.ErrorContains(t, actualErr, grpcStatus.Err().Error())
+				require.ErrorContains(t, actualErr, typeName)
+				for _, detail := range details {
+					require.ErrorContains(t, actualErr, detail.GetAddress())
+					require.ErrorContains(t, actualErr, detail.GetMspId())
+					require.ErrorContains(t, actualErr, detail.GetMessage())
+				}
+			})
+
+			t.Run("Details", func(t *testing.T) {
+				expectedErr := new(TransactionError)
+				require.ErrorAs(t, actualErr, &expectedErr)
+
+				require.Len(t, expectedErr.Details(), len(details), "number of detail messages")
+				for i, actual := range expectedErr.Details() {
+					expected := details[i]
+					AssertProtoEqual(t, expected, actual)
+				}
+			})
+		})
+
+		t.Run(typeName+" without details", func(t *testing.T) {
+			grpcStatus, err := newGrpcStatus(codes.Aborted, "STATUS_MESSAGE")
+			require.NoError(t, err)
+
+			transactionErr := newTransactionError(grpcStatus.Err(), "TRANSACTION_ID")
+			actualErr := newInstance(transactionErr)
+
+			t.Run("Error", func(t *testing.T) {
+				require.ErrorContains(t, actualErr, grpcStatus.Err().Error())
+				require.ErrorContains(t, actualErr, typeName)
+			})
+
+			t.Run("TransactionID", func(t *testing.T) {
+				var actualTransactionErr *TransactionError
+				require.ErrorAs(t, actualErr, &actualTransactionErr)
+
+				require.Equal(t, transactionErr.TransactionID, actualTransactionErr.TransactionID)
+			})
+
+			t.Run("Details", func(t *testing.T) {
+				var actualTransactionErr *TransactionError
+				require.ErrorAs(t, actualErr, &actualTransactionErr)
+
+				require.Empty(t, actualTransactionErr.Details())
+			})
+		})
+	}
+
+	t.Run("Consistent behavior", func(t *testing.T) {
+		grpcStatus, err := newGrpcStatus(codes.Aborted, "STATUS_MESSAGE")
+		require.NoError(t, err)
+
+		transactionErr := newTransactionError(grpcStatus.Err(), "TRANSACTION_ID")
+
+		t.Run("EndorseError", func(t *testing.T) {
+			actualErr := &EndorseError{transactionErr}
+
+			var endorseErr *EndorseError
+			require.ErrorAs(t, actualErr, &endorseErr)
+
+			assert.Equal(t, transactionErr.TransactionID, endorseErr.TransactionID)
+			assert.Empty(t, endorseErr.Details())
+		})
+
+		t.Run("SubmitError", func(t *testing.T) {
+			actualErr := &SubmitError{transactionErr}
+
+			var submitErr *SubmitError
+			require.ErrorAs(t, actualErr, &submitErr)
+
+			assert.Equal(t, transactionErr.TransactionID, submitErr.TransactionID)
+			assert.Empty(t, submitErr.Details())
+		})
+
+		t.Run("CommitStatusError", func(t *testing.T) {
+			actualErr := &CommitStatusError{transactionErr}
+
+			var commitStatusErr *CommitStatusError
+			require.ErrorAs(t, actualErr, &commitStatusErr)
+
+			assert.Equal(t, transactionErr.TransactionID, commitStatusErr.TransactionID)
+			assert.Empty(t, commitStatusErr.Details())
+		})
+	})
+}

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -169,6 +169,7 @@
             "integrity": "sha512-659CCFsrsyvuBi/Eix1fnhSheMnojSfnBcqJ3IMPNawx7JlrNJDcXYSSdxcUw3n/nG05P+ptCjmiZY3i14p+tA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cucumber/messages": ">=19.1.4 <29"
             }
@@ -280,6 +281,7 @@
             "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@cucumber/messages": ">=17.1.1"
             }
@@ -289,6 +291,7 @@
             "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
             "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
             "dev": true,
+            "peer": true,
             "dependencies": {
                 "@types/uuid": "10.0.0",
                 "class-transformer": "0.5.1",
@@ -602,9 +605,9 @@
             }
         },
         "node_modules/@hyperledger/fabric-gateway": {
-            "version": "1.9.1",
+            "version": "1.10.0",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-b6M1+63eUDfrfrZGfROcpw5iSaZyuag5QJYvcmJHfMlpOvt/Kq99TlgaXOws0rgPTy5OlPHlQ/g2auasE2ScyA==",
+            "integrity": "sha512-jpAwSRrL4urBqXn2FCfUTmzEvf7GujvalsxL12kp6sB/g5Aw1HJzxbCofIjNZ987v3vbQrVmw7bU/VvvvywDLw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",
@@ -1080,6 +1083,7 @@
             "integrity": "sha512-n1H6IcDhmmUEG7TNVSspGmiHHutt7iVKtZwRppD7e04wha5MrkV1h3pti9xQLcCMt6YWsncpoT0HMjkH1FNwWQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.46.0",
                 "@typescript-eslint/types": "8.46.0",
@@ -1297,6 +1301,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1714,6 +1719,7 @@
             "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3664,6 +3670,7 @@
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"


### PR DESCRIPTION
- Add Details() method to transaction errors.
- Include error details in Error() message.
- Add Unwrap() methods to specific transaction errors so the underlying TransactionError can be retrieved without knowing the specific error type, to provide easier access to TransactionID and Details().
- Change Java stack trace to use similar YAML-like format as Go error details.