### PR TITLE
Use the Makefile for scan workflows

### DIFF
--- a/.bin/.gitignore
+++ b/.bin/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -42,27 +42,19 @@ jobs:
           cache: false
       - name: Create OSV-Scanner configuration
         run: |
-          echo "GoVersionOverride = '${{ steps.setup-go.outputs.go-version }}'" > src/osv-scanner-config.toml
           if [ -r latest/osv-scanner.toml ]; then
-              cat latest/osv-scanner.toml >> src/osv-scanner-config.toml
-          elif [ -r src/osv-scanner.toml ]; then
-              cat src/osv-scanner.toml >> src/osv-scanner-config.toml
+              cp -f latest/osv-scanner.toml src/osv-scanner.toml
           fi
       - name: Scan
         id: scan-go
-        run: |
-          docker run --rm \
-            --volume './src/:/src' \
-            ghcr.io/google/osv-scanner:latest \
-            scan source \
-            --config=/src/osv-scanner-config.toml \
-            --lockfile=/src/go.mod \
-            --format=markdown \
-            --output-file=/src/osv-scanner.md
+        working-directory: src
+        run: make scan-go
+        env:
+          OSV_SCANNER_ARGS: --format=markdown --output-file=${{ github.workspace }}/osv-scanner.md
       - name: Report failure
         if: ${{ failure() && steps.scan-go.conclusion == 'failure' }}
         run: |
-          cat src/osv-scanner.md >> ${GITHUB_STEP_SUMMARY}
+          cat osv-scanner.md >> ${GITHUB_STEP_SUMMARY}
 
   node:
     runs-on: ubuntu-latest
@@ -89,25 +81,16 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
-      - name: Create BOM
-        working-directory: src/node
-        run: |
-          npm update --omit=dev
-          npm sbom --omit=dev --package-lock-only --sbom-format cyclonedx > bom.cdx.json
       - name: Scan
         id: scan-node
-        run: |
-          docker run --rm \
-            --volume './src/:/src' \
-            ghcr.io/google/osv-scanner:latest \
-            scan source \
-            --lockfile=/src/node/bom.cdx.json \
-            --format=markdown \
-            --output-file=/src/osv-scanner.md
+        working-directory: src
+        run: make scan-node
+        env:
+          OSV_SCANNER_ARGS: --format=markdown --output-file=${{ github.workspace }}/osv-scanner.md
       - name: Report failure
         if: ${{ failure() && steps.scan-node.conclusion == 'failure' }}
         run: |
-          cat src/osv-scanner.md >> ${GITHUB_STEP_SUMMARY}
+          cat osv-scanner.md >> ${GITHUB_STEP_SUMMARY}
 
   java:
     runs-on: ubuntu-latest
@@ -132,15 +115,11 @@ jobs:
           fi
       - name: Scan
         id: scan-java
-        run: |
-          docker run --rm \
-            --volume './src/:/src' \
-            ghcr.io/google/osv-scanner:latest \
-            scan source \
-            --lockfile=/src/java/pom.xml \
-            --format=markdown \
-            --output-file=/src/osv-scanner.md
+        working-directory: src
+        run: make scan-java
+        env:
+          OSV_SCANNER_ARGS: --format=markdown --output-file=${{ github.workspace }}/osv-scanner.md
       - name: Report failure
         if: ${{ failure() && steps.scan-java.conclusion == 'failure' }}
         run: |
-          cat src/osv-scanner.md >> ${GITHUB_STEP_SUMMARY}
+          cat osv-scanner.md >> ${GITHUB_STEP_SUMMARY}

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,15 @@ go_dir := $(base_dir)/pkg
 node_dir := $(base_dir)/node
 java_dir := $(base_dir)/java
 scenario_dir := $(base_dir)/scenario
+bin_dir := $(base_dir)/.bin
 
-go_bin_dir := $(shell go env GOPATH)/bin
 python_venv_dir := $(base_dir)/.venv
 python_venv_activate := $(python_venv_dir)/bin/activate
 
-golangci_lint := $(go_bin_dir)/golangci-lint
-osv_scanner := $(go_bin_dir)/osv-scanner
-mockery := $(go_bin_dir)/mockery
-fabric_ca_client := $(go_bin_dir)/fabric-ca-client
+golangci_lint := $(bin_dir)/golangci-lint
+osv_scanner := $(bin_dir)/osv-scanner
+mockery := $(bin_dir)/mockery
+fabric_ca_client := $(bin_dir)/fabric-ca-client
 
 kernel_name := $(shell uname -s)
 lowercase_kernel_name := $(shell echo '$(kernel_name)' | tr '[:upper:]' '[:lower:]')
