### PR TITLE
Drop support for Node 20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,6 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 20
           - 22
           - 24
     env:
@@ -131,7 +130,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 20
+          - 22
           - 24
     env:
       SOFTHSM2_CONF: ${{ github.workspace }}/softhsm2.conf

--- a/.github/workflows/verify-versions.yml
+++ b/.github/workflows/verify-versions.yml
@@ -7,7 +7,7 @@ permissions:
   contents: read
 
 env:
-  GATEWAY_VERSION: 1.11.1
+  GATEWAY_VERSION: 1.12.0
 
 jobs:
   go:

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>org.hyperledger.fabric</groupId>
     <artifactId>fabric-gateway</artifactId>
-    <version>1.11.1-SNAPSHOT</version>
+    <version>1.12.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>fabric-gateway</name>

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@hyperledger/fabric-gateway",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",
@@ -17,10 +17,10 @@
             "devDependencies": {
                 "@eslint/eslintrc": "^3.3.4",
                 "@eslint/js": "^10.0.1",
-                "@tsconfig/node20": "^20.1.5",
+                "@tsconfig/node22": "^22.0.5",
                 "@types/google-protobuf": "^3.15.12",
                 "@types/jest": "^30.0.0",
-                "@types/node": "^20.19.1",
+                "@types/node": "^22.19.19",
                 "eslint": "^10.4.0",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-jest": "^29.15.0",
@@ -32,7 +32,7 @@
                 "typescript-eslint": "^8.59.0"
             },
             "engines": {
-                "node": ">=20.9.0"
+                "node": ">=22.22.3"
             },
             "optionalDependencies": {
                 "pkcs11js": "^2.1.0"
@@ -794,9 +794,9 @@
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.14.3",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.3.tgz",
-            "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.8.0",
@@ -1440,16 +1440,22 @@
             }
         },
         "node_modules/@napi-rs/wasm-runtime": {
-            "version": "0.2.12",
-            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
-            "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+            "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
             "dev": true,
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@emnapi/core": "^1.4.3",
-                "@emnapi/runtime": "^1.4.3",
-                "@tybys/wasm-util": "^0.10.0"
+                "@tybys/wasm-util": "^0.10.1"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/Brooooooklyn"
+            },
+            "peerDependencies": {
+                "@emnapi/core": "^1.7.1",
+                "@emnapi/runtime": "^1.7.1"
             }
         },
         "node_modules/@noble/curves": {
@@ -1522,19 +1528,18 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
@@ -1544,9 +1549,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1643,10 +1648,10 @@
                 "@sinonjs/commons": "^3.0.1"
             }
         },
-        "node_modules/@tsconfig/node20": {
-            "version": "20.1.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.9.tgz",
-            "integrity": "sha512-IjlTv1RsvnPtUcjTqtVsZExKVq+KQx4g5pCP5tI7rAs6Xesl2qFwSz/tPDBC4JajkL/MlezBu3gPUwqRHl+RIg==",
+        "node_modules/@tsconfig/node22": {
+            "version": "22.0.5",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+            "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
             "dev": true,
             "license": "MIT"
         },
@@ -1783,9 +1788,9 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.19.41",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-            "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+            "version": "22.19.19",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+            "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -1823,17 +1828,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-            "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+            "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.3",
-                "@typescript-eslint/type-utils": "8.59.3",
-                "@typescript-eslint/utils": "8.59.3",
-                "@typescript-eslint/visitor-keys": "8.59.3",
+                "@typescript-eslint/scope-manager": "8.59.4",
+                "@typescript-eslint/type-utils": "8.59.4",
+                "@typescript-eslint/utils": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -1846,7 +1851,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.3",
+                "@typescript-eslint/parser": "^8.59.4",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -1862,16 +1867,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-            "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+            "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.3",
-                "@typescript-eslint/types": "8.59.3",
-                "@typescript-eslint/typescript-estree": "8.59.3",
-                "@typescript-eslint/visitor-keys": "8.59.3",
+                "@typescript-eslint/scope-manager": "8.59.4",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1887,14 +1892,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-            "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+            "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.3",
-                "@typescript-eslint/types": "^8.59.3",
+                "@typescript-eslint/tsconfig-utils": "^8.59.4",
+                "@typescript-eslint/types": "^8.59.4",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1909,14 +1914,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-            "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+            "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.3",
-                "@typescript-eslint/visitor-keys": "8.59.3"
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1927,9 +1932,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-            "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+            "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1944,15 +1949,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-            "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+            "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.3",
-                "@typescript-eslint/typescript-estree": "8.59.3",
-                "@typescript-eslint/utils": "8.59.3",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4",
+                "@typescript-eslint/utils": "8.59.4",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -1969,9 +1974,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-            "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+            "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1983,16 +1988,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-            "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+            "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.3",
-                "@typescript-eslint/tsconfig-utils": "8.59.3",
-                "@typescript-eslint/types": "8.59.3",
-                "@typescript-eslint/visitor-keys": "8.59.3",
+                "@typescript-eslint/project-service": "8.59.4",
+                "@typescript-eslint/tsconfig-utils": "8.59.4",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -2050,16 +2055,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-            "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+            "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.3",
-                "@typescript-eslint/types": "8.59.3",
-                "@typescript-eslint/typescript-estree": "8.59.3"
+                "@typescript-eslint/scope-manager": "8.59.4",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2074,13 +2079,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-            "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+            "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.3",
+                "@typescript-eslint/types": "8.59.4",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -2099,9 +2104,9 @@
             "license": "ISC"
         },
         "node_modules/@unrs/resolver-binding-android-arm-eabi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
