### PR TITLE
Create .bin directory on demand

### DIFF
--- a/.bin/.gitignore
+++ b/.bin/.gitignore
@@ -1,3 +1,0 @@
-*
-!.gitignore
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea/
 .vscode/
+.bin/
 bin/
 cover.out
 fabric-protos/

--- a/Makefile
+++ b/Makefile
@@ -113,13 +113,14 @@ uninstall-golangci-lint:
 	rm -f '$(golangci_lint)'
 
 $(golangci_lint):
+	mkdir -p '$(dir $(golangci_lint))'
 	curl --fail --location --show-error --silent \
 		https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh \
 		| sh -s -- -b '$(dir $(golangci_lint))'
 
 .PHONY: golangci-lint
 golangci-lint: $(golangci_lint)
-	$(golangci-lint) run
+	$(golangci_lint) run
 
 .PHONY: scan
 scan: scan-go scan-node scan-java
@@ -145,6 +146,7 @@ uninstall-osv-scanner:
 	rm -f '$(osv_scanner)'
 
 $(osv_scanner):
+	mkdir -p '$(dir $(osv_scanner))'
 	curl --fail --location --show-error --silent --output '$(osv_scanner)' \
     	'https://github.com/google/osv-scanner/releases/latest/download/osv-scanner_$(lowercase_kernel_name)_$(amd_arm_machine_hardware)'
 	chmod u+x '$(osv_scanner)'
@@ -191,6 +193,7 @@ uninstall-mockery:
 # Silent to prevent printing of auth token
 .SILENT: $(mockery)
 $(mockery):
+	mkdir -p '$(dir $(mockery))'
 	mockery_version=$$(curl --fail --show-error --silent $(gh_api_auth) https://api.github.com/repos/vektra/mockery/releases | jq --raw-output '.[].tag_name' | sort --version-sort | tail -1) && \
 		curl --fail --location --show-error --silent \
 			"https://github.com/vektra/mockery/releases/download/$${mockery_version}/mockery_$${mockery_version#v}_$(kernel_name)_$(machine_hardware).tar.gz" \
@@ -259,7 +262,8 @@ uninstall-fabric-ca-client:
 
 $(fabric_ca_client):
 	go install -tags pkcs11 github.com/hyperledger/fabric-ca/cmd/fabric-ca-client@latest
-	cp -f $(shell go env GOBIN)/fabric-ca-client $(fabric_ca_client)
+	mkdir -p '$(dir $(fabric_ca_client))'
+	cp -fp $(shell go env GOBIN)/fabric-ca-client $(fabric_ca_client)
 
 .PHONY: setup-softhsm
 setup-softhsm:


### PR DESCRIPTION
Running scans on back-level versions can fail since the Makefile relies on the .bin directory existing. This change ensures that the .bin directory is created before placing binaries there.