@@ -44,6 +44,8 @@ endif
 
 # If GH_TOKEN environment variable is set, use it as the GitHub API auth token
 gh_api_auth := $(if $(GH_TOKEN),--header 'Authorization: Bearer $(GH_TOKEN)',)
+
+OSV_SCANNER_ARGS ?=
 
 # These should match names in Docker .env file
 export FABRIC_VERSION ?= 2.5
@@ -113,11 +115,11 @@ uninstall-golangci-lint:
 $(golangci_lint):
 	curl --fail --location --show-error --silent $(gh_api_auth) \
 		https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
-		| sh -s -- -b '$(go_bin_dir)'
+		| sh -s -- -b '$(dir $(golangci_lint))'
 
 .PHONY: golangci-lint
 golangci-lint: $(golangci_lint)
-	golangci-lint run
+	$(golangci-lint) run
 
 .PHONY: scan
 scan: scan-go scan-node scan-java
@@ -151,7 +153,7 @@ $(osv_scanner):
 scan-go-osv-scanner: $(osv_scanner)
 	echo "GoVersionOverride = '$$(go env GOVERSION | sed -e 's/^go//' -e 's/-.*//')'" > '$(TMPDIR)/osv-scanner.toml' && \
 		if [ -r '$(base_dir)/osv-scanner.toml' ]; then cat '$(base_dir)/osv-scanner.toml' >> '$(TMPDIR)/osv-scanner.toml'; fi && \
-		osv-scanner scan source --config='$(TMPDIR)/osv-scanner.toml' --lockfile='$(base_dir)/go.mod'
+		$(osv_scanner) scan source --config='$(TMPDIR)/osv-scanner.toml' --lockfile='$(base_dir)/go.mod' $(OSV_SCANNER_ARGS)
 
 .PHONY: scan-node
 scan-node: scan-node-osv-scanner
@@ -165,7 +167,7 @@ scan-node-npm-audit:
 scan-node-osv-scanner: $(osv_scanner)
 	cd '$(node_dir)' && \
 		npm sbom --omit=dev --package-lock-only --sbom-format cyclonedx > bom.cdx.json && \
-		osv-scanner scan source --lockfile=bom.cdx.json
+		$(osv_scanner) scan source --lockfile=bom.cdx.json $(OSV_SCANNER_ARGS)
 
 .PHONY: scan-java
 scan-java: scan-java-osv-scanner
@@ -177,7 +179,7 @@ scan-java-dependency-check:
 
 .PHONY: scan-java-osv-scanner
 scan-java-osv-scanner: $(osv_scanner)
-	osv-scanner scan source --lockfile='$(java_dir)/pom.xml'
+	$(osv_scanner) scan source --lockfile='$(java_dir)/pom.xml' $(OSV_SCANNER_ARGS)
 
 .PHONY: install-mockery
 install-mockery: uninstall-mockery $(mockery)
@@ -192,12 +194,12 @@ $(mockery):
 	mockery_version=$$(curl --fail --show-error --silent $(gh_api_auth) https://api.github.com/repos/vektra/mockery/releases/latest | jq --raw-output .tag_name) && \
 		curl --fail --location --show-error --silent \
 			"https://github.com/vektra/mockery/releases/download/$${mockery_version}/mockery_$${mockery_version#v}_$(kernel_name)_$(machine_hardware).tar.gz" \
-			| tar -C '$(go_bin_dir)' -xzf - mockery
+			| tar -C '$(dir $(mockery))' -xzf - mockery
 	chmod u+x '$(mockery)'
 
 .PHONY: generate
 generate: $(mockery) clean-generated
-	cd '$(base_dir)' && mockery
+	cd '$(base_dir)' && $(mockery)
 
 .PHONY: vendor-chaincode
 vendor-chaincode:
@@ -257,6 +259,7 @@ uninstall-fabric-ca-client:
 
 $(fabric_ca_client):
 	go install -tags pkcs11 github.com/hyperledger/fabric-ca/cmd/fabric-ca-client@latest
+	cp -f $(shell go env GOBIN)/fabric-ca-client $(fabric_ca_client)
 
 .PHONY: setup-softhsm
 setup-softhsm:

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -40,13 +40,13 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -55,9 +55,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+            "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -65,21 +65,21 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-            "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+            "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-compilation-targets": "^7.28.6",
-                "@babel/helper-module-transforms": "^7.28.6",
-                "@babel/helpers": "^7.28.6",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/traverse": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.7",
+                "@babel/helper-compilation-targets": "^7.29.7",
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helpers": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/template": "^7.29.7",
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -106,14 +106,14 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.1",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+            "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.29.0",
-                "@babel/types": "^7.29.0",
+                "@babel/parser": "^7.29.8",
+                "@babel/types": "^7.29.8",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -123,14 +123,14 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+            "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.28.6",
-                "@babel/helper-validator-option": "^7.27.1",
+                "@babel/compat-data": "^7.29.7",
+                "@babel/helper-validator-option": "^7.29.7",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
                 "semver": "^6.3.1"
@@ -150,9 +150,9 @@
             }
         },
         "node_modules/@babel/helper-globals": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-            "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+            "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -160,29 +160,29 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+            "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/traverse": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+            "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.28.6",