-            "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+            "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
             "cpu": [
                 "arm"
             ],
@@ -2113,9 +2118,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-android-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
-            "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+            "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
             "cpu": [
                 "arm64"
             ],
@@ -2127,9 +2132,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-arm64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
-            "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+            "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
             "cpu": [
                 "arm64"
             ],
@@ -2141,9 +2146,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-darwin-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
-            "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+            "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
             "cpu": [
                 "x64"
             ],
@@ -2155,9 +2160,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-freebsd-x64": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
-            "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+            "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
             "cpu": [
                 "x64"
             ],
@@ -2169,9 +2174,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
-            "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+            "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
             "cpu": [
                 "arm"
             ],
@@ -2183,9 +2188,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
-            "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+            "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
             "cpu": [
                 "arm"
             ],
@@ -2197,13 +2202,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
-            "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+            "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2211,13 +2219,50 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
-            "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+            "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
             "cpu": [
                 "arm64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+            "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "glibc"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ]
+        },
+        "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+            "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2225,13 +2270,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
-            "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+            "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
             "cpu": [
                 "ppc64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2239,13 +2287,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
-            "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+            "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2253,13 +2304,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
-            "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+            "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
             "cpu": [
                 "riscv64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2267,13 +2321,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
-            "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+            "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
             "cpu": [
                 "s390x"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2281,13 +2338,16 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
-            "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+            "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "glibc"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
@@ -2295,23 +2355,40 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-linux-x64-musl": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
-            "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+            "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
             "cpu": [
                 "x64"
             ],
             "dev": true,
+            "libc": [
+                "musl"
+            ],
             "license": "MIT",
             "optional": true,
             "os": [
                 "linux"
             ]
         },
+        "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+            "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ]
+        },
         "node_modules/@unrs/resolver-binding-wasm32-wasi": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
-            "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+            "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
             "cpu": [
                 "wasm32"
             ],
@@ -2319,16 +2396,18 @@
             "license": "MIT",
             "optional": true,
             "dependencies": {
-                "@napi-rs/wasm-runtime": "^0.2.11"
+                "@emnapi/core": "1.10.0",
+                "@emnapi/runtime": "1.10.0",
+                "@napi-rs/wasm-runtime": "^1.1.4"
             },
             "engines": {
                 "node": ">=14.0.0"
             }
         },
         "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
-            "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+            "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
             "cpu": [
                 "arm64"
             ],
@@ -2340,9 +2419,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
-            "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+            "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
             "cpu": [
                 "ia32"
             ],
@@ -2354,9 +2433,9 @@
             ]
         },
         "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
-            "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+            "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
             "cpu": [
                 "x64"
             ],
