### PR TITLE
Update Mockery from 3.7.2 to 3.7.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ golangci_lint := $(go_bin_dir)/golangci-lint
 osv_scanner := $(go_bin_dir)/osv-scanner
 
 mockery := $(go_bin_dir)/mockery
-mockery_version := 3.7.2
+mockery_version := 3.7.4
 
 fabric_ca_client := $(go_bin_dir)/fabric-ca-client
 


### PR DESCRIPTION
Mockery v3.7.4 fixes an incompatibility with Go 1.27 that caused mock generation to fail with the following error:

> internal error: package "time" without types was imported from "google.golang.org/grpc"