-                "@babel/helper-validator-identifier": "^7.28.5",
-                "@babel/traverse": "^7.28.6"
+                "@babel/helper-module-imports": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7",
+                "@babel/traverse": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -202,9 +202,9 @@
             }
         },
         "node_modules/@babel/helper-string-parser": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-            "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+            "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -212,9 +212,9 @@
             }
         },
         "node_modules/@babel/helper-validator-identifier": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-            "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+            "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -222,9 +222,9 @@
             }
         },
         "node_modules/@babel/helper-validator-option": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-            "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+            "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -232,27 +232,27 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.29.2",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+            "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0"
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+            "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.29.0"
+                "@babel/types": "^7.29.8"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -501,33 +501,33 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+            "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.28.6",
-                "@babel/parser": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/code-frame": "^7.29.7",
+                "@babel/parser": "^7.29.7",
+                "@babel/types": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+            "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
+                "@babel/code-frame": "^7.29.7",
+                "@babel/generator": "^7.29.8",
+                "@babel/helper-globals": "^7.29.7",
+                "@babel/parser": "^7.29.8",
+                "@babel/template": "^7.29.7",
+                "@babel/types": "^7.29.8",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -535,14 +535,14 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-            "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+            "version": "7.29.8",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+            "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-string-parser": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.28.5"
+                "@babel/helper-string-parser": "^7.29.7",
+                "@babel/helper-validator-identifier": "^7.29.7"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -657,16 +657,16 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -964,9 +964,9 @@
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+            "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1547,12 +1547,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -3020,9 +3014,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -3390,9 +3384,9 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.419",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.419.tgz",
-            "integrity": "sha512-nHMPn8x4yCxCI0iSnL+LlHL5sUoUfjLXkcRIagZ4GBdrfFLFaiLNvzJWbJqZhFT9IAhw5tUSNlhggWN+otvp/A==",
+            "version": "1.5.420",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.420.tgz",
+            "integrity": "sha512-2yD6XreGusOfNV+dUcvipJEXc3n/n7fgr7996aszTG+YY5E4mqM4tOq/3uhP129cazL9YHbVWSpc79ePotWtPA==",
             "dev": true,
             "license": "ISC"
         },
@@ -3609,16 +3603,16 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/eslint/node_modules/espree": {
@@ -4022,9 +4016,9 @@
             }
         },
         "node_modules/glob/node_modules/brace-expansion": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-            "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+            "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4942,9 +4936,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-            "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {
@@ -5675,9 +5669,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.6.1",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-            "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+            "version": "7.6.6",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+            "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -5687,7 +5681,6 @@
                 "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",
@@ -6325,16 +6318,16 @@
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {
-            "version": "5.0.6",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-            "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/typedoc/node_modules/minimatch": {

--- a/scenario/node/package-lock.json
+++ b/scenario/node/package-lock.json
@@ -703,12 +703,6 @@
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
             "license": "BSD-3-Clause"
         },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
-            "license": "BSD-3-Clause"
-        },
         "node_modules/@protobufjs/path": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
@@ -1541,16 +1535,16 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/buffer-from": {
@@ -2795,9 +2789,9 @@
             "license": "MIT"
         },
         "node_modules/protobufjs": {
-            "version": "7.6.1",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.1.tgz",
-            "integrity": "sha512-4K0myLaWL5EteuSAro91EGFgcfVgxb64Jx+7oDAY6GOkXD4M69yuSEljNcInGVCA5sOPxmZ/EqDLj2x0Q0+Ygg==",
+            "version": "7.6.6",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.6.tgz",
+            "integrity": "sha512-dYDWdjSl5RNb7SgPxGQcRU+GtvP7s2fpkrY0r432PcOIaZ0/rBcxEZnQN67iJhFuQiVw754JDoPruPCNdGsbjg==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -2807,7 +2801,6 @@
                 "@protobufjs/eventemitter": "^1.1.1",
                 "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.2",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
                 "@protobufjs/utf8": "^1.1.1",


### PR DESCRIPTION
Refactor the Makefile to allow its scan targets to be used directly by the scan workflow. This reduces duplication of logic and dramatically simplified the scan workflow.