@@ -2592,9 +2671,9 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.10.29",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.29.tgz",
-            "integrity": "sha512-Asa2krT+XTPZINCS+2QcyS8WTkObE77RwkydwF7h6DmnKqbvlalz93m/dnphUyCa6SWSP51VgtEUf2FN+gelFQ==",
+            "version": "2.10.31",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+            "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -2700,9 +2779,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001792",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001792.tgz",
-            "integrity": "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==",
+            "version": "1.0.30001793",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
             "dev": true,
             "funding": [
                 {
@@ -2975,9 +3054,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.356",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.356.tgz",
-            "integrity": "sha512-9NgFd7m5t5MCJ5rUSjJITUXAH9mEGlrlofnMf4YEr+pz6JlP7cWmTAH+JFmbPnaSW8koVTkuW7pacORWAnA5Yw==",
+            "version": "1.5.361",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+            "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
             "dev": true,
             "license": "ISC"
         },
@@ -4846,11 +4925,14 @@
             "license": "MIT"
         },
         "node_modules/node-releases": {
-            "version": "2.0.44",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
-            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
+            "version": "2.0.46",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+            "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/normalize-path": {
             "version": "3.0.0",
@@ -5224,24 +5306,24 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.8",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-            "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+            "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -5343,9 +5425,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-            "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+            "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -5730,9 +5812,9 @@
             }
         },
         "node_modules/ts-jest": {
-            "version": "29.4.9",
-            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.9.tgz",
-            "integrity": "sha512-LTb9496gYPMCqjeDLdPrKuXtncudeV1yRZnF4Wo5l3SFi0RYEnYRNgMrFIdg+FHvfzjCyQk1cLncWVqiSX+EvQ==",
+            "version": "29.4.11",
+            "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.4.11.tgz",
+            "integrity": "sha512-IrFl7l9AuB/qrNw5quqvAv/hmKMb8dhWOH4jQOGo0Oq8tCeo1O86/iTFG1FaRimgUkF13l4PcepO8ATFT6Ns4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -5742,7 +5824,7 @@
                 "json5": "^2.2.3",
                 "lodash.memoize": "^4.1.2",
                 "make-error": "^1.3.6",
-                "semver": "^7.7.4",
+                "semver": "^7.8.0",
                 "type-fest": "^4.41.0",
                 "yargs-parser": "^21.1.1"
             },
