### PR TITLE
Update @noble/curves from v1 to v2

### DIFF
--- a/node/jest.config.js
+++ b/node/jest.config.js
@@ -8,4 +8,10 @@ module.exports = {
     testMatch: ['**/?(*.)+(spec|test).[jt]s?(x)'],
     verbose: true,
     workerThreads: true,
+    // Transform ESM JavaScript files in @node/curves and @noble/hashes.
+    transformIgnorePatterns: ['node_modules/(?!@noble/)'],
+    transform: {
+        '^.+\\.tsx?$': ['ts-jest', {}],
+        '^.+\\.js$': ['ts-jest', { tsconfig: { allowJs: true } }],
+    },
 };

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -11,7 +11,7 @@
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",
                 "@hyperledger/fabric-protos": "^0.3.0",
-                "@noble/curves": "^1.9.4",
+                "@noble/curves": "^2.2.0",
                 "google-protobuf": "^3.21.0"
             },
             "devDependencies": {
@@ -32,7 +32,7 @@
                 "typescript-eslint": "^8.62.1"
             },
             "engines": {
-                "node": ">=22.11.0"
+                "node": ">=22.12.0"
             },
             "optionalDependencies": {
                 "pkcs11js": "^2.1.0"
@@ -1459,27 +1459,27 @@
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.7",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+            "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
             "license": "MIT",
             "dependencies": {
-                "@noble/hashes": "1.8.0"
+                "@noble/hashes": "2.2.0"
             },
             "engines": {
-                "node": "^14.21.3 || >=16"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@noble/hashes": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
             "license": "MIT",
             "engines": {
-                "node": "^14.21.3 || >=16"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"

--- a/node/package.json
+++ b/node/package.json
@@ -5,7 +5,7 @@
     "main": "dist/index.js",
     "types": "dist/index.d.ts",
     "engines": {
-        "node": ">=22.11.0"
+        "node": ">=22.12.0"
     },
     "repository": {
         "type": "git",
@@ -41,7 +41,7 @@
     "dependencies": {
         "@grpc/grpc-js": "^1.14.0",
         "@hyperledger/fabric-protos": "^0.3.0",
-        "@noble/curves": "^1.9.4",
+        "@noble/curves": "^2.2.0",
         "google-protobuf": "^3.21.0"
     },
     "optionalDependencies": {

--- a/node/src/identity/ecdsa.ts
+++ b/node/src/identity/ecdsa.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CurveFn } from '@noble/curves/abstract/weierstrass';
-import { p256 } from '@noble/curves/nist';
-import { p384 } from '@noble/curves/nist';
+import { ECDSA } from '@noble/curves/abstract/weierstrass.js';
+import { p256, p384 } from '@noble/curves/nist.js';
 import { KeyObject } from 'node:crypto';
 import { Signer } from './signer';
 
-const namedCurves: Record<string, CurveFn> = {
+const namedCurves: Record<string, ECDSA> = {
     'P-256': p256,
     'P-384': p384,
 };
@@ -28,12 +27,12 @@ export function newECPrivateKeySigner(key: KeyObject): Signer {
     const privateKey = Buffer.from(d, 'base64url');
 
     return (digest) => {
-        const signature = curve.sign(digest, privateKey, { lowS: true });
-        return Promise.resolve(signature.toBytes('der'));
+        const signature = curve.sign(digest, privateKey, { format: 'der', lowS: true, prehash: false });
+        return Promise.resolve(signature);
     };
 }
 
-function getCurve(name: string): CurveFn {
+function getCurve(name: string): ECDSA {
     const curve = namedCurves[name];
     if (!curve) {
         throw new Error(`Unsupported curve: ${name}`);

--- a/node/src/identity/hsmsigner.test.ts
+++ b/node/src/identity/hsmsigner.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import { p256 } from '@noble/curves/nist';
+import { p256 } from '@noble/curves/nist.js';
 import { createHash } from 'node:crypto';
 import pkcs11js, { Handle, InitializationOptions, Mechanism, Pkcs11Error, Template, TokenInfo } from 'pkcs11js';
 import { HSMSignerOptions } from './hsmsigner';
@@ -95,7 +95,7 @@ describe('When using an HSM Signer', () => {
         mocks.C_OpenSession.mockReturnValue(mockSession);
         mocks.C_FindObjects.mockReturnValue([mockPrivateKeyHandle]);
         mocks.C_SignAsync.mockImplementation((session: Buffer, digest: Buffer, buffer: Buffer) => {
-            const signature = p256.sign(digest, privateKey).toBytes('compact');
+            const signature = p256.sign(digest, privateKey, { format: 'compact', prehash: false });
             signature.forEach((b, i) => buffer.writeUInt8(b, i));
             // Return buffer of exactly signature length regardless of supplied buffer size
             const result = buffer.subarray(0, signature.length);
@@ -244,7 +244,7 @@ describe('When using an HSM Signer', () => {
         const { signer } = hsmSignerFactory.newSigner(hsmOptions);
         const signature = await signer(digest);
 
-        const valid = p256.verify(signature, digest, publicKey);
+        const valid = p256.verify(signature, digest, publicKey, { format: 'der', prehash: false });
         expect(valid).toBe(true);
 
         expect(mocks.C_SignInit).toHaveBeenCalledWith(

--- a/node/src/identity/hsmsigner.ts
+++ b/node/src/identity/hsmsigner.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { p256 } from '@noble/curves/nist';
+import { p256 } from '@noble/curves/nist.js';
 import * as pkcs11js from 'pkcs11js';
 import { Signer } from './signer';
 
@@ -114,9 +114,8 @@ export class HSMSignerFactoryImpl implements HSMSignerFactory {
                 let signature = p256.Signature.fromBytes(compactSignature, 'compact');
                 if (signature.hasHighS()) {
                     const lowS = p256.Point.Fn.neg(signature.s);
-                    signature = new p256.Signature(signature.r, lowS, signature.recovery);
+                    signature = new p256.Signature(signature.r, lowS);
                 }
-
                 return signature.toBytes('der');
             },
             close: () => {

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -517,16 +517,16 @@
         "node_modules/@hyperledger/fabric-gateway": {
             "version": "1.12.0",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-7dUIqiLrtzE9UggWr68WOyQwZZFr3pXD7D/KQ0mXbsKlfY7riR2tkzIB+h3jCLEcNC1YALwNmuQbyVAOBjQ8Qg==",
+            "integrity": "sha512-GjwkbZgg1ns4d3F7Tmg61CWzLdROe/RBBNXXcUX6Mw5phbhO8BFxwt+rWIJgS0GLO0yrlolBwJXwLVMb4VJclQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",
                 "@hyperledger/fabric-protos": "^0.3.0",
-                "@noble/curves": "^1.9.4",
+                "@noble/curves": "^2.2.0",
                 "google-protobuf": "^3.21.0"
             },
             "engines": {
-                "node": ">=22.11.0"
+                "node": ">=22.12.0"
             },
             "optionalDependencies": {
                 "pkcs11js": "^2.1.0"
@@ -635,27 +635,27 @@
             }
         },
         "node_modules/@noble/curves": {
-            "version": "1.9.7",
-            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
-            "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+            "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
             "license": "MIT",
             "dependencies": {
-                "@noble/hashes": "1.8.0"
+                "@noble/hashes": "2.2.0"
             },
             "engines": {
-                "node": "^14.21.3 || >=16"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"
             }
         },
         "node_modules/@noble/hashes": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-            "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+            "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
             "license": "MIT",
             "engines": {
-                "node": "^14.21.3 || >=16"
+                "node": ">= 20.19.0"
             },
             "funding": {
                 "url": "https://paulmillr.com/funding/"


### PR DESCRIPTION
@noble/curves v2 is an ESM-only module. Loading ESM modules from CommonJS modules using require() is supported by default from Node 22.12.0, allowing the fabric-gateway module to remain CommonJS and compatible with existing client application code.

Closes #1109