### PR TITLE
Use auth token for GitHub API calls in workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
           go-version: stable
       - name: Generate mocks
         run: make generate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: golangci-lint
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9.3.0
         with:
@@ -66,6 +68,8 @@ jobs:
           TMPDIR: ${{ runner.temp }}
       - name: Generate mocks
         run: make generate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Run unit tests
         run: make unit-test-go-pkcs11
       - name: Coverage report
@@ -107,6 +111,8 @@ jobs:
           TMPDIR: ${{ runner.temp }}
       - name: Generate mocks
         run: make generate
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull Docker images
         run: make pull-docker-images
       - name: Run scenario tests

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -20,7 +20,8 @@ jobs:
       tag_name: ${{ steps.tag-name.outputs.value }}
     steps:
       - id: tag-name
-        run: echo "value=$(curl --location --silent --fail "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq --raw-output '.tag_name')" >> "${GITHUB_OUTPUT}"
+        run: |
+          echo "value=$(curl --silent --fail --header 'Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' "https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest" | jq --raw-output '.tag_name')" >> "${GITHUB_OUTPUT}"        
 
   release:
     name: Scan ${{ needs.latest-release-version.outputs.tag_name }}

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ ifneq (, $(shell command -v mvnd 2>/dev/null))
 	maven := mvnd
 endif
 
+# If GH_TOKEN environment variable is set, use it as the GitHub API auth token
+gh_api_auth := $(if $(GH_TOKEN),--header 'Authorization: Bearer $(GH_TOKEN)',)
+
 # These should match names in Docker .env file
 export FABRIC_VERSION ?= 2.5
 export NODEENV_VERSION ?= 2.5
@@ -108,7 +111,7 @@ uninstall-golangci-lint:
 	rm -f '$(golangci_lint)'
 
 $(golangci_lint):
-	curl --fail --location --show-error --silent \
+	curl --fail --location --show-error --silent $(gh_api_auth) \
 		https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
 		| sh -s -- -b '$(go_bin_dir)'
 
@@ -140,7 +143,7 @@ uninstall-osv-scanner:
 	rm -f '$(osv_scanner)'
 
 $(osv_scanner):
-	curl --fail --location --show-error --silent --output '$(osv_scanner)' \
+	curl --fail --location --show-error --silent $(gh_api_auth) --output '$(osv_scanner)' \
     	'https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_$(lowercase_kernel_name)_$(amd_arm_machine_hardware)'
 	chmod u+x '$(osv_scanner)'
 
@@ -183,8 +186,10 @@ install-mockery: uninstall-mockery $(mockery)
 uninstall-mockery:
 	rm -f '$(mockery)'
 
+# Silent to prevent printing of auth token
+.SILENT: $(mockery)
 $(mockery):
-	mockery_version=$$(curl --fail --show-error --silent https://api.github.com/repos/vektra/mockery/releases/latest | jq --raw-output .tag_name) && \
+	mockery_version=$$(curl --fail --show-error --silent $(gh_api_auth) https://api.github.com/repos/vektra/mockery/releases/latest | jq --raw-output .tag_name) && \
 		curl --fail --location --show-error --silent \
 			"https://github.com/vektra/mockery/releases/download/$${mockery_version}/mockery_$${mockery_version#v}_$(kernel_name)_$(machine_hardware).tar.gz" \
 			| tar -C '$(go_bin_dir)' -xzf - mockery


### PR DESCRIPTION
Avoid rate limiting in GitHub Actions workflows by passing the GITHUB_TOKEN in calls to the GitHub API.

A specific case where the lack of auth token could case issues is using the GitHub API to check the latest release version of Mockery when generating test mocks, which happens multiple times in the test workflow.