@@ -5917,16 +5999,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.59.3",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-            "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
+            "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.59.3",
-                "@typescript-eslint/parser": "8.59.3",
-                "@typescript-eslint/typescript-estree": "8.59.3",
-                "@typescript-eslint/utils": "8.59.3"
+                "@typescript-eslint/eslint-plugin": "8.59.4",
+                "@typescript-eslint/parser": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4",
+                "@typescript-eslint/utils": "8.59.4"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5968,38 +6050,41 @@
             "license": "MIT"
         },
         "node_modules/unrs-resolver": {
-            "version": "1.11.1",
-            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
-            "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+            "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "napi-postinstall": "^0.3.0"
+                "napi-postinstall": "^0.3.4"
             },
             "funding": {
                 "url": "https://opencollective.com/unrs-resolver"
             },
             "optionalDependencies": {
-                "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
-                "@unrs/resolver-binding-android-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-arm64": "1.11.1",
-                "@unrs/resolver-binding-darwin-x64": "1.11.1",
-                "@unrs/resolver-binding-freebsd-x64": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
-                "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
-                "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
-                "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
-                "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
-                "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
+                "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+                "@unrs/resolver-binding-android-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+                "@unrs/resolver-binding-darwin-x64": "1.12.2",
+                "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+                "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+                "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+                "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+                "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+                "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+                "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
             }
         },
         "node_modules/update-browserslist-db": {

--- a/node/package.json
+++ b/node/package.json
@@ -1,11 +1,11 @@
 {
     "name": "@hyperledger/fabric-gateway",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "description": "Hyperledger Fabric Gateway client API for Node",
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "engines": {
-        "node": ">=20.9.0"
+        "node": ">=22.11.0"
     },
     "repository": {
         "type": "git",
@@ -44,10 +44,10 @@
     "devDependencies": {
         "@eslint/eslintrc": "^3.3.4",
         "@eslint/js": "^10.0.1",
-        "@tsconfig/node20": "^20.1.5",
+        "@tsconfig/node22": "^22.0.5",
         "@types/google-protobuf": "^3.15.12",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20.19.1",
+        "@types/node": "^22.19.19",
         "eslint": "^10.4.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jest": "^29.15.0",

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node20/tsconfig.json",
+    "extends": "@tsconfig/node22/tsconfig.json",
     "compilerOptions": {
         "declaration": true,
         "declarationMap": true,

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -14,8 +14,8 @@
             },
             "devDependencies": {
                 "@cucumber/cucumber": "^12.9.0",
-                "@tsconfig/node20": "^20.1.5",
-                "@types/node": "^20.19.1",
+                "@tsconfig/node22": "^22.0.5",
+                "@types/node": "^22.19.19",
                 "cucumber-console-formatter": "^1.0.0",
                 "eslint": "^10.4.0",
                 "eslint-config-prettier": "^10.1.2",
@@ -25,16 +25,17 @@
                 "typescript-eslint": "^8.59.0"
             },
             "engines": {
-                "node": ">=20.9.0"
+                "node": ">=22.11.0"
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.29.0",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -43,10 +44,11 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
-            "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+            "version": "7.28.5",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -56,6 +58,7 @@
             "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
             "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
             "dev": true,
+            "license": "MIT",
             "optional": true,
             "engines": {
                 "node": ">=0.1.90"
@@ -164,6 +167,16 @@
                 "@cucumber/messages": ">=17.1.1"
             }
         },
+        "node_modules/@cucumber/gherkin-streams/node_modules/commander": {
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
         "node_modules/@cucumber/gherkin-utils": {
             "version": "11.0.0",
             "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-11.0.0.tgz",
@@ -256,19 +269,6 @@
             "peerDependencies": {
                 "@cucumber/cucumber": ">=7.0.0",
                 "@cucumber/messages": "*"
-            }
-        },
-        "node_modules/@cucumber/pretty-formatter/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/@cucumber/query": {
@@ -400,9 +400,9 @@
             }
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.0.tgz",
-            "integrity": "sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==",
+            "version": "1.14.4",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
+            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/proto-loader": "^0.8.0",
@@ -413,14 +413,14 @@
             }
         },
         "node_modules/@grpc/proto-loader": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.0.tgz",
-            "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+            "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash.camelcase": "^4.3.0",
                 "long": "^5.0.0",
-                "protobufjs": "^7.5.3",
+                "protobufjs": "^7.5.5",
                 "yargs": "^17.7.2"
             },
             "bin": {
@@ -431,41 +431,41 @@
             }
         },
         "node_modules/@humanfs/core": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "version": "0.19.2",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+            "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@humanfs/types": "^0.15.0"
+            },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "version": "0.16.8",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+            "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@humanfs/core": "^0.19.1",
-                "@humanwhocodes/retry": "^0.3.0"
+                "@humanfs/core": "^0.19.2",
+                "@humanfs/types": "^0.15.0",
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
             }
         },
-        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+        "node_modules/@humanfs/types": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+            "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=18.18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
+                "node": ">=18.18.0"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -483,9 +483,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.2.tgz",
-            "integrity": "sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -497,9 +497,9 @@
             }
         },
         "node_modules/@hyperledger/fabric-gateway": {
-            "version": "1.11.1",
+            "version": "1.12.0",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-VWXkCfXahIctQNm0OuDZxh+eLOFpr4hSh1n20x/+Hffw1taueWEWpRuew7svdALvR7B7AIERnM3EEVG0Uk5PAQ==",
+            "integrity": "sha512-4Wvp9P/IvJoU/bEx1QXafUiw7lr+JTQ7vofx4ZsIzhsrjqEO4bwaDe/XzGe8j6IjS5Qo97JKzOysPJ79a8dYnA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",
@@ -508,7 +508,7 @@
                 "google-protobuf": "^3.21.0"
             },
             "engines": {
-                "node": ">=20.9.0"
+                "node": ">=22.11.0"
             },
             "optionalDependencies": {
                 "pkcs11js": "^2.1.0"
@@ -617,9 +617,9 @@
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.4",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.4.tgz",
-            "integrity": "sha512-2bKONnuM53lINoDrSmK8qP8W271ms7pygDhZt4SiLOoLwBtoHqeCFi6RG42V8zd3mLHuJFhU/Bmaqo4nX0/kBw==",
+            "version": "1.9.7",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
             "license": "MIT",
             "dependencies": {
                 "@noble/hashes": "1.8.0"
@@ -662,19 +662,18 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-            "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+            "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
@@ -684,9 +683,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-            "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -724,10 +723,10 @@
                 "node": ">=14"
             }
         },
