### PR TITLE
Suppress false positive for CVE-2026-41242

### DIFF
--- a/node/osv-scanner.toml
+++ b/node/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "CVE-2026-41242"
+reason = "Client API uses pre-compiled protobuf bindings and this vulnerability affects on-the-fly compilation"


### PR DESCRIPTION
This vulnerability affects on-the-fly protobuf compilation. The client API uses pre-compiled protobuf bindings and does not use on-the-fly compilation.