### PR TITLE
Publish Node releases to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,28 @@ jobs:
   verify-versions:
     uses: ./.github/workflows/verify-versions.yml
 
-  publish-node:
+  publish-node-github:
+    needs: verify-versions
+    name: Publish Node package to GitHub Packages
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "lts/*"
+          registry-url: "https://npm.pkg.github.com"
+      - name: Build
+        run: make build-node
+      - name: Publish
+        run: ${{ github.workspace }}/.github/scripts/npm_publish.sh latest
+        working-directory: node
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-node-npmjs:
     needs: verify-versions
     name: Publish Node package to npm registry
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Publishing to GitHub Packages in addition to the public npm registry makes it easier to consume alongside other @hyperledger scoped packages that are published only to GitHub Packages.