-        "node_modules/@tsconfig/node20": {
-            "version": "20.1.5",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node20/-/node20-20.1.5.tgz",
-            "integrity": "sha512-Vm8e3WxDTqMGPU4GATF9keQAIy1Drd7bPwlgzKJnZtoOsTm1tduUTbDjg0W5qERvGuxPI2h9RbMufH0YdfBylA==",
+        "node_modules/@tsconfig/node22": {
+            "version": "22.0.5",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node22/-/node22-22.0.5.tgz",
+            "integrity": "sha512-hLf2ld+sYN/BtOJjHUWOk568dvjFQkHnLNa6zce25GIH+vxKfvTgm3qpaH6ToF5tu/NN0IH66s+Bb5wElHrLcw==",
             "dev": true,
             "license": "MIT"
         },
@@ -739,9 +738,9 @@
             "license": "MIT"
         },
         "node_modules/@types/estree": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+            "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
             "dev": true,
             "license": "MIT"
         },
@@ -787,9 +786,10 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.19.1",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-            "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+            "version": "22.19.19",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.19.tgz",
+            "integrity": "sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==",
+            "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
             }
@@ -826,17 +826,17 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
-            "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
+            "integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/type-utils": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/scope-manager": "8.59.4",
+                "@typescript-eslint/type-utils": "8.59.4",
+                "@typescript-eslint/utils": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -849,7 +849,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.59.0",
+                "@typescript-eslint/parser": "^8.59.4",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
@@ -865,16 +865,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-            "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
+            "integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/scope-manager": "8.59.4",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -890,14 +890,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-            "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
+            "integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.59.0",
-                "@typescript-eslint/types": "^8.59.0",
+                "@typescript-eslint/tsconfig-utils": "^8.59.4",
+                "@typescript-eslint/types": "^8.59.4",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -912,14 +912,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
-            "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
+            "integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0"
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -930,9 +930,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-            "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
+            "integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -947,15 +947,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
-            "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
+            "integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4",
+                "@typescript-eslint/utils": "8.59.4",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -972,9 +972,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-            "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
+            "integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -986,16 +986,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-            "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
+            "integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.59.0",
-                "@typescript-eslint/tsconfig-utils": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/visitor-keys": "8.59.0",
+                "@typescript-eslint/project-service": "8.59.4",
+                "@typescript-eslint/tsconfig-utils": "8.59.4",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/visitor-keys": "8.59.4",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1014,16 +1014,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
-            "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
+            "integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.59.0",
-                "@typescript-eslint/types": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0"
+                "@typescript-eslint/scope-manager": "8.59.4",
+                "@typescript-eslint/types": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1038,13 +1038,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-            "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
+            "integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.59.0",
+                "@typescript-eslint/types": "8.59.4",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1079,9 +1079,9 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.14.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-            "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+            "version": "6.15.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+            "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1106,15 +1106,13 @@
             }
         },
         "node_modules/ansi-styles": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "dev": true,
             "license": "MIT",
-            "dependencies": {
-                "color-convert": "^2.0.1"
-            },
             "engines": {
-                "node": ">=8"
+                "node": ">=10"
             },
             "funding": {
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
@@ -1139,25 +1137,25 @@
                 "repeat-string": "^1.6.1"
             }
         },
