### PR TITLE
Publish Node releases to GitHub Packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,9 +24,12 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "lts/*"
-          registry-url: "https://npm.pkg.github.com"
       - name: Build
         run: make build-node
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: "lts/*"
+          registry-url: "https://npm.pkg.github.com"
       - name: Publish
         run: ${{ github.workspace }}/.github/scripts/npm_publish.sh latest
         working-directory: node


### PR DESCRIPTION
Publish to both npmjs and GitHub Packages to aid working with hyperledger packages that are published only to GitHub Packages.