### PR TITLE
Apply Go code modernizations using go fix

### DIFF
--- a/pkg/client/blockevents_test.go
+++ b/pkg/client/blockevents_test.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -49,8 +48,7 @@ func TestBlockEvents(t *testing.T) {
 		tester := NewBlockEventsTest(t)
 		tester.SetResponses(responses...)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		err := tester.Events(ctx)
 		require.NoError(t, err)
@@ -93,8 +91,7 @@ func TestBlockEvents(t *testing.T) {
 		tester := NewBlockEventsTest(t)
 		tester.SetResponses(responses...)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		err := tester.Events(ctx)
 		require.NoError(t, err)

--- a/pkg/client/blockeventscommon_test.go
+++ b/pkg/client/blockeventscommon_test.go
@@ -38,8 +38,7 @@ func TestCommonBlockEvents(t *testing.T) {
 				tester := newTester(t)
 				tester.SetConnectError(expected)
 
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+				ctx := t.Context()
 
 				err := tester.Events(ctx)
 
@@ -155,8 +154,7 @@ func TestCommonBlockEvents(t *testing.T) {
 				tester := newTester(t)
 				tester.SetNetworkName(networkName)
 
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
+				ctx := t.Context()
 
 				err := tester.Events(ctx, testCase.options...)
 				require.NoError(t, err)
@@ -175,8 +173,7 @@ func TestCommonBlockEvents(t *testing.T) {
 			tester := newTester(t)
 			tester.SetReceiveError(errors.New("fake"))
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			err := tester.Events(ctx)
 			require.NoError(t, err)
@@ -191,8 +188,7 @@ func TestCommonBlockEvents(t *testing.T) {
 
 			tester := newTester(t)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			err := tester.EventsWithCallOptions(ctx, expected)
 			require.NoError(t, err)
@@ -206,8 +202,7 @@ func TestCommonBlockEvents(t *testing.T) {
 			tester := newTester(t)
 			tester.SetGatewayOptions(WithTLSClientCertificateHash(expected))
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			err := tester.Events(ctx)
 			require.NoError(t, err)

--- a/pkg/client/blockeventsfiltered_test.go
+++ b/pkg/client/blockeventsfiltered_test.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -47,8 +46,7 @@ func TestFilteredBlockEvents(t *testing.T) {
 		tester := NewFilteredBlockEventsTest(t)
 		tester.SetResponses(responses...)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		err := tester.Events(ctx)
 		require.NoError(t, err)
@@ -90,8 +88,7 @@ func TestFilteredBlockEvents(t *testing.T) {
 		tester := NewFilteredBlockEventsTest(t)
 		tester.SetResponses(responses...)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		err := tester.Events(ctx)
 		require.NoError(t, err)

--- a/pkg/client/blockeventswithprivatedata_test.go
+++ b/pkg/client/blockeventswithprivatedata_test.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"context"
 	"testing"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
@@ -66,8 +65,7 @@ func TestBlockAndPrivateDataEvents(t *testing.T) {
 		tester := NewBlockAndPrivateDataEventsTest(t)
 		tester.SetResponses(responses...)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		err := tester.Events(ctx)
 		require.NoError(t, err)
@@ -118,8 +116,7 @@ func TestBlockAndPrivateDataEvents(t *testing.T) {
 		tester := NewBlockAndPrivateDataEventsTest(t)
 		tester.SetResponses(responses...)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		err := tester.Events(ctx)
 		require.NoError(t, err)

--- a/pkg/client/chaincodeevents_test.go
+++ b/pkg/client/chaincodeevents_test.go
@@ -4,7 +4,6 @@
 package client
 
 import (
-	"context"
 	"errors"
 	"io"
 	"testing"
@@ -46,8 +45,7 @@ func TestChaincodeEvents(t *testing.T) {
 		mockConnection := NewMockClientConnInterface(t)
 		ExpectChaincodeEvents(mockConnection, WithNewStreamError(expected))
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClientConnection(mockConnection))
 		_, err := network.ChaincodeEvents(ctx, "CHAINCODE")
@@ -204,8 +202,7 @@ func TestChaincodeEvents(t *testing.T) {
 			mockStream.EXPECT().CloseSend().Return(nil)
 			ExpectRecvMsg(mockStream).Maybe().Return(io.EOF)
 
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			network := AssertNewTestNetwork(t, "NETWORK", WithClientConnection(mockConnection))
 			_, err := network.ChaincodeEvents(ctx, "CHAINCODE", testCase.options...)
@@ -235,8 +232,7 @@ func TestChaincodeEvents(t *testing.T) {
 		mockStream.EXPECT().CloseSend().Return(nil)
 		ExpectRecvMsg(mockStream).Maybe().Return(errors.New("fake"))
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClientConnection(mockConnection))
 
@@ -286,8 +282,7 @@ func TestChaincodeEvents(t *testing.T) {
 			newChaincodeEventsResponse(expected[2:]),
 		))
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClientConnection(mockConnection))
 
@@ -313,8 +308,7 @@ func TestChaincodeEvents(t *testing.T) {
 		mockStream.EXPECT().CloseSend().Return(nil)
 		ExpectRecvMsg(mockStream).Maybe().Return(io.EOF)
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		network := AssertNewTestNetwork(t, "NETWORK", WithClientConnection(mockConnection))
 

--- a/pkg/client/submit_test.go
+++ b/pkg/client/submit_test.go
@@ -654,8 +654,7 @@ func TestSubmitTransaction(t *testing.T) {
 		proposal, err := contract.NewProposal("transaction")
 		require.NoError(t, err, "NewProposal")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		_, err = proposal.EndorseWithContext(ctx, expected)
 		require.NoError(t, err, "Endorse")
@@ -701,8 +700,7 @@ func TestSubmitTransaction(t *testing.T) {
 		transaction, err := proposal.Endorse()
 		require.NoError(t, err, "Endorse")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		_, err = transaction.SubmitWithContext(ctx, expected)
 		require.NoError(t, err, "Submit")
@@ -762,8 +760,7 @@ func TestSubmitTransaction(t *testing.T) {
 		commit, err := transaction.Submit(expected)
 		require.NoError(t, err, "Submit")
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+		ctx := t.Context()
 
 		_, err = commit.StatusWithContext(ctx, expected)
 		require.NoError(t, err, "Status")

--- a/pkg/identity/sign_test.go
+++ b/pkg/identity/sign_test.go
@@ -51,7 +51,7 @@ func TestSigner(t *testing.T) {
 
 		halfOrder := new(big.Int).Rsh(ecdsaPrivateKey.Params().N, 1)
 
-		for i := 0; i < 10; i++ {
+		for range 10 {
 			signature, err := sign(digest)
 			require.NoError(t, err, "sign")
 
@@ -89,7 +89,7 @@ func BenchmarkECDSA(b *testing.B) {
 	_, err = rand.Read(digest)
 	require.NoError(b, err)
 
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = sign(digest)
 	}
 }


### PR DESCRIPTION
- Use new test API for creating a Context that is cancelled at the end of the test.
- Use range loop instead of incrementing explicit index variable.
- Use b.Loop instead of for-range in benchmarks.