### PR TITLE
Update tsc to TypeScript 7

### DIFF
--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -21,6 +21,7 @@
                 "@tsconfig/node22": "^22.0.5",
                 "@types/google-protobuf": "^3.15.12",
                 "@types/node": "^22.20.1",
+                "@typescript/native": "npm:typescript@~7.0.2",
                 "eslint": "^10.8.0",
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-jest": "^29.16.0",
@@ -28,7 +29,7 @@
                 "prettier": "^3.9.6",
                 "ts-jest": "^29.4.12",
                 "typedoc": "^0.28.20",
-                "typescript": "~6.0.3",
+                "typescript": "npm:@typescript/typescript6@~6.0.3",
                 "typescript-eslint": "^8.65.0"
             },
             "engines": {
@@ -1846,9 +1847,9 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+            "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2083,6 +2084,382 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript/native": {
+            "name": "typescript",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "node_modules/@typescript/typescript-aix-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-loong64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-mips64el": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-riscv64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-s390x": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-sunos-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -5767,9 +6144,9 @@
             }
         },
         "node_modules/tinyglobby": {
-            "version": "0.2.16",
-            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+            "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/node/package.json
+++ b/node/package.json
@@ -54,6 +54,7 @@
         "@tsconfig/node22": "^22.0.5",
         "@types/google-protobuf": "^3.15.12",
         "@types/node": "^22.20.1",
+        "@typescript/native": "npm:typescript@~7.0.2",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-jest": "^29.16.0",
@@ -61,7 +62,7 @@
         "prettier": "^3.9.6",
         "ts-jest": "^29.4.12",
         "typedoc": "^0.28.20",
-        "typescript": "~6.0.3",
+        "typescript": "npm:@typescript/typescript6@~6.0.3",
         "typescript-eslint": "^8.65.0"
     }
 }

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -16,12 +16,13 @@
                 "@cucumber/cucumber": "^13.2.0",
                 "@tsconfig/node22": "^22.0.5",
                 "@types/node": "^22.20.1",
+                "@typescript/native": "npm:typescript@~7.0.2",
                 "cucumber-console-formatter": "^1.0.0",
                 "eslint": "^10.8.0",
                 "eslint-config-prettier": "^10.1.2",
                 "expect": "^30.4.1",
                 "prettier": "^3.9.6",
-                "typescript": "~6.0.3",
+                "typescript": "npm:@typescript/typescript6@~6.0.3",
                 "typescript-eslint": "^8.65.0"
             },
             "engines": {
@@ -509,7 +510,7 @@
         "node_modules/@hyperledger/fabric-gateway": {
             "version": "1.12.1",
             "resolved": "file:../../node/fabric-gateway-dev.tgz",
-            "integrity": "sha512-jmpLf+g4glsV4QgpfnfeMvCOzSA+NXxp7xOFU125WYV71yxCE3L37o1p0T2Wwsw1G/MM6fhyn1CM8Uc88jResg==",
+            "integrity": "sha512-BflVm0BqY7Kv1lHNxFmgOLLlDekmdk27uq81pi8F7stzh+j2v5zkU0dpEmC4YXobj8ShK9G4YwF/S4o4TPDU/A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@grpc/grpc-js": "^1.14.0",
@@ -1063,6 +1064,382 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript/native": {
+            "name": "typescript",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+            "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc"
+            },
+            "engines": {
+                "node": ">=16.20.0"
+            },
+            "optionalDependencies": {
+                "@typescript/typescript-aix-ppc64": "7.0.2",
+                "@typescript/typescript-darwin-arm64": "7.0.2",
+                "@typescript/typescript-darwin-x64": "7.0.2",
+                "@typescript/typescript-freebsd-arm64": "7.0.2",
+                "@typescript/typescript-freebsd-x64": "7.0.2",
+                "@typescript/typescript-linux-arm": "7.0.2",
+                "@typescript/typescript-linux-arm64": "7.0.2",
+                "@typescript/typescript-linux-loong64": "7.0.2",
+                "@typescript/typescript-linux-mips64el": "7.0.2",
+                "@typescript/typescript-linux-ppc64": "7.0.2",
+                "@typescript/typescript-linux-riscv64": "7.0.2",
+                "@typescript/typescript-linux-s390x": "7.0.2",
+                "@typescript/typescript-linux-x64": "7.0.2",
+                "@typescript/typescript-netbsd-arm64": "7.0.2",
+                "@typescript/typescript-netbsd-x64": "7.0.2",
+                "@typescript/typescript-openbsd-arm64": "7.0.2",
+                "@typescript/typescript-openbsd-x64": "7.0.2",
+                "@typescript/typescript-sunos-x64": "7.0.2",
+                "@typescript/typescript-win32-arm64": "7.0.2",
+                "@typescript/typescript-win32-x64": "7.0.2"
+            }
+        },
+        "node_modules/@typescript/typescript-aix-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+            "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+            "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+            "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+            "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+            "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+            "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-loong64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+            "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-mips64el": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+            "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+            "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-riscv64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+            "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-s390x": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+            "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+            "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+            "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+            "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-sunos-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+            "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+            "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+            "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/acorn": {

--- a/scenario/node/package.json
+++ b/scenario/node/package.json
@@ -28,12 +28,13 @@
         "@cucumber/cucumber": "^13.2.0",
         "@tsconfig/node22": "^22.0.5",
         "@types/node": "^22.20.1",
+        "@typescript/native": "npm:typescript@~7.0.2",
         "cucumber-console-formatter": "^1.0.0",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.2",
         "expect": "^30.4.1",
         "prettier": "^3.9.6",
-        "typescript": "~6.0.3",
+        "typescript": "npm:@typescript/typescript6@~6.0.3",
         "typescript-eslint": "^8.65.0"
     },
     "allowScripts": {


### PR DESCRIPTION
The typescript library still needs to remain at v6 for now since this provides the APIs required by typescript-eslint. This is achieved by using an alias to a @typescript/typescript6 compatibility module.