### PR TITLE
build: group dependabot updates to codeql actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    groups:
+      # CodeQL updates must be applied together to avoid breaking the build.
+      codeql:
+        patterns:
+         - "github/codeql-action/*"
   - package-ecosystem: gomod
     directories:
       - "/"


### PR DESCRIPTION
CodeQL actions are very sensitive to version changes, and have dependencies between related actions. They must all be updated together or build breaks occur in the CodeQL scan workflow.