### PR TITLE
No explicit data source in Java vulnerability scan

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -135,7 +135,6 @@ jobs:
             ghcr.io/google/osv-scanner:latest \
             scan source \
             --lockfile=/src/java/pom.xml \
-            --data-source=native \
             --format=markdown > osv-scanner.md
       - name: Report failure
         if: ${{ failure() && steps.scan-java.conclusion == 'failure' }}


### PR DESCRIPTION
The vulnerability scan workflow explicitly specified the (non-default) `native` data source for OSV-Scanner when scanning Java code. This was introduced to go to Maven Central directly and avoid a transient failure in the default data source. However, stricter Maven Central rate limiting is now causing errors.

This change reverts to using the default data source for dependency resolution.