### PR TITLE
Remove obsolete Go build tags

### DIFF
--- a/pkg/identity/hsmsign.go
+++ b/pkg/identity/hsmsign.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build pkcs11
-// +build pkcs11
 
 package identity
 

--- a/pkg/identity/hsmsign_test.go
+++ b/pkg/identity/hsmsign_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build pkcs11
-// +build pkcs11
 
 package identity
 


### PR DESCRIPTION
A new Go build tag syntax in the form `//go:build` was added in Go 1.17. In Go 1.18, this new syntax replaced the old syntax, which used the form `// +build`. The fabric-gateway code retained both build tags for backwards compatibility. Since the minimum supported Go version is now 1.24, the old format is obsolete and now flags a linting error. This change removes the old style build tags.