### PR TITLE
Update versions following 1.10.1 release

### DIFF
--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GATEWAY_VERSION: 1.10.1
+  GATEWAY_VERSION: 1.10.2
 
 jobs:
   go:

--- a/java/README.md
+++ b/java/README.md
@@ -30,7 +30,7 @@ Add the following dependency to your project's `pom.xml` file:
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-bom</artifactId>
-            <version>4.33.0</version>
+            <version>4.33.4</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -41,7 +41,7 @@ Add the following dependency to your project's `pom.xml` file:
     <dependency>
         <groupId>org.hyperledger.fabric</groupId>
         <artifactId>fabric-gateway</artifactId>
-        <version>1.10.0</version>
+        <version>1.10.1</version>
     </dependency>
 </dependencies>
 ```
@@ -56,7 +56,7 @@ A suitable gRPC channel service provider must also be specified (as described in
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-bom</artifactId>
-            <version>1.76.0</version>
+            <version>1.78.0</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>
@@ -81,8 +81,8 @@ A suitable gRPC channel service provider must also be specified (as described in
 Add the following dependency to your project's `build.gradle` file:
 
 ```groovy
-implementation 'org.hyperledger.fabric:fabric-gateway:1.10.0'
-implementation platform('com.google.protobuf:protobuf-bom:4.33.0')
+implementation 'org.hyperledger.fabric:fabric-gateway:1.10.1'
+implementation platform('com.google.protobuf:protobuf-bom:4.33.4')
 ```
 
 Note the **platform** import, which ensures that v4 of the Java protocol buffers package is resolved by your project.
@@ -90,7 +90,7 @@ Note the **platform** import, which ensures that v4 of the Java protocol buffers
 A suitable gRPC channel service provider must also be specified (as described in the [gRPC security documentation](https://github.com/grpc/grpc-java/blob/master/SECURITY.md#transport-security-tls)), such as:
 
 ```groovy
-implementation platform('io.grpc:grpc-bom:1.76.0')
+implementation platform('io.grpc:grpc-bom:1.78.0')
 compileOnly 'io.grpc:grpc-api'
 runtimeOnly 'io.grpc:grpc-netty-shaded'
 ```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hyperledger.fabric</groupId>
     <artifactId>fabric-gateway</artifactId>
-    <version>1.10.1-SNAPSHOT</version>
+    <version>1.10.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>fabric-gateway</name>

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hyperledger/fabric-gateway",
-            "version": "1.10.1",
+            "version": "1.10.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.10.1",
+    "version": "1.10.2",
     "description": "Hyperledger Fabric Gateway client API for Node",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -74,6 +74,7 @@
             "integrity": "sha512-z6XKBIcUnJebnR3W8+K7Q2jJKB+pKpoD1l3CygEa9ufq/aeGuS5LAlllNxrod8loepLJhNmp8J8aengGbkL4cg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cucumber/ci-environment": "12.0.0",
                 "@cucumber/cucumber-expressions": "18.1.0",
@@ -142,6 +143,7 @@
             "integrity": "sha512-VmX+PKa9vqKZiycZoQKYlCsA0N7gAfiOfrcHSjK+suEVUwvKEH2sjO47NznrFFLmVWYTRmw3DLHQnpBAznkYEA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@cucumber/messages": ">=31.0.0 <32"
             }
@@ -248,6 +250,7 @@
             "integrity": "sha512-Kxap9uP5jD8tHUZVjTWgzxemi/0uOsbGjd4LBOSxcJoOCRbESFwemUzilJuzNTB8pcTQUh8D5oudUyxfkJOKmA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@cucumber/messages": ">=17.1.1"
             }
@@ -258,6 +261,7 @@
             "integrity": "sha512-3urzBNCwmU/YKrKR0b3XdioFcOFNuxlLwEImsxeP8rXnweLs+Ky04QURcbKpFom3T6a6v9zVioLCfHUuSQ72pg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "class-transformer": "0.5.1",
                 "reflect-metadata": "0.2.2"
@@ -556,9 +560,9 @@
             }
         },
         "node_modules/@hyperledger/fabric-gateway": {
-            "version": "1.10.1",
+            "version": "1.10.2",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-wDWloHkArhCQjnFkiw5SNaqEEZrJiHNa3TeRFHeDJhb8Cr1jnFh/+LlrFPKAUElBwsKtNQaLXAMHckQvxyhW6g==",
+            "integrity": "sha512-Q/EGkTUtiMFYSz4dJgeorLqJtUjQ/GcbFSBCFvnY2JvDfmQx+iLfSabfZvO9tF2l1uMRgZ4444KNtbIZSPEzfA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",
@@ -952,6 +956,7 @@
             "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "8.54.0",
                 "@typescript-eslint/types": "8.54.0",
@@ -1168,6 +1173,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -1578,6 +1584,7 @@
             "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
@@ -3263,6 +3270,7 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3352,6 +3360,7 @@
             "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"

--- a/scripts/update-versions.sh
+++ b/scripts/update-versions.sh
@@ -12,7 +12,10 @@ if [ $# -eq 1 ]; then
     NEXT_VERSION="$1"
 else
     NEXT_VERSION="$(
-        awk 'match($0, /^[ \t]*GATEWAY_VERSION:[ \t]*([0-9]+)\.([0-9]+)\.([0-9]+)/, v) {
+        awk -F'GATEWAY_VERSION:' '/^[ \t]*GATEWAY_VERSION:/ {
+                sub(/^[ \t]+/, "", $2)
+                sub(/[ \t]$/, "", $2)
+                split($2, v, ".")
                 printf "%d.%d.%d", v[1], v[2], v[3]+1
                 exit
             }' \


### PR DESCRIPTION
Also modify the update-versions.sh script to avoid gawk-specific features so that it will run with the standard awk version available on macOS.