### PR TITLE
Ignore CVE-2026-54269, CVE-2026-59877

### DIFF
--- a/node/osv-scanner.toml
+++ b/node/osv-scanner.toml
@@ -1,3 +1,11 @@
 [[IgnoredVulns]]
 id = "CVE-2026-41242"
 reason = "Client API uses pre-compiled protobuf bindings and this vulnerability affects on-the-fly compilation"
+
+[[IgnoredVulns]]
+id = "CVE-2026-54269"
+reason = "Client API uses pre-compiled protobuf bindings and this vulnerability affects on-the-fly compilation of untrusted schemas"
+
+[[IgnoredVulns]]
+id = "CVE-2026-59877"
+reason = "Client API uses pre-compiled protobuf bindings and this vulnerability affects on-the-fly compilation of untrusted schemas"


### PR DESCRIPTION
These vulnabilities are not applicable to the client API usage of protobufjs.