-        "node_modules/brace-expansion": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
-            "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^4.0.2"
-            },
-            "engines": {
-                "node": "18 || 20 || >=22"
-            }
-        },
-        "node_modules/brace-expansion/node_modules/balanced-match": {
+        "node_modules/balanced-match": {
             "version": "4.0.4",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
             "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
             "dev": true,
             "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/brace-expansion": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
             "engines": {
                 "node": "18 || 20 || >=22"
             }
@@ -1196,6 +1194,22 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/chalk/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
         "node_modules/chalk/node_modules/supports-color": {
@@ -1239,6 +1253,7 @@
             "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
             "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "string-width": "^4.2.0"
             },
@@ -1263,44 +1278,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/cliui/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/cliui/node_modules/wrap-ansi": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.0.0",
-                "string-width": "^4.1.0",
-                "strip-ansi": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-            }
-        },
         "node_modules/color-convert": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1320,9 +1297,9 @@
             "license": "MIT"
         },
         "node_modules/commander": {
-            "version": "14.0.0",
-            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-            "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
+            "version": "14.0.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+            "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1490,13 +1467,16 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "10.1.2",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.2.tgz",
-            "integrity": "sha512-Epgp/EofAUeEpIdZkW60MHKvPyru1ruQJxPL+WIycnaPApuseK0Zpkrh/FwL9oIpQvIhJwV7ptOy0DWUjTlCiA==",
+            "version": "10.1.8",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+            "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
             "dev": true,
             "license": "MIT",
             "bin": {
                 "eslint-config-prettier": "bin/cli.js"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint-config-prettier"
             },
             "peerDependencies": {
                 "eslint": ">=7.0.0"
@@ -1755,18 +1735,18 @@
             }
         },
         "node_modules/glob": {
-            "version": "13.0.0",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.0.tgz",
-            "integrity": "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA==",
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "minimatch": "^10.1.1",
-                "minipass": "^7.1.2",
-                "path-scurry": "^2.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -1838,9 +1818,9 @@
             }
         },
         "node_modules/hosted-git-info": {
-            "version": "9.0.2",
-            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
-            "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+            "version": "9.0.3",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-9.0.3.tgz",
+            "integrity": "sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -2201,9 +2181,9 @@
             }
         },
         "node_modules/lru-cache": {
-            "version": "11.2.4",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
-            "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+            "version": "11.5.0",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+            "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "engines": {
@@ -2234,13 +2214,13 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "10.2.4",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-            "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
-                "brace-expansion": "^5.0.2"
+                "brace-expansion": "^5.0.5"
             },
             "engines": {
                 "node": "18 || 20 || >=22"
@@ -2250,11 +2230,11 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
             "dev": true,
-            "license": "ISC",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -2439,9 +2419,9 @@
             }
         },
         "node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "dev": true,
             "license": "BlueOak-1.0.0",
             "dependencies": {
@@ -2449,7 +2429,7 @@
                 "minipass": "^7.1.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -2501,9 +2481,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.0.tgz",
-            "integrity": "sha512-yEPsovQfpxYfgWNhCfECjG5AQaO+K3dp6XERmOepyPDVqcJm+bjyCVO3pmU+nAPe0N5dDvekfGezt/EIiRe1TA==",
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+            "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2532,19 +2512,6 @@
                 "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
             }
         },
-        "node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
         "node_modules/progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2563,24 +2530,24 @@
             "license": "MIT"
         },
         "node_modules/protobufjs": {
-            "version": "7.5.8",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-            "integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
+            "version": "7.6.1",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
+            "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
                 "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.1",
+                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^5.0.0"
+                "long": "^5.3.2"
             },
             "engines": {
                 "node": ">=12.0.0"
@@ -2631,9 +2598,9 @@
             }
         },
         "node_modules/read-package-up/node_modules/type-fest": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.2.0.tgz",
-            "integrity": "sha512-xxCJm+Bckc6kQBknN7i9fnP/xobQRsRQxR01CztFkp/h++yfVxUUcmMgfR2HttJx/dpWjS9ubVuyspJv24Q9DA==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -2647,17 +2614,17 @@
             }
         },
         "node_modules/read-pkg": {
-            "version": "10.0.0",
-            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.0.0.tgz",
-            "integrity": "sha512-A70UlgfNdKI5NSvTTfHzLQj7NJRpJ4mT5tGafkllJ4wh71oYuGm/pzphHcmW4s35iox56KSK721AihodoXSc/A==",
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-10.1.0.tgz",
+            "integrity": "sha512-I8g2lArQiP78ll51UeMZojewtYgIRCKCWqZEgOO8c/uefTI+XDXvCSXu3+YNUaTNvZzobrL5+SqHjBrByRRTdg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/normalize-package-data": "^2.4.4",
                 "normalize-package-data": "^8.0.0",
                 "parse-json": "^8.3.0",
-                "type-fest": "^5.2.0",
-                "unicorn-magic": "^0.3.0"
+                "type-fest": "^5.4.4",
+                "unicorn-magic": "^0.4.0"
             },
             "engines": {
                 "node": ">=20"
@@ -2667,9 +2634,9 @@
             }
         },
         "node_modules/read-pkg/node_modules/type-fest": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.2.0.tgz",
