### PR TITLE
Use latest Go version to install fabric-ca-client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,17 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
+          go-version: stable
+      - name: Install Fabric CA client
+        run: |
+          make install-fabric-ca-client
+          cp "$(go env GOPATH)/bin/fabric-ca-client" "${RUNNER_TEMP}"
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
           go-version: ${{ matrix.go-version }}
+      - name: Reinstall Fabric CA client for Go version
+        run: |
+          cp "${RUNNER_TEMP}/fabric-ca-client" "$(go env GOPATH)/bin/fabric-ca-client"
       - name: Install SoftHSM
         run: sudo apt install -y softhsm2
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Pull Docker images
         run: make pull-docker-images
       - name: Run scenario tests
-        run: make scenario-test-go-no-hsm
+        run: make scenario-test-go
 
   node_unit:
     needs: verify-versions
@@ -159,7 +159,7 @@ jobs:
       - name: Pull Docker images
         run: make pull-docker-images
       - name: Run scenario tests
-        run: make scenario-test-node-no-hsm
+        run: make scenario-test-node
 
   java_unit:
     needs: verify-versions

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ osv_scanner := $(go_bin_dir)/osv-scanner
 mockery := $(go_bin_dir)/mockery
 mockery_version := 3.7.2
 
+fabric_ca_client := $(go_bin_dir)/fabric-ca-client
+
 kernel_name := $(shell uname -s)
 lowercase_kernel_name := $(shell echo '$(kernel_name)' | tr '[:upper:]' '[:lower:]')
 
@@ -193,7 +195,7 @@ vendor-chaincode:
 		GO111MODULE=on go mod vendor
 
 .PHONY: scenario-test-go
-scenario-test-go: vendor-chaincode install-fabric-ca-client setup-softhsm
+scenario-test-go: vendor-chaincode $(fabric_ca_client) setup-softhsm
 	cd '$(scenario_dir)/go' && \
 		go test -timeout 20m -tags pkcs11 -v -args '$(scenario_dir)/features/'
 
@@ -203,12 +205,12 @@ scenario-test-go-no-hsm: vendor-chaincode
 		go test -timeout 20m -tags pkcs11 -v --godog.tags='~@hsm' -args '$(scenario_dir)/features/'
 
 .PHONY: scenario-test-node
-scenario-test-node: vendor-chaincode build-scenario-node install-fabric-ca-client setup-softhsm
+scenario-test-node: vendor-chaincode build-scenario-node $(fabric_ca_client) setup-softhsm
 	cd '$(scenario_dir)/node' && \
 		npm test
 
 .PHONY: scenario-test-node-no-hsm
-scenario-test-node-no-hsm: vendor-chaincode build-scenario-node install-fabric-ca-client
+scenario-test-node-no-hsm: vendor-chaincode build-scenario-node $(fabric_ca_client)
 	cd '$(scenario_dir)/node' && \
 		npm run test:no-hsm
 
@@ -237,6 +239,9 @@ pull-docker-images:
 .PHONY: install-fabric-ca-client
 install-fabric-ca-client:
 	go install -tags pkcs11 github.com/hyperledger/fabric-ca/cmd/fabric-ca-client@latest
+
+$(fabric_ca_client):
+	$(MAKE) install-fabric-ca-client
 
 .PHONY: setup-softhsm
 setup-softhsm:


### PR DESCRIPTION
The CA client may require a very recent Go version to build, which causes failures in `go install` if an older version is used. This is a particular issue in Go scenario tests, which explicitly test with older Go versions.

This change uses the latest stable Go version to install/build fabric-ca-client in scenario tests.