-            "integrity": "sha512-xxCJm+Bckc6kQBknN7i9fnP/xobQRsRQxR01CztFkp/h++yfVxUUcmMgfR2HttJx/dpWjS9ubVuyspJv24Q9DA==",
+            "version": "5.6.0",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.6.0.tgz",
+            "integrity": "sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
             "dependencies": {
@@ -2832,9 +2799,9 @@
             }
         },
         "node_modules/spdx-license-ids": {
-            "version": "3.0.22",
-            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.22.tgz",
-            "integrity": "sha512-4PRT4nh1EImPbt2jASOKHX7PB7I+e4IWNLvkKFDxNhJlfjbYlleYQh285Z/3mPTHSAK/AvdMmw5BNNuYH8ShgQ==",
+            "version": "3.0.23",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+            "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
             "dev": true,
             "license": "CC0-1.0"
         },
@@ -2892,16 +2859,7 @@
                 "node": ">=8"
             }
         },
-        "node_modules/string-width/node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/string-width/node_modules/strip-ansi": {
+        "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
             "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -2909,6 +2867,15 @@
             "dependencies": {
                 "ansi-regex": "^5.0.1"
             },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/strip-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3067,16 +3034,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.59.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
-            "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+            "version": "8.59.4",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
+            "integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.59.0",
-                "@typescript-eslint/parser": "8.59.0",
-                "@typescript-eslint/typescript-estree": "8.59.0",
-                "@typescript-eslint/utils": "8.59.0"
+                "@typescript-eslint/eslint-plugin": "8.59.4",
+                "@typescript-eslint/parser": "8.59.4",
+                "@typescript-eslint/typescript-estree": "8.59.4",
+                "@typescript-eslint/utils": "8.59.4"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3093,16 +3060,17 @@
         "node_modules/undici-types": {
             "version": "6.21.0",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+            "license": "MIT"
         },
         "node_modules/unicorn-magic": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
-            "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+            "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=18"
+                "node": ">=20"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -3172,6 +3140,38 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/wrap-ansi": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+            "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.0.0",
+                "string-width": "^4.1.0",
+                "strip-ansi": "^6.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
         "node_modules/xmlbuilder": {
             "version": "15.1.1",
             "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
@@ -3192,16 +3192,19 @@
             }
         },
         "node_modules/yaml": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
-            "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "dev": true,
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"
             },
             "engines": {
-                "node": ">= 14"
+                "node": ">= 14.6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/eemeli"
             }
         },
         "node_modules/yargs": {

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.1",
     "description": "Scenario test for Fabric Gateway",
     "engines": {
-        "node": ">=20.9.0"
+        "node": ">=22.11.0"
     },
     "scripts": {
         "build": "npm run clean && npm run compile && npm run lint && npm run format",
@@ -26,8 +26,8 @@
     },
     "devDependencies": {
         "@cucumber/cucumber": "^12.9.0",
-        "@tsconfig/node20": "^20.1.5",
-        "@types/node": "^20.19.1",
+        "@tsconfig/node22": "^22.0.5",
+        "@types/node": "^22.19.19",
         "cucumber-console-formatter": "^1.0.0",
         "eslint": "^10.4.0",
         "eslint-config-prettier": "^10.1.2",

--- a/scenario/node/tsconfig.json
+++ b/scenario/node/tsconfig.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "@tsconfig/node20/tsconfig.json",
+    "extends": "@tsconfig/node22/tsconfig.json",
     "compilerOptions": {
         "declaration": false,
         "erasableSyntaxOnly": true,


### PR DESCRIPTION
Node 20 reached end-of-life at 2026-04-30 and is no longer supported. The currently supported Node LTS versions are